### PR TITLE
feat: solar systems, planets & world generation

### DIFF
--- a/src/Voidforge.Api/Documents/SolarSystem.cs
+++ b/src/Voidforge.Api/Documents/SolarSystem.cs
@@ -1,0 +1,11 @@
+namespace Voidforge.Api.Documents;
+
+public sealed class SolarSystem
+{
+    public Guid Id { get; set; }
+    public required string Name { get; set; }
+    public decimal X { get; set; }
+    public decimal Y { get; set; }
+    public decimal Z { get; set; }
+    public IList<Guid> PlanetIds { get; set; } = [];
+}

--- a/src/Voidforge.Api/Domain/Events/PlanetCreated.cs
+++ b/src/Voidforge.Api/Domain/Events/PlanetCreated.cs
@@ -1,0 +1,9 @@
+namespace Voidforge.Api.Domain.Events;
+
+public sealed record PlanetCreated(
+    string Name,
+    Guid SolarSystemId,
+    long IronOrePool,
+    int BuildingSlotCount,
+    long IronOreStorageCapacity,
+    long IronIngotStorageCapacity);

--- a/src/Voidforge.Api/Domain/Planet.cs
+++ b/src/Voidforge.Api/Domain/Planet.cs
@@ -1,0 +1,25 @@
+using Voidforge.Api.Domain.Events;
+
+namespace Voidforge.Api.Domain;
+
+public sealed class Planet
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public Guid SolarSystemId { get; set; }
+    public Guid? OwnerId { get; set; }
+    public long IronOrePool { get; set; }
+    public int BuildingSlotCount { get; set; }
+    public long IronOreStorageCapacity { get; set; }
+    public long IronIngotStorageCapacity { get; set; }
+
+    public void Apply(PlanetCreated @event)
+    {
+        Name = @event.Name;
+        SolarSystemId = @event.SolarSystemId;
+        IronOrePool = @event.IronOrePool;
+        BuildingSlotCount = @event.BuildingSlotCount;
+        IronOreStorageCapacity = @event.IronOreStorageCapacity;
+        IronIngotStorageCapacity = @event.IronIngotStorageCapacity;
+    }
+}

--- a/src/Voidforge.Api/Domain/ResourceType.cs
+++ b/src/Voidforge.Api/Domain/ResourceType.cs
@@ -1,7 +1,0 @@
-namespace Voidforge.Api.Domain;
-
-public enum ResourceType
-{
-    IronOre,
-    IronIngots,
-}

--- a/src/Voidforge.Api/Domain/ResourceType.cs
+++ b/src/Voidforge.Api/Domain/ResourceType.cs
@@ -1,0 +1,7 @@
+namespace Voidforge.Api.Domain;
+
+public enum ResourceType
+{
+    IronOre,
+    IronIngots,
+}

--- a/src/Voidforge.Api/Endpoints/PlanetEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/PlanetEndpoints.cs
@@ -1,0 +1,30 @@
+using Marten;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Voidforge.Api.Domain;
+using Wolverine.Http;
+
+namespace Voidforge.Api.Endpoints;
+
+public static class PlanetEndpoints
+{
+    [WolverineGet("/api/planets/{id}")]
+    public static async Task<Results<Ok<PlanetResponse>, NotFound>> GetById(Guid id, IQuerySession session)
+    {
+        var planet = await session.LoadAsync<Planet>(id);
+
+        if (planet is null)
+        {
+            return TypedResults.NotFound();
+        }
+
+        return TypedResults.Ok(new PlanetResponse(
+            planet.Id,
+            planet.Name,
+            planet.SolarSystemId,
+            planet.OwnerId,
+            planet.IronOrePool,
+            planet.BuildingSlotCount,
+            planet.IronOreStorageCapacity,
+            planet.IronIngotStorageCapacity));
+    }
+}

--- a/src/Voidforge.Api/Endpoints/PlanetResponse.cs
+++ b/src/Voidforge.Api/Endpoints/PlanetResponse.cs
@@ -1,0 +1,11 @@
+namespace Voidforge.Api.Endpoints;
+
+public sealed record PlanetResponse(
+    Guid Id,
+    string Name,
+    Guid SolarSystemId,
+    Guid? OwnerId,
+    long IronOrePool,
+    int BuildingSlotCount,
+    long IronOreStorageCapacity,
+    long IronIngotStorageCapacity);

