### PR TITLE
feat: API key authentication middleware

### DIFF
--- a/src/Voidforge.Api/Auth/ApiKeyAuthenticationDefaults.cs
+++ b/src/Voidforge.Api/Auth/ApiKeyAuthenticationDefaults.cs
@@ -1,0 +1,7 @@
+namespace Voidforge.Api.Auth;
+
+public static class ApiKeyAuthenticationDefaults
+{
+    public const string AuthenticationScheme = "ApiKey";
+    public const string HeaderName = "X-API-Key";
+}

--- a/src/Voidforge.Api/Auth/ApiKeyAuthenticationHandler.cs
+++ b/src/Voidforge.Api/Auth/ApiKeyAuthenticationHandler.cs
@@ -1,0 +1,59 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using Marten;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using Voidforge.Api.Documents;
+
+namespace Voidforge.Api.Auth;
+
+public sealed class ApiKeyAuthenticationHandler(
+    IOptionsMonitor<ApiKeyAuthenticationOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder,
+    IQuerySession querySession)
+    : AuthenticationHandler<ApiKeyAuthenticationOptions>(options, logger, encoder)
+{
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(ApiKeyAuthenticationDefaults.HeaderName, out var headerValues))
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        var rawKey = headerValues.ToString();
+        if (string.IsNullOrWhiteSpace(rawKey))
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        var hashedKey = HashKey(rawKey);
+
+        var apiKey = await querySession.Query<ApiKey>()
+            .FirstOrDefaultAsync(k => k.HashedKey == hashedKey);
+
+        if (apiKey is null)
+        {
+            return AuthenticateResult.Fail("Invalid API key.");
+        }
+
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, apiKey.PlayerId.ToString()),
+        };
+
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        return AuthenticateResult.Success(ticket);
+    }
+
+    internal static string HashKey(string rawKey)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(rawKey));
+        return Convert.ToHexStringLower(bytes);
+    }
+}

--- a/src/Voidforge.Api/Auth/ApiKeyAuthenticationOptions.cs
+++ b/src/Voidforge.Api/Auth/ApiKeyAuthenticationOptions.cs
@@ -1,0 +1,5 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace Voidforge.Api.Auth;
+
+public sealed class ApiKeyAuthenticationOptions : AuthenticationSchemeOptions;

