### PR TITLE
ResourcePool value object & lazy resource calculation

### DIFF
--- a/src/Voidforge.Api/Domain/Events/PlanetColonized.cs
+++ b/src/Voidforge.Api/Domain/Events/PlanetColonized.cs
@@ -1,3 +1,3 @@
 namespace Voidforge.Api.Domain.Events;
 
-public sealed record PlanetColonized(Guid OwnerId, long IronOreStored, long IronIngotStored);
+public sealed record PlanetColonized(Guid OwnerId, long IronOreStored, long IronIngotStored, DateTimeOffset ColonizedAt);

--- a/src/Voidforge.Api/Domain/Planet.cs
+++ b/src/Voidforge.Api/Domain/Planet.cs
@@ -10,10 +10,8 @@ public sealed class Planet
     public Guid? OwnerId { get; set; }
     public long IronOrePool { get; set; }
     public int BuildingSlotCount { get; set; }
-    public long IronOreStorageCapacity { get; set; }
-    public long IronIngotStorageCapacity { get; set; }
-    public long IronOreStored { get; set; }
-    public long IronIngotStored { get; set; }
+    public ResourcePool IronOre { get; set; } = new(0, 0, 0, default);
+    public ResourcePool IronIngot { get; set; } = new(0, 0, 0, default);
 
     public void Apply(PlanetCreated @event)
     {
@@ -21,14 +19,20 @@ public sealed class Planet
         SolarSystemId = @event.SolarSystemId;
         IronOrePool = @event.IronOrePool;
         BuildingSlotCount = @event.BuildingSlotCount;
-        IronOreStorageCapacity = @event.IronOreStorageCapacity;
-        IronIngotStorageCapacity = @event.IronIngotStorageCapacity;
+        IronOre = new ResourcePool(0, 0, @event.IronOreStorageCapacity, default);
+        IronIngot = new ResourcePool(0, 0, @event.IronIngotStorageCapacity, default);
     }
 
     public void Apply(PlanetColonized @event)
     {
         OwnerId = @event.OwnerId;
-        IronOreStored = @event.IronOreStored;
-        IronIngotStored = @event.IronIngotStored;
+        IronOre = IronOre with { CheckpointValue = @event.IronOreStored, CheckpointTime = @event.ColonizedAt };
+        IronIngot = IronIngot with { CheckpointValue = @event.IronIngotStored, CheckpointTime = @event.ColonizedAt };
+    }
+
+    public void CheckpointAllResources(DateTimeOffset now)
+    {
+        IronOre = IronOre.Checkpoint(now);
+        IronIngot = IronIngot.Checkpoint(now);
     }
 }

--- a/src/Voidforge.Api/Domain/ResourcePool.cs
+++ b/src/Voidforge.Api/Domain/ResourcePool.cs
@@ -1,0 +1,19 @@
+namespace Voidforge.Api.Domain;
+
+public sealed record ResourcePool(
+    decimal CheckpointValue,
+    decimal Rate,
+    decimal StorageCapacity,
+    DateTimeOffset CheckpointTime)
+{
+    public decimal GetCurrentValue(DateTimeOffset now)
+    {
+        var elapsed = (decimal)(now - CheckpointTime).TotalSeconds;
+        return Math.Clamp(CheckpointValue + Rate * elapsed, 0, StorageCapacity);
+    }
+
+    public ResourcePool Checkpoint(DateTimeOffset now)
+    {
+        return this with { CheckpointValue = GetCurrentValue(now), CheckpointTime = now };
+    }
+}

--- a/src/Voidforge.Api/Endpoints/PlanetEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/PlanetEndpoints.cs
@@ -17,6 +17,8 @@ public static class PlanetEndpoints
             return TypedResults.NotFound();
         }
 
+        var now = DateTimeOffset.UtcNow;
+
         return TypedResults.Ok(new PlanetResponse(
             planet.Id,
             planet.Name,
@@ -24,9 +26,13 @@ public static class PlanetEndpoints
             planet.OwnerId,
             planet.IronOrePool,
             planet.BuildingSlotCount,
-            planet.IronOreStorageCapacity,
-            planet.IronIngotStorageCapacity,
-            planet.IronOreStored,
-            planet.IronIngotStored));
+            new ResourcePoolResponse(
+                planet.IronOre.GetCurrentValue(now),
+                planet.IronOre.Rate,
+                planet.IronOre.StorageCapacity),
+            new ResourcePoolResponse(
+                planet.IronIngot.GetCurrentValue(now),
+                planet.IronIngot.Rate,
+                planet.IronIngot.StorageCapacity)));
     }
 }