--- a/src/Voidforge.Api/Endpoints/SolarSystemEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/SolarSystemEndpoints.cs
@@ -1,0 +1,22 @@
+using Marten;
+using Voidforge.Api.Documents;
+using Wolverine.Http;
+
+namespace Voidforge.Api.Endpoints;
+
+public static class SolarSystemEndpoints
+{
+    [WolverineGet("/api/solar-systems")]
+    public static async Task<IReadOnlyList<SolarSystemResponse>> GetAll(IQuerySession session)
+    {
+        var systems = await session.Query<SolarSystem>().ToListAsync();
+
+        return systems.Select(s => new SolarSystemResponse(
+            s.Id,
+            s.Name,
+            s.X,
+            s.Y,
+            s.Z,
+            s.PlanetIds.ToList().AsReadOnly())).ToList();
+    }
+}

--- a/src/Voidforge.Api/Endpoints/SolarSystemResponse.cs
+++ b/src/Voidforge.Api/Endpoints/SolarSystemResponse.cs
@@ -1,0 +1,9 @@
+namespace Voidforge.Api.Endpoints;
+
+public sealed record SolarSystemResponse(
+    Guid Id,
+    string Name,
+    decimal X,
+    decimal Y,
+    decimal Z,
+    IReadOnlyList<Guid> PlanetIds);

--- a/src/Voidforge.Api/Program.cs
+++ b/src/Voidforge.Api/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.OpenApi;
 using Voidforge.Api.Auth;
 using Voidforge.Api.Documents;
 using Voidforge.Api.Domain;
+using Voidforge.Api.WorldGeneration;
 using Wolverine;
 using Wolverine.Http;
 using Wolverine.Marten;
@@ -26,6 +27,7 @@ builder.Services.AddMarten(opts =>
     opts.Events.AppendMode = EventAppendMode.Quick;
     opts.Events.UseIdentityMapForAggregates = true;
     opts.Projections.Snapshot<Player>(SnapshotLifecycle.Inline);
+    opts.Projections.Snapshot<Planet>(SnapshotLifecycle.Inline);
     opts.Schema.For<Player>().UniqueIndex(x => x.Name);
 })
 .UseLightweightSessions()
@@ -62,6 +64,8 @@ builder.Services.AddSwaggerGen(opts =>
         { new OpenApiSecuritySchemeReference("ApiKey", doc), [] },
     });
 });
+builder.Services.Configure<WorldGenOptions>(builder.Configuration.GetSection("WorldGeneration"));
+builder.Services.AddHostedService<WorldSeeder>();
 builder.Services.AddHealthChecks().AddNpgSql(connectionString);
 
 var app = builder.Build();

--- a/src/Voidforge.Api/WorldGeneration/WorldGenOptions.cs
+++ b/src/Voidforge.Api/WorldGeneration/WorldGenOptions.cs
@@ -1,0 +1,12 @@
+namespace Voidforge.Api.WorldGeneration;
+
+public sealed class WorldGenOptions
+{
+    public int SolarSystemCount { get; set; } = 5;
+    public int PlanetsPerSystem { get; set; } = 3;
+    public long IronOrePool { get; set; } = 50000;
+    public int BuildingSlotCount { get; set; } = 6;
+    public long IronOreStorageCapacity { get; set; } = 10000;
+    public long IronIngotStorageCapacity { get; set; } = 5000;
+    public decimal CoordinateRange { get; set; } = 1000;
+}