--- a/src/Voidforge.Api/Documents/ApiKey.cs
+++ b/src/Voidforge.Api/Documents/ApiKey.cs
@@ -1,0 +1,9 @@
+namespace Voidforge.Api.Documents;
+
+public sealed class ApiKey
+{
+    public Guid Id { get; set; }
+    public required string HashedKey { get; set; }
+    public required Guid PlayerId { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/src/Voidforge.Api/Endpoints/PingEndpoint.cs
+++ b/src/Voidforge.Api/Endpoints/PingEndpoint.cs
@@ -1,0 +1,9 @@
+using Wolverine.Http;
+
+namespace Voidforge.Api.Endpoints;
+
+public static class PingEndpoint
+{
+    [WolverineGet("/api/ping")]
+    public static string Get() => "pong";
+}

--- a/src/Voidforge.Api/Program.cs
+++ b/src/Voidforge.Api/Program.cs
@@ -1,6 +1,7 @@
 using JasperFx;
 using Marten;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.OpenApi;
 using Voidforge.Api.Auth;
 using Voidforge.Api.Documents;
 using Wolverine;
@@ -40,7 +41,20 @@ builder.Services.AddAuthorizationBuilder()
 
 builder.Services.AddWolverineHttp();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(opts =>
+{
+    opts.AddSecurityDefinition("ApiKey", new OpenApiSecurityScheme
+    {
+        Name = ApiKeyAuthenticationDefaults.HeaderName,
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+    });
+
+    opts.AddSecurityRequirement(doc => new OpenApiSecurityRequirement
+    {
+        { new OpenApiSecuritySchemeReference("ApiKey", doc), [] },
+    });
+});
 builder.Services.AddHealthChecks().AddNpgSql(connectionString);
 
 var app = builder.Build();

--- a/src/Voidforge.Api/Program.cs
+++ b/src/Voidforge.Api/Program.cs
@@ -1,5 +1,8 @@
 using JasperFx;
 using Marten;
+using Microsoft.AspNetCore.Authorization;
+using Voidforge.Api.Auth;
+using Voidforge.Api.Documents;
 using Wolverine;
 using Wolverine.Http;
 using Wolverine.Marten;
@@ -15,6 +18,7 @@ builder.Services.AddMarten(opts =>
 {
     opts.Connection(connectionString);
     opts.DatabaseSchemaName = "voidforge";
+    opts.Schema.For<ApiKey>().UniqueIndex(x => x.HashedKey);
 })
 .UseLightweightSessions()
 .IntegrateWithWolverine();
@@ -25,6 +29,15 @@ builder.Host.UseWolverine(opts =>
     opts.Durability.Mode = DurabilityMode.Solo;
 });
 
+builder.Services.AddAuthentication(ApiKeyAuthenticationDefaults.AuthenticationScheme)
+    .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>(
+        ApiKeyAuthenticationDefaults.AuthenticationScheme, _ => { });
+
+builder.Services.AddAuthorizationBuilder()
+    .SetFallbackPolicy(new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build());
+
 builder.Services.AddWolverineHttp();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -34,7 +47,9 @@ var app = builder.Build();
 
 app.UseSwagger();
 app.UseSwaggerUI();
-app.MapHealthChecks("/health");
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapHealthChecks("/health").AllowAnonymous();
 app.MapWolverineEndpoints();
 
 return await app.RunJasperFxCommands(args);

--- a/src/Voidforge.Api/Voidforge.Api.csproj
+++ b/src/Voidforge.Api/Voidforge.Api.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Voidforge.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="WolverineFx.Http.Marten" Version="5.16.4" />

--- a/src/Voidforge.Tests/Auth/ApiKeyAuthTests.cs
+++ b/src/Voidforge.Tests/Auth/ApiKeyAuthTests.cs
@@ -1,0 +1,87 @@
+using Alba;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Voidforge.Api.Auth;
+using Voidforge.Api.Documents;
+using Xunit;
+
+namespace Voidforge.Tests.Auth;
+
+[Collection(IntegrationCollection.Name)]
+public sealed class ApiKeyAuthTests : IAsyncLifetime
+{
+    private const string _testRawKey = "test-api-key-for-integration";
+    private readonly IAlbaHost _host;
+
+    public ApiKeyAuthTests(AppFixture fixture)
+    {
+        _host = fixture.Host;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var session = _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        var hashedKey = ApiKeyAuthenticationHandler.HashKey(_testRawKey);
+
+        var existing = await session.Query<ApiKey>()
+            .FirstOrDefaultAsync(k => k.HashedKey == hashedKey);
+
+        if (existing is null)
+        {
+            session.Store(new ApiKey
+            {
+                Id = Guid.NewGuid(),
+                HashedKey = hashedKey,
+                PlayerId = Guid.NewGuid(),
+            });
+            await session.SaveChangesAsync();
+        }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task PingWithoutKeyReturns401()
+    {
+        await _host.Scenario(s =>
+        {
+            s.Get.Url("/api/ping");
+            s.StatusCodeShouldBe(401);
+        });
+    }
+
+    [Fact]
+    public async Task PingWithInvalidKeyReturns401()
+    {
+        await _host.Scenario(s =>
+        {
+            s.Get.Url("/api/ping");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, "bogus-key");
+            s.StatusCodeShouldBe(401);
+        });
+    }
+
+    [Fact]
+    public async Task PingWithValidKeyReturns200()
+    {
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url("/api/ping");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, _testRawKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var body = result.ReadAsText();
+        Assert.Equal("pong", body);
+    }
+
+    [Fact]
+    public async Task HealthWithoutKeyReturns200()
+    {
+        await _host.Scenario(s =>
+        {
+            s.Get.Url("/health");
+            s.StatusCodeShouldBe(200);
+        });
+    }
+}

--- a/src/Voidforge.Tests/Auth/ApiKeyAuthTests.cs
+++ b/src/Voidforge.Tests/Auth/ApiKeyAuthTests.cs
@@ -84,4 +84,14 @@ public sealed class ApiKeyAuthTests : IAsyncLifetime
             s.StatusCodeShouldBe(200);
         });
     }
+
+    [Fact]
+    public async Task SwaggerWithoutKeyReturns200()
+    {
+        await _host.Scenario(s =>
+        {
+            s.Get.Url("/swagger/v1/swagger.json");
+            s.StatusCodeShouldBe(200);
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- Add `X-API-Key` header authentication using ASP.NET Core's `AuthenticationHandler<T>` with SHA-256 key hashing and Marten-backed lookup
- Configure `FallbackPolicy` requiring authentication on all endpoints; health endpoint opts out via `AllowAnonymous()`
- Add `GET /api/ping` Wolverine endpoint as authenticated connectivity check

## New Files
| File | Purpose |
|------|---------|
| `Auth/ApiKeyAuthenticationDefaults.cs` | Scheme name + header constants |
| `Auth/ApiKeyAuthenticationOptions.cs` | Empty scheme options subclass |
| `Auth/ApiKeyAuthenticationHandler.cs` | Core auth logic: extract header → SHA-256 hash → Marten query → ClaimsPrincipal |
| `Documents/ApiKey.cs` | Marten document with unique index on `HashedKey` |
| `Endpoints/PingEndpoint.cs` | `GET /api/ping` → `"pong"` |
| `Tests/Auth/ApiKeyAuthTests.cs` | 4 integration tests |

## Test plan
- [x] `GET /api/ping` without key → 401
- [x] `GET /api/ping` with invalid key → 401
- [x] `GET /api/ping` with valid seeded key → 200
- [x] `GET /health` without key → 200 (AllowAnonymous)
- [x] Zero build warnings (TreatWarningsAsErrors)
- [x] `dotnet format --verify-no-changes` clean

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)