--- a/src/Voidforge.Api/Endpoints/PlanetResponse.cs
+++ b/src/Voidforge.Api/Endpoints/PlanetResponse.cs
@@ -7,7 +7,5 @@ public sealed record PlanetResponse(
     Guid? OwnerId,
     long IronOrePool,
     int BuildingSlotCount,
-    long IronOreStorageCapacity,
-    long IronIngotStorageCapacity,
-    long IronOreStored,
-    long IronIngotStored);
+    ResourcePoolResponse IronOre,
+    ResourcePoolResponse IronIngot);

--- a/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
@@ -53,7 +53,7 @@ public static class PlayerEndpoints
         session.Events.StartStream<Player>(playerId, new PlayerRegistered(request.Name, DateTimeOffset.UtcNow));
         // Race: two concurrent registrations can colonize the same planet. Fix with optimistic
         // concurrency (expected version) on Append. Tracked in GitHub issue.
-        session.Events.Append(homeworldId, new PlanetColonized(playerId, opts.StartingIronOre, opts.StartingIronIngots));
+        session.Events.Append(homeworldId, new PlanetColonized(playerId, opts.StartingIronOre, opts.StartingIronIngots, DateTimeOffset.UtcNow));
         session.Store(new ApiKey
         {
             Id = Guid.NewGuid(),

--- a/src/Voidforge.Api/Endpoints/ResourcePoolResponse.cs
+++ b/src/Voidforge.Api/Endpoints/ResourcePoolResponse.cs
@@ -1,0 +1,6 @@
+namespace Voidforge.Api.Endpoints;
+
+public sealed record ResourcePoolResponse(
+    decimal CurrentValue,
+    decimal Rate,
+    decimal StorageCapacity);

--- a/src/Voidforge.Tests/Domain/ResourcePoolTests.cs
+++ b/src/Voidforge.Tests/Domain/ResourcePoolTests.cs
@@ -1,0 +1,80 @@
+using Voidforge.Api.Domain;
+using Xunit;
+
+namespace Voidforge.Tests.Domain;
+
+public sealed class ResourcePoolTests
+{
+    [Fact]
+    public void AccumulatesOverTime()
+    {
+        var checkpoint = DateTimeOffset.UtcNow;
+        var pool = new ResourcePool(100, 10, 1000, checkpoint);
+
+        Assert.Equal(150m, pool.GetCurrentValue(checkpoint.AddSeconds(5)));
+    }
+
+    [Fact]
+    public void ConsumesOverTime()
+    {
+        var checkpoint = DateTimeOffset.UtcNow;
+        var pool = new ResourcePool(200, -5, 1000, checkpoint);
+
+        Assert.Equal(150m, pool.GetCurrentValue(checkpoint.AddSeconds(10)));
+    }
+
+    [Fact]
+    public void ClampsAtZero()
+    {
+        var checkpoint = DateTimeOffset.UtcNow;
+        var pool = new ResourcePool(50, -10, 1000, checkpoint);
+
+        Assert.Equal(0m, pool.GetCurrentValue(checkpoint.AddSeconds(10)));
+    }
+
+    [Fact]
+    public void ClampsAtCapacity()
+    {
+        var checkpoint = DateTimeOffset.UtcNow;
+        var pool = new ResourcePool(900, 50, 1000, checkpoint);
+
+        Assert.Equal(1000m, pool.GetCurrentValue(checkpoint.AddSeconds(10)));
+    }
+
+    [Fact]
+    public void CheckpointResetsBaseline()
+    {
+        var checkpoint = DateTimeOffset.UtcNow;
+        var pool = new ResourcePool(100, 10, 1000, checkpoint);
+        var newTime = checkpoint.AddSeconds(5);
+
+        var checkpointed = pool.Checkpoint(newTime);
+
+        Assert.Equal(150m, checkpointed.CheckpointValue);
+        Assert.Equal(newTime, checkpointed.CheckpointTime);
+        Assert.Equal(10m, checkpointed.Rate);
+        Assert.Equal(1000m, checkpointed.StorageCapacity);
+    }
+
+    [Fact]
+    public void ZeroRateReturnsCheckpointValue()
+    {
+        var checkpoint = DateTimeOffset.UtcNow;
+        var pool = new ResourcePool(500, 0, 10000, checkpoint);
+
+        Assert.Equal(500m, pool.GetCurrentValue(checkpoint.AddSeconds(100)));
+    }
+
+    [Fact]
+    public void IsImmutable()
+    {
+        var checkpoint = DateTimeOffset.UtcNow;
+        var pool = new ResourcePool(100, 10, 1000, checkpoint);
+
+        var checkpointed = pool.Checkpoint(checkpoint.AddSeconds(5));
+
+        Assert.Equal(100m, pool.CheckpointValue);
+        Assert.Equal(checkpoint, pool.CheckpointTime);
+        Assert.NotSame(pool, checkpointed);
+    }
+}

--- a/src/Voidforge.Tests/Planets/PlanetAggregateTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetAggregateTests.cs
@@ -24,8 +24,12 @@ public sealed class PlanetAggregateTests
         Assert.Equal(solarSystemId, planet.SolarSystemId);
         Assert.Equal(50000, planet.IronOrePool);
         Assert.Equal(6, planet.BuildingSlotCount);
-        Assert.Equal(10000, planet.IronOreStorageCapacity);
-        Assert.Equal(5000, planet.IronIngotStorageCapacity);
+        Assert.Equal(0m, planet.IronOre.CheckpointValue);
+        Assert.Equal(0m, planet.IronOre.Rate);
+        Assert.Equal(10000m, planet.IronOre.StorageCapacity);
+        Assert.Equal(0m, planet.IronIngot.CheckpointValue);
+        Assert.Equal(0m, planet.IronIngot.Rate);
+        Assert.Equal(5000m, planet.IronIngot.StorageCapacity);
     }
 
     [Fact]
@@ -47,25 +51,59 @@ public sealed class PlanetAggregateTests
         Assert.Null(planet.OwnerId);
         Assert.Equal(0, planet.IronOrePool);
         Assert.Equal(0, planet.BuildingSlotCount);
-        Assert.Equal(0, planet.IronOreStorageCapacity);
-        Assert.Equal(0, planet.IronIngotStorageCapacity);
-        Assert.Equal(0, planet.IronOreStored);
-        Assert.Equal(0, planet.IronIngotStored);
+        Assert.Equal(0m, planet.IronOre.CheckpointValue);
+        Assert.Equal(0m, planet.IronOre.StorageCapacity);
+        Assert.Equal(0m, planet.IronIngot.CheckpointValue);
+        Assert.Equal(0m, planet.IronIngot.StorageCapacity);
     }
 
     [Fact]
     public void ApplyPlanetColonizedSetsOwnerAndResources()
     {
         var planet = new Planet();
+        var solarSystemId = Guid.NewGuid();
         var ownerId = Guid.NewGuid();
+        var colonizedAt = DateTimeOffset.UtcNow;
+
+        planet.Apply(new PlanetCreated(
+            Name: "Test Planet",
+            SolarSystemId: solarSystemId,
+            IronOrePool: 50000,
+            BuildingSlotCount: 6,
+            IronOreStorageCapacity: 10000,
+            IronIngotStorageCapacity: 5000));
 
         planet.Apply(new PlanetColonized(
             OwnerId: ownerId,
             IronOreStored: 500,
-            IronIngotStored: 100));
+            IronIngotStored: 100,
+            ColonizedAt: colonizedAt));
 
         Assert.Equal(ownerId, planet.OwnerId);
