### PR TITLE
feat: planet ownership & homeworld assignment

### DIFF
--- a/src/Voidforge.Api/Domain/Events/PlanetColonized.cs
+++ b/src/Voidforge.Api/Domain/Events/PlanetColonized.cs
@@ -1,0 +1,3 @@
+namespace Voidforge.Api.Domain.Events;
+
+public sealed record PlanetColonized(Guid OwnerId, long IronOreStored, long IronIngotStored);

--- a/src/Voidforge.Api/Domain/Planet.cs
+++ b/src/Voidforge.Api/Domain/Planet.cs
@@ -12,6 +12,8 @@ public sealed class Planet
     public int BuildingSlotCount { get; set; }
     public long IronOreStorageCapacity { get; set; }
     public long IronIngotStorageCapacity { get; set; }
+    public long IronOreStored { get; set; }
+    public long IronIngotStored { get; set; }
 
     public void Apply(PlanetCreated @event)
     {
@@ -21,5 +23,12 @@ public sealed class Planet
         BuildingSlotCount = @event.BuildingSlotCount;
         IronOreStorageCapacity = @event.IronOreStorageCapacity;
         IronIngotStorageCapacity = @event.IronIngotStorageCapacity;
+    }
+
+    public void Apply(PlanetColonized @event)
+    {
+        OwnerId = @event.OwnerId;
+        IronOreStored = @event.IronOreStored;
+        IronIngotStored = @event.IronIngotStored;
     }
 }

--- a/src/Voidforge.Api/Endpoints/PlanetEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/PlanetEndpoints.cs
@@ -25,6 +25,8 @@ public static class PlanetEndpoints
             planet.IronOrePool,
             planet.BuildingSlotCount,
             planet.IronOreStorageCapacity,
-            planet.IronIngotStorageCapacity));
+            planet.IronIngotStorageCapacity,
+            planet.IronOreStored,
+            planet.IronIngotStored));
     }
 }

--- a/src/Voidforge.Api/Endpoints/PlanetResponse.cs
+++ b/src/Voidforge.Api/Endpoints/PlanetResponse.cs
@@ -8,4 +8,6 @@ public sealed record PlanetResponse(
     long IronOrePool,
     int BuildingSlotCount,
     long IronOreStorageCapacity,
-    long IronIngotStorageCapacity);
+    long IronIngotStorageCapacity,
+    long IronOreStored,
+    long IronIngotStored);