--- a/src/Voidforge.Api/WorldGeneration/WorldSeeder.cs
+++ b/src/Voidforge.Api/WorldGeneration/WorldSeeder.cs
@@ -1,0 +1,75 @@
+using Marten;
+using Microsoft.Extensions.Options;
+using Voidforge.Api.Documents;
+using Voidforge.Api.Domain;
+using Voidforge.Api.Domain.Events;
+
+namespace Voidforge.Api.WorldGeneration;
+
+public sealed partial class WorldSeeder(
+    IDocumentStore store,
+    IOptions<WorldGenOptions> options,
+    ILogger<WorldSeeder> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await using var session = store.LightweightSession();
+
+        var existingCount = await session.Query<SolarSystem>().CountAsync(cancellationToken);
+        if (existingCount > 0)
+        {
+            LogWorldAlreadySeeded(logger, existingCount);
+            return;
+        }
+
+        var opts = options.Value;
+        var random = new Random(42);
+
+        for (var s = 0; s < opts.SolarSystemCount; s++)
+        {
+            var systemId = Guid.NewGuid();
+            var planetIds = new List<Guid>();
+
+            for (var p = 0; p < opts.PlanetsPerSystem; p++)
+            {
+                var planetId = Guid.NewGuid();
+                planetIds.Add(planetId);
+
+                session.Events.StartStream<Planet>(planetId, new PlanetCreated(
+                    Name: $"Planet {s + 1}-{p + 1}",
+                    SolarSystemId: systemId,
+                    IronOrePool: opts.IronOrePool,
+                    BuildingSlotCount: opts.BuildingSlotCount,
+                    IronOreStorageCapacity: opts.IronOreStorageCapacity,
+                    IronIngotStorageCapacity: opts.IronIngotStorageCapacity));
+            }
+
+            session.Store(new SolarSystem
+            {
+                Id = systemId,
+                Name = $"System {s + 1}",
+                X = NextCoordinate(random, opts.CoordinateRange),
+                Y = NextCoordinate(random, opts.CoordinateRange),
+                Z = NextCoordinate(random, opts.CoordinateRange),
+                PlanetIds = planetIds,
+            });
+        }
+
+        await session.SaveChangesAsync(cancellationToken);
+
+        LogWorldSeeded(logger, opts.SolarSystemCount, opts.PlanetsPerSystem);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static decimal NextCoordinate(Random random, decimal range)
+    {
+        return (decimal)(random.NextDouble() * (double)(range * 2)) - range;
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "World already seeded with {Count} solar systems, skipping.")]
+    private static partial void LogWorldAlreadySeeded(ILogger logger, int count);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Seeded {SystemCount} solar systems with {PlanetsPerSystem} planets each.")]
+    private static partial void LogWorldSeeded(ILogger logger, int systemCount, int planetsPerSystem);
+}

--- a/src/Voidforge.Api/WorldGeneration/WorldSeeder.cs
+++ b/src/Voidforge.Api/WorldGeneration/WorldSeeder.cs
@@ -23,7 +23,7 @@ public sealed partial class WorldSeeder(
         }
 
         var opts = options.Value;