-        Assert.Equal(500, planet.IronOreStored);
-        Assert.Equal(100, planet.IronIngotStored);
+        Assert.Equal(500m, planet.IronOre.CheckpointValue);
+        Assert.Equal(colonizedAt, planet.IronOre.CheckpointTime);
+        Assert.Equal(10000m, planet.IronOre.StorageCapacity);
+        Assert.Equal(100m, planet.IronIngot.CheckpointValue);
+        Assert.Equal(colonizedAt, planet.IronIngot.CheckpointTime);
+        Assert.Equal(5000m, planet.IronIngot.StorageCapacity);
+    }
+
+    [Fact]
+    public void CheckpointAllResourcesUpdatesBaselines()
+    {
+        var planet = new Planet();
+        var colonizedAt = DateTimeOffset.UtcNow;
+
+        planet.Apply(new PlanetCreated("P", Guid.NewGuid(), 50000, 6, 10000, 5000));
+        planet.Apply(new PlanetColonized(Guid.NewGuid(), 500, 100, colonizedAt));
+
+        // Manually set a rate to verify checkpoint math
+        planet.IronOre = planet.IronOre with { Rate = 10 };
+
+        var checkpointTime = colonizedAt.AddSeconds(5);
+        planet.CheckpointAllResources(checkpointTime);
+
+        Assert.Equal(550m, planet.IronOre.CheckpointValue);
+        Assert.Equal(checkpointTime, planet.IronOre.CheckpointTime);
     }
 }

--- a/src/Voidforge.Tests/Planets/PlanetEndpointTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetEndpointTests.cs
@@ -61,10 +61,30 @@ public sealed class PlanetEndpointTests
         Assert.Equal(registration.PlayerId, planet.OwnerId);
         Assert.True(planet.IronOrePool > 0);
         Assert.True(planet.BuildingSlotCount > 0);