--- a/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
@@ -18,7 +18,7 @@ public static class PlayerEndpoints
 {
     [AllowAnonymous]
     [WolverinePost("/api/players/register")]
-    public static async Task<Results<Ok<RegisterPlayerResponse>, Conflict<string>>> Register(
+    public static async Task<Results<Ok<RegisterPlayerResponse>, Conflict<string>, StatusCodeHttpResult>> Register(
         RegisterPlayerRequest request,
         IDocumentSession session,
         IOptions<WorldGenOptions> worldGenOptions)
@@ -31,6 +31,8 @@ public static class PlayerEndpoints
             return TypedResults.Conflict("Player name is already taken.");
         }
 
+        // Perf: loads all uncolonized planet IDs into memory. Replace with COUNT + random offset
+        // or database-side random selection when planet counts grow large.
         var uncolonized = await session.Query<Planet>()
             .Where(p => p.OwnerId == null)
             .Select(p => p.Id)
@@ -38,7 +40,7 @@ public static class PlayerEndpoints
 
         if (uncolonized.Count == 0)
         {
-            return TypedResults.Conflict("No uncolonized planets available.");
+            return TypedResults.StatusCode(503);
         }
 
         var homeworldId = uncolonized[Random.Shared.Next(uncolonized.Count)];
@@ -49,6 +51,8 @@ public static class PlayerEndpoints
         var opts = worldGenOptions.Value;
 
         session.Events.StartStream<Player>(playerId, new PlayerRegistered(request.Name, DateTimeOffset.UtcNow));
+        // Race: two concurrent registrations can colonize the same planet. Fix with optimistic
+        // concurrency (expected version) on Append. Tracked in GitHub issue.
         session.Events.Append(homeworldId, new PlanetColonized(playerId, opts.StartingIronOre, opts.StartingIronIngots));
         session.Store(new ApiKey
         {

--- a/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
@@ -4,10 +4,12 @@ using Marten;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Options;
 using Voidforge.Api.Auth;
 using Voidforge.Api.Documents;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Domain.Events;
+using Voidforge.Api.WorldGeneration;
 using Wolverine.Http;
 
 namespace Voidforge.Api.Endpoints;
@@ -18,7 +20,8 @@ public static class PlayerEndpoints
     [WolverinePost("/api/players/register")]
     public static async Task<Results<Ok<RegisterPlayerResponse>, Conflict<string>>> Register(
         RegisterPlayerRequest request,
-        IDocumentSession session)
+        IDocumentSession session,
+        IOptions<WorldGenOptions> worldGenOptions)
     {
         var nameTaken = await session.Query<Player>()
             .AnyAsync(p => p.Name == request.Name);
@@ -28,11 +31,25 @@ public static class PlayerEndpoints
             return TypedResults.Conflict("Player name is already taken.");
         }
 
+        var uncolonized = await session.Query<Planet>()
+            .Where(p => p.OwnerId == null)
+            .Select(p => p.Id)
+            .ToListAsync();
+
+        if (uncolonized.Count == 0)
+        {
+            return TypedResults.Conflict("No uncolonized planets available.");
+        }
+
+        var homeworldId = uncolonized[Random.Shared.Next(uncolonized.Count)];
+
         var playerId = Guid.NewGuid();
         var rawKey = GenerateApiKey();
         var hashedKey = ApiKeyAuthenticationHandler.HashKey(rawKey);
+        var opts = worldGenOptions.Value;
 
         session.Events.StartStream<Player>(playerId, new PlayerRegistered(request.Name, DateTimeOffset.UtcNow));
+        session.Events.Append(homeworldId, new PlanetColonized(playerId, opts.StartingIronOre, opts.StartingIronIngots));
         session.Store(new ApiKey
         {
             Id = Guid.NewGuid(),
@@ -42,7 +59,7 @@ public static class PlayerEndpoints
 
         await session.SaveChangesAsync();
 
-        return TypedResults.Ok(new RegisterPlayerResponse(playerId, rawKey));
+        return TypedResults.Ok(new RegisterPlayerResponse(playerId, rawKey, homeworldId));
     }
 
     [WolverineGet("/api/players/me")]

--- a/src/Voidforge.Api/Endpoints/RegisterPlayerResponse.cs
+++ b/src/Voidforge.Api/Endpoints/RegisterPlayerResponse.cs
@@ -1,3 +1,3 @@
 namespace Voidforge.Api.Endpoints;
 
-public sealed record RegisterPlayerResponse(Guid PlayerId, string ApiKey);
+public sealed record RegisterPlayerResponse(Guid PlayerId, string ApiKey, Guid HomeworldId);

--- a/src/Voidforge.Api/WorldGeneration/WorldGenOptions.cs
+++ b/src/Voidforge.Api/WorldGeneration/WorldGenOptions.cs
@@ -9,4 +9,6 @@ public sealed class WorldGenOptions
     public long IronOreStorageCapacity { get; set; } = 10000;
     public long IronIngotStorageCapacity { get; set; } = 5000;
     public decimal CoordinateRange { get; set; } = 1000;
+    public long StartingIronOre { get; set; } = 500;
+    public long StartingIronIngots { get; set; } = 100;
 }

--- a/src/Voidforge.Api/appsettings.json
+++ b/src/Voidforge.Api/appsettings.json
@@ -9,7 +9,9 @@
     "BuildingSlotCount": 6,
     "IronOreStorageCapacity": 10000,
     "IronIngotStorageCapacity": 5000,
-    "CoordinateRange": 1000
+    "CoordinateRange": 1000,
+    "StartingIronOre": 500,
+    "StartingIronIngots": 100
   },
   "Logging": {
     "LogLevel": {

--- a/src/Voidforge.Tests/AppFixture.cs
+++ b/src/Voidforge.Tests/AppFixture.cs
@@ -1,4 +1,5 @@
 using Alba;
+using Npgsql;
 using Xunit;
 
 namespace Voidforge.Tests;
@@ -17,6 +18,21 @@ public sealed class AppFixture : IAsyncLifetime
         // Using the env var path avoids AlbaHost.For's WithWebHostBuilder overload,
         // which triggers a service provider disposal race with RunJasperFxCommands in .NET 9.
         Environment.SetEnvironmentVariable("ConnectionStrings__Marten", connStr);
+
+        // Safety check: refuse to drop schema on a non-test database.
+        var builder = new NpgsqlConnectionStringBuilder(connStr);
+        if (builder.Database is not { } db || !db.Contains("test", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to reset database '{builder.Database}'. Test connection string must target a database containing 'test' in its name.");
+        }
+
+        // Drop the schema before the host starts so the WorldSeeder re-seeds fresh data.
+        await using var conn = new NpgsqlConnection(connStr);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "DROP SCHEMA IF EXISTS voidforge CASCADE;";
+        await cmd.ExecuteNonQueryAsync();
 
         Host = await AlbaHost.For<Program>();
     }

--- a/src/Voidforge.Tests/Planets/PlanetAggregateTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetAggregateTests.cs
@@ -49,5 +49,23 @@ public sealed class PlanetAggregateTests
         Assert.Equal(0, planet.BuildingSlotCount);
         Assert.Equal(0, planet.IronOreStorageCapacity);
         Assert.Equal(0, planet.IronIngotStorageCapacity);
+        Assert.Equal(0, planet.IronOreStored);
+        Assert.Equal(0, planet.IronIngotStored);
+    }
+
+    [Fact]
+    public void ApplyPlanetColonizedSetsOwnerAndResources()
+    {
+        var planet = new Planet();
+        var ownerId = Guid.NewGuid();
+
+        planet.Apply(new PlanetColonized(
+            OwnerId: ownerId,
+            IronOreStored: 500,
+            IronIngotStored: 100));
+
+        Assert.Equal(ownerId, planet.OwnerId);
+        Assert.Equal(500, planet.IronOreStored);
+        Assert.Equal(100, planet.IronIngotStored);
     }
 }

--- a/src/Voidforge.Tests/Planets/PlanetEndpointTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetEndpointTests.cs
@@ -18,12 +18,12 @@ public sealed class PlanetEndpointTests
     [Fact]
     public async Task GetSolarSystemsReturnsSeededSystems()
     {
-        var apiKey = await RegisterAndGetApiKey();
+        var registration = await RegisterPlayer();
 
         var result = await _host.Scenario(s =>
         {
             s.Get.Url("/api/solar-systems");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, apiKey);
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
             s.StatusCodeShouldBe(200);
         });
 
@@ -45,49 +45,37 @@ public sealed class PlanetEndpointTests
     [Fact]
     public async Task GetPlanetByIdReturnsSeededPlanet()
     {
-        var apiKey = await RegisterAndGetApiKey();
-
-        var systemsResult = await _host.Scenario(s =>
-        {
-            s.Get.Url("/api/solar-systems");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, apiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var systems = await systemsResult.ReadAsJsonAsync<List<SolarSystemResponse>>();
-        Assert.NotNull(systems);
-        Assert.NotEmpty(systems);
-
-        var planetId = systems[0].PlanetIds[0];
+        var registration = await RegisterPlayer();
 
         var planetResult = await _host.Scenario(s =>
         {
-            s.Get.Url($"/api/planets/{planetId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, apiKey);
+            s.Get.Url($"/api/planets/{registration.HomeworldId}");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
             s.StatusCodeShouldBe(200);
         });
 
         var planet = await planetResult.ReadAsJsonAsync<PlanetResponse>();
         Assert.NotNull(planet);
-        Assert.Equal(planetId, planet.Id);
+        Assert.Equal(registration.HomeworldId, planet.Id);
         Assert.NotEqual(string.Empty, planet.Name);
-        Assert.Equal(systems[0].Id, planet.SolarSystemId);
-        Assert.Null(planet.OwnerId);
+        Assert.Equal(registration.PlayerId, planet.OwnerId);
         Assert.True(planet.IronOrePool > 0);
         Assert.True(planet.BuildingSlotCount > 0);
         Assert.True(planet.IronOreStorageCapacity > 0);
         Assert.True(planet.IronIngotStorageCapacity > 0);
+        Assert.True(planet.IronOreStored > 0);
+        Assert.True(planet.IronIngotStored > 0);
     }
 
     [Fact]
     public async Task GetPlanetByNonExistentIdReturns404()
     {
-        var apiKey = await RegisterAndGetApiKey();
+        var registration = await RegisterPlayer();
 
         await _host.Scenario(s =>
         {
             s.Get.Url($"/api/planets/{Guid.NewGuid()}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, apiKey);
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
             s.StatusCodeShouldBe(404);
         });
     }
@@ -102,7 +90,7 @@ public sealed class PlanetEndpointTests
         });
     }
 
-    private async Task<string> RegisterAndGetApiKey()
+    private async Task<RegisterPlayerResponse> RegisterPlayer()
     {
         var result = await _host.Scenario(s =>
         {
@@ -113,6 +101,6 @@ public sealed class PlanetEndpointTests
 
         var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
         Assert.NotNull(response);
-        return response.ApiKey;
+        return response;
     }
 }

--- a/src/Voidforge.Tests/Players/PlayerRegistrationTests.cs
+++ b/src/Voidforge.Tests/Players/PlayerRegistrationTests.cs
@@ -129,4 +129,49 @@ public sealed class PlayerRegistrationTests
             s.StatusCodeShouldBe(409);
         });
     }