-        var random = new Random(42);
+        var random = new Random();
 
         for (var s = 0; s < opts.SolarSystemCount; s++)
         {

--- a/src/Voidforge.Api/appsettings.json
+++ b/src/Voidforge.Api/appsettings.json
@@ -2,6 +2,15 @@
   "ConnectionStrings": {
     "Marten": "Host=localhost;Port=5432;Database=voidforge;Username=postgres;Password=voidforge_dev"
   },
+  "WorldGeneration": {
+    "SolarSystemCount": 5,
+    "PlanetsPerSystem": 3,
+    "IronOrePool": 50000,
+    "BuildingSlotCount": 6,
+    "IronOreStorageCapacity": 10000,
+    "IronIngotStorageCapacity": 5000,
+    "CoordinateRange": 1000
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Voidforge.Tests/Planets/PlanetAggregateTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetAggregateTests.cs
@@ -1,0 +1,53 @@
+using Voidforge.Api.Domain;
+using Voidforge.Api.Domain.Events;
+using Xunit;
+
+namespace Voidforge.Tests.Planets;
+
+public sealed class PlanetAggregateTests
+{
+    [Fact]
+    public void ApplyPlanetCreatedSetsAllProperties()
+    {
+        var planet = new Planet();
+        var solarSystemId = Guid.NewGuid();
+
+        planet.Apply(new PlanetCreated(
+            Name: "Test Planet",
+            SolarSystemId: solarSystemId,
+            IronOrePool: 50000,
+            BuildingSlotCount: 6,
+            IronOreStorageCapacity: 10000,
+            IronIngotStorageCapacity: 5000));
+
+        Assert.Equal("Test Planet", planet.Name);
+        Assert.Equal(solarSystemId, planet.SolarSystemId);
+        Assert.Equal(50000, planet.IronOrePool);
+        Assert.Equal(6, planet.BuildingSlotCount);
+        Assert.Equal(10000, planet.IronOreStorageCapacity);
+        Assert.Equal(5000, planet.IronIngotStorageCapacity);
+    }
+
+    [Fact]
+    public void NewPlanetHasNullOwner()
+    {
+        var planet = new Planet();
+
+        Assert.Null(planet.OwnerId);
+    }
+
+    [Fact]
+    public void NewPlanetHasDefaultValues()
+    {
+        var planet = new Planet();
+
+        Assert.Equal(Guid.Empty, planet.Id);
+        Assert.Equal(string.Empty, planet.Name);
+        Assert.Equal(Guid.Empty, planet.SolarSystemId);
+        Assert.Null(planet.OwnerId);
+        Assert.Equal(0, planet.IronOrePool);
+        Assert.Equal(0, planet.BuildingSlotCount);
+        Assert.Equal(0, planet.IronOreStorageCapacity);
+        Assert.Equal(0, planet.IronIngotStorageCapacity);
+    }
+}

--- a/src/Voidforge.Tests/Planets/PlanetEndpointTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetEndpointTests.cs
@@ -1,0 +1,118 @@
+using Alba;
+using Voidforge.Api.Auth;
+using Voidforge.Api.Endpoints;
+using Xunit;
+
+namespace Voidforge.Tests.Planets;
+
+[Collection(IntegrationCollection.Name)]
+public sealed class PlanetEndpointTests
+{
+    private readonly IAlbaHost _host;
+
+    public PlanetEndpointTests(AppFixture fixture)
+    {
+        _host = fixture.Host;
+    }
+
+    [Fact]
+    public async Task GetSolarSystemsReturnsSeededSystems()
+    {
+        var apiKey = await RegisterAndGetApiKey();
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url("/api/solar-systems");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, apiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var systems = await result.ReadAsJsonAsync<List<SolarSystemResponse>>();
+        Assert.NotNull(systems);
+        Assert.NotEmpty(systems);
+    }
+
+    [Fact]
+    public async Task GetSolarSystemsWithoutAuthReturns401()
+    {
+        await _host.Scenario(s =>
+        {
+            s.Get.Url("/api/solar-systems");
+            s.StatusCodeShouldBe(401);
+        });
+    }
+
+    [Fact]
+    public async Task GetPlanetByIdReturnsSeededPlanet()
+    {
+        var apiKey = await RegisterAndGetApiKey();
+
+        var systemsResult = await _host.Scenario(s =>
+        {
+            s.Get.Url("/api/solar-systems");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, apiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var systems = await systemsResult.ReadAsJsonAsync<List<SolarSystemResponse>>();
+        Assert.NotNull(systems);
+        Assert.NotEmpty(systems);
+
+        var planetId = systems[0].PlanetIds[0];
+
+        var planetResult = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/planets/{planetId}");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, apiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var planet = await planetResult.ReadAsJsonAsync<PlanetResponse>();
+        Assert.NotNull(planet);
+        Assert.Equal(planetId, planet.Id);
+        Assert.NotEqual(string.Empty, planet.Name);
+        Assert.Equal(systems[0].Id, planet.SolarSystemId);
+        Assert.Null(planet.OwnerId);
+        Assert.True(planet.IronOrePool > 0);
+        Assert.True(planet.BuildingSlotCount > 0);
+        Assert.True(planet.IronOreStorageCapacity > 0);
+        Assert.True(planet.IronIngotStorageCapacity > 0);
+    }
+
+    [Fact]
+    public async Task GetPlanetByNonExistentIdReturns404()
+    {
+        var apiKey = await RegisterAndGetApiKey();
+
+        await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/planets/{Guid.NewGuid()}");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, apiKey);
+            s.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
+    public async Task GetPlanetWithoutAuthReturns401()
+    {
+        await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/planets/{Guid.NewGuid()}");
+            s.StatusCodeShouldBe(401);
+        });
+    }
+
+    private async Task<string> RegisterAndGetApiKey()
+    {
+        var result = await _host.Scenario(s =>
+        {
+            s.Post.Json(new RegisterPlayerRequest($"Planet_Test_{Guid.NewGuid():N}"))
+                .ToUrl("/api/players/register");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
+        Assert.NotNull(response);
+        return response.ApiKey;
+    }
+}

--- a/technical-design/domain-model.md
+++ b/technical-design/domain-model.md
@@ -28,15 +28,6 @@ Created during registration via `session.Events.StartStream<Player>(...)`.
 
 Created during world seeding via `session.Events.StartStream<Planet>(...)`. `OwnerId` starts null (uncolonized).
 
-## Enums
-
-### ResourceType
-
-- **File**: `Domain/ResourceType.cs`
-- **Values**: `IronOre`, `IronIngots`
-
-Used to identify resource types for pools, storage, and production chains.
-
 ## Documents
 
 ### ApiKey

--- a/technical-design/domain-model.md
+++ b/technical-design/domain-model.md
@@ -19,6 +19,24 @@ The domain uses two storage patterns from Marten:
 
 Created during registration via `session.Events.StartStream<Player>(...)`.
 
+### Planet
+
+- **File**: `Domain/Planet.cs`
+- **Events**: `PlanetCreated(Name, SolarSystemId, IronOrePool, BuildingSlotCount, IronOreStorageCapacity, IronIngotStorageCapacity)`
+- **Snapshot fields**: `Id`, `Name`, `SolarSystemId`, `OwnerId` (nullable), `IronOrePool`, `BuildingSlotCount`, `IronOreStorageCapacity`, `IronIngotStorageCapacity`
+- **Marten config**: `opts.Projections.Snapshot<Planet>(SnapshotLifecycle.Inline)`
+
+Created during world seeding via `session.Events.StartStream<Planet>(...)`. `OwnerId` starts null (uncolonized).
+
+## Enums
+
+### ResourceType
+
+- **File**: `Domain/ResourceType.cs`
+- **Values**: `IronOre`, `IronIngots`
+
+Used to identify resource types for pools, storage, and production chains.
+
 ## Documents
 
 ### ApiKey
@@ -28,6 +46,13 @@ Created during registration via `session.Events.StartStream<Player>(...)`.
 - **Unique index**: `HashedKey`
 
 Stores SHA-256 hashed API keys. The raw key is returned once at registration and never stored.
+
+### SolarSystem
+
+- **File**: `Documents/SolarSystem.cs`
+- **Fields**: `Id`, `Name`, `X`, `Y`, `Z` (decimal coordinates), `PlanetIds`
+
+Groups planets into a named system at a 3D position. Created during world seeding.
 
 ## Relationships
 
@@ -41,6 +66,16 @@ Registration (atomic transaction):
 
 Authentication:
   X-API-Key header → SHA-256 hash → query ApiKey doc → PlayerId → ClaimsPrincipal
+
+World Seeding (atomic transaction via IHostedService):
+┌─────────────────────────────────────────────────┐
+│  For each solar system:                         │
+│    For each planet:                             │
+│      StartStream<Planet>(planetId, PlanetCreated)│
+│    Store(new SolarSystem { PlanetIds = [...] }) │
+│  SaveChangesAsync()  → single DB transaction    │
+└─────────────────────────────────────────────────┘
+  Idempotent: skips if SolarSystem count > 0
 ```
 
 ## Adding New Aggregates

--- a/technical-design/project-structure.md
+++ b/technical-design/project-structure.md
@@ -14,9 +14,11 @@ src/
 │   ├── Domain/                     # Event-sourced aggregates
 │   │   └── Events/                 # Domain events
 │   ├── Endpoints/                  # Wolverine HTTP endpoints + DTOs
+│   ├── WorldGeneration/            # World seeding (hosted service + config)
 │   └── Program.cs                  # App bootstrap (Marten, Wolverine, auth, middleware)
 └── Voidforge.Tests/                # Integration + unit tests
     ├── Auth/                       # Auth-related tests
+    ├── Planets/                    # Planet aggregate + endpoint tests
     ├── Players/                    # Player registration tests
     ├── AppFixture.cs               # Shared test host (Alba + PostgreSQL)
     └── IntegrationCollection.cs    # xUnit collection for shared fixture
@@ -31,6 +33,7 @@ src/
 | `Documents/` | Flat Marten documents (no event stream) | `ApiKey.cs` |
 | `Endpoints/` | Wolverine HTTP endpoint classes + request/response DTOs | `PlayerEndpoints.cs`, `RegisterPlayerRequest.cs` |
 | `Auth/` | Authentication handler, options, defaults | `ApiKeyAuthenticationHandler.cs` |
+| `WorldGeneration/` | World seeding hosted service + configuration | `WorldSeeder.cs`, `WorldGenOptions.cs` |
 
 **Rule**: One public type per file (enforced by Meziantou.Analyzer MA0048).
 


### PR DESCRIPTION
## Summary
- Add `Planet` event-sourced aggregate with `PlanetCreated` event and inline snapshot projection
- Add `SolarSystem` Marten document with 3D coordinates and planet references
- Add `WorldSeeder` hosted service with idempotent, configurable world generation
- Add `GET /api/solar-systems` and `GET /api/planets/{id}` endpoints
- Add unit tests for Planet aggregate and integration tests for all endpoints
- Update technical design docs (domain model, project structure)

Closes #7

## Test plan
- [x] 21 tests pass (4 existing + 3 aggregate unit tests + 5 endpoint integration tests + 9 other)
- [x] Build clean with no warnings
- [x] Quality gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)