-        Assert.True(planet.IronOreStorageCapacity > 0);
-        Assert.True(planet.IronIngotStorageCapacity > 0);
-        Assert.True(planet.IronOreStored > 0);
-        Assert.True(planet.IronIngotStored > 0);
+        Assert.True(planet.IronOre.StorageCapacity > 0);
+        Assert.True(planet.IronIngot.StorageCapacity > 0);
+        Assert.True(planet.IronOre.CurrentValue > 0);
+        Assert.True(planet.IronIngot.CurrentValue > 0);
+    }
+
+    [Fact]
+    public async Task GetPlanetByIdReturnsComputedValuesNotRawCheckpoint()
+    {
+        var registration = await RegisterPlayer();
+
+        var planetResult = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/planets/{registration.HomeworldId}");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var planet = await planetResult.ReadAsJsonAsync<PlanetResponse>();
+        Assert.NotNull(planet);
+
+        // With rate=0 (no buildings yet), current value should equal starting resources
+        Assert.Equal(0m, planet.IronOre.Rate);
+        Assert.Equal(0m, planet.IronIngot.Rate);
     }
 
     [Fact]

--- a/src/Voidforge.Tests/Players/PlayerRegistrationTests.cs
+++ b/src/Voidforge.Tests/Players/PlayerRegistrationTests.cs
@@ -149,8 +149,8 @@ public sealed class PlayerRegistrationTests
         var planet = await session.LoadAsync<Planet>(response.HomeworldId);
         Assert.NotNull(planet);
         Assert.Equal(response.PlayerId, planet.OwnerId);
-        Assert.True(planet.IronOreStored > 0);
-        Assert.True(planet.IronIngotStored > 0);
+        Assert.True(planet.IronOre.CheckpointValue > 0);
+        Assert.True(planet.IronIngot.CheckpointValue > 0);
     }
 
     [Fact]

--- a/technical-design/domain-model.md
+++ b/technical-design/domain-model.md
@@ -22,11 +22,20 @@ Created during registration via `session.Events.StartStream<Player>(...)`.
 ### Planet
 
 - **File**: `Domain/Planet.cs`
-- **Events**: `PlanetCreated(Name, SolarSystemId, IronOrePool, BuildingSlotCount, IronOreStorageCapacity, IronIngotStorageCapacity)`, `PlanetColonized(OwnerId, IronOreStored, IronIngotStored)`
-- **Snapshot fields**: `Id`, `Name`, `SolarSystemId`, `OwnerId` (nullable), `IronOrePool`, `BuildingSlotCount`, `IronOreStorageCapacity`, `IronIngotStorageCapacity`, `IronOreStored`, `IronIngotStored`
+- **Events**: `PlanetCreated(Name, SolarSystemId, IronOrePool, BuildingSlotCount, IronOreStorageCapacity, IronIngotStorageCapacity)`, `PlanetColonized(OwnerId, IronOreStored, IronIngotStored, ColonizedAt)`
+- **Snapshot fields**: `Id`, `Name`, `SolarSystemId`, `OwnerId` (nullable), `IronOrePool`, `BuildingSlotCount`, `IronOre` (ResourcePool), `IronIngot` (ResourcePool)
 - **Marten config**: `opts.Projections.Snapshot<Planet>(SnapshotLifecycle.Inline)`
 
 Created during world seeding via `session.Events.StartStream<Planet>(...)`. `OwnerId` starts null (uncolonized).
+
+### ResourcePool (Value Object)
+
+- **File**: `Domain/ResourcePool.cs`
+- **Fields**: `CheckpointValue` (decimal), `Rate` (decimal, units/sec), `StorageCapacity` (decimal), `CheckpointTime` (DateTimeOffset)
+- **Methods**: `GetCurrentValue(now)` — computes `Clamp(checkpoint + rate * elapsed, 0, capacity)`; `Checkpoint(now)` — returns new instance with current value as baseline
+- **Semantics**: Immutable record. Methods return new instances. Rate starts at 0; buildings (#10) will set rates via checkpointing.
+
+Used by `Planet.IronOre` and `Planet.IronIngot`. The query endpoint computes current values at request time using `GetCurrentValue(DateTimeOffset.UtcNow)` — no background ticks needed.
 
 ## Documents
 


### PR DESCRIPTION
## Summary

- Introduce immutable `ResourcePool` value object with checkpoint-based math (`CheckpointValue + Rate * elapsed`, clamped to `[0, capacity]`)
- Replace raw `IronOreStored`/`IronIngotStored` fields on `Planet` aggregate with `ResourcePool IronOre`/`IronIngot`
- `GET /api/planets/{id}` now computes resource values at request time — no background ticks needed

## Test plan

- [x] 7 unit tests for `ResourcePool` (accumulation, consumption, zero/capacity clamping, checkpoint, immutability)
- [x] 5 unit tests for `Planet` aggregate (created, colonized, default values, checkpoint)
- [x] Integration tests for planet endpoint (computed values, rate=0 verification)
- [x] All 33 tests passing, 0 warnings, format clean

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)