+
+    [Fact]
+    public async Task RegisterAssignsHomeworldWithStartingResources()
+    {
+        var result = await _host.Scenario(s =>
+        {
+            s.Post.Json(new RegisterPlayerRequest($"Player_{Guid.NewGuid():N}")).ToUrl("/api/players/register");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
+        Assert.NotNull(response);
+        Assert.NotEqual(Guid.Empty, response.HomeworldId);
+
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession();
+
+        var planet = await session.LoadAsync<Planet>(response.HomeworldId);
+        Assert.NotNull(planet);
+        Assert.Equal(response.PlayerId, planet.OwnerId);
+        Assert.True(planet.IronOreStored > 0);
+        Assert.True(planet.IronIngotStored > 0);
+    }
+
+    [Fact]
+    public async Task TwoPlayersGetDifferentHomeworlds()
+    {
+        var result1 = await _host.Scenario(s =>
+        {
+            s.Post.Json(new RegisterPlayerRequest($"Player_{Guid.NewGuid():N}")).ToUrl("/api/players/register");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var result2 = await _host.Scenario(s =>
+        {
+            s.Post.Json(new RegisterPlayerRequest($"Player_{Guid.NewGuid():N}")).ToUrl("/api/players/register");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var response1 = await result1.ReadAsJsonAsync<RegisterPlayerResponse>();
+        var response2 = await result2.ReadAsJsonAsync<RegisterPlayerResponse>();
+        Assert.NotNull(response1);
+        Assert.NotNull(response2);
+        Assert.NotEqual(response1.HomeworldId, response2.HomeworldId);
+    }
 }

--- a/technical-design/domain-model.md
+++ b/technical-design/domain-model.md
@@ -22,8 +22,8 @@ Created during registration via `session.Events.StartStream<Player>(...)`.
 ### Planet
 
 - **File**: `Domain/Planet.cs`
-- **Events**: `PlanetCreated(Name, SolarSystemId, IronOrePool, BuildingSlotCount, IronOreStorageCapacity, IronIngotStorageCapacity)`
-- **Snapshot fields**: `Id`, `Name`, `SolarSystemId`, `OwnerId` (nullable), `IronOrePool`, `BuildingSlotCount`, `IronOreStorageCapacity`, `IronIngotStorageCapacity`
+- **Events**: `PlanetCreated(Name, SolarSystemId, IronOrePool, BuildingSlotCount, IronOreStorageCapacity, IronIngotStorageCapacity)`, `PlanetColonized(OwnerId, IronOreStored, IronIngotStored)`
+- **Snapshot fields**: `Id`, `Name`, `SolarSystemId`, `OwnerId` (nullable), `IronOrePool`, `BuildingSlotCount`, `IronOreStorageCapacity`, `IronIngotStorageCapacity`, `IronOreStored`, `IronIngotStored`
 - **Marten config**: `opts.Projections.Snapshot<Planet>(SnapshotLifecycle.Inline)`
 
 Created during world seeding via `session.Events.StartStream<Planet>(...)`. `OwnerId` starts null (uncolonized).
@@ -49,11 +49,13 @@ Groups planets into a named system at a 3D position. Created during world seedin
 
 ```
 Registration (atomic transaction):
-┌─────────────────────────────────────────┐
-│  1. StartStream<Player>(playerId, event)│  → mt_events + mt_doc_player
-│  2. Store(new ApiKey { ... })           │  → mt_doc_apikey
-│  3. SaveChangesAsync()                  │  → single DB transaction
-└─────────────────────────────────────────┘
+┌──────────────────────────────────────────────────┐
+│  1. StartStream<Player>(playerId, event)         │  → mt_events + mt_doc_player
+│  2. Append(homeworldId, PlanetColonized)         │  → mt_events + mt_doc_planet
+│  3. Store(new ApiKey { ... })                    │  → mt_doc_apikey
+│  4. SaveChangesAsync()                           │  → single DB transaction
+└──────────────────────────────────────────────────┘
+  Homeworld: random uncolonized planet, colonized with starting resources
 
 Authentication:
   X-API-Key header → SHA-256 hash → query ApiKey doc → PlayerId → ClaimsPrincipal


### PR DESCRIPTION
## Summary
- Add `PlanetColonized` event with owner ID and starting resources (Iron Ore, Iron Ingots)
- Extend registration to assign a random uncolonized planet as homeworld in a single transaction
- Add configurable starting resources via `WorldGenOptions` (`StartingIronOre`, `StartingIronIngots`)
- Return `HomeworldId` in registration response
- Add safety guard in test fixture to refuse schema drops on non-test databases

Closes #8

## Test plan
- [x] 24 tests pass (unit + integration)
- [x] `RegisterAssignsHomeworldWithStartingResources` — verifies ownership and starting resources
- [x] `TwoPlayersGetDifferentHomeworlds` — verifies unique planet assignment
- [x] `ApplyPlanetColonizedSetsOwnerAndResources` — unit test for aggregate event
- [x] Existing tests updated for new response shapes
- [x] Tests stable across repeated runs (schema reset on startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)