### PR TITLE
feat: add start-infra skill and script for devcontainer postgres

### DIFF
--- a/.claude/skills/start-infra/SKILL.md
+++ b/.claude/skills/start-infra/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: start-infra
+description: Start Voidforge development infrastructure. Use ONLY when the user asks to start the database, postgres, infrastructure, docker services, or when tests fail with database connection errors.
+---
+
+# Voidforge Infrastructure
+
+Voidforge runs PostgreSQL 16 as its only infrastructure dependency. Postgres shares the devcontainer's network stack via `--network container:`, so `localhost:5432` works transparently — no env vars, no code changes needed.
+
+## Starting Postgres
+
+```bash
+bash .claude/start-infra.sh
+```
+
+The script:
+- Creates a container named `voidforge-postgres` sharing the devcontainer's network stack
+- Idempotent — safe to run repeatedly
+- Waits for `pg_isready` before returning
+- Creates the `voidforge_test` database if missing
+
+Postgres will be reachable at `localhost:5432` — the same host the application code and tests already use.
+
+## Teardown
+
+```bash
+docker stop voidforge-postgres
+docker rm voidforge-postgres
+```
+
+Note: because the container shares the devcontainer's network stack, restarting the devcontainer will orphan the postgres container. Re-run `bash .claude/start-infra.sh` to recreate it.
+
+## Troubleshooting
+
+```bash
+docker ps -f name=voidforge-postgres   # is it running?
+docker logs voidforge-postgres          # check logs
+pg_isready -h localhost -U postgres     # can we reach it?
+docker rm -f voidforge-postgres         # nuke and recreate
+bash .claude/start-infra.sh
+```
+
+The existing `dockerfiles/docker-compose.yml` is a production config — untouched by this setup.

--- a/.claude/start-infra.sh
+++ b/.claude/start-infra.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+CONTAINER_NAME="voidforge-postgres"
+PASSWORD="${POSTGRES_PASSWORD:-voidforge_dev}"
+
+# Detect if running inside a Docker container
+IN_CONTAINER=false
+if docker inspect "$(hostname)" &>/dev/null; then
+  IN_CONTAINER=true
+fi
+
+# Build docker run flags based on environment
+if $IN_CONTAINER; then
+  NETWORK_ARG="--network container:$(hostname)"
+  echo "Detected devcontainer — sharing network stack" >&2
+else
+  NETWORK_ARG="-p 5432:5432"
+  echo "Detected host environment — using port publishing" >&2
+fi
+
+# Start postgres idempotently
+if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+  FULL_ID="$(docker inspect "$(hostname)" --format '{{.Id}}' 2>/dev/null || echo "")"
+  EXISTING_NET="$(docker inspect "$CONTAINER_NAME" --format '{{.HostConfig.NetworkMode}}' 2>/dev/null || true)"
+  EXPECTED_NET="container:$FULL_ID"
+
+  if $IN_CONTAINER && [ "$EXISTING_NET" != "$EXPECTED_NET" ]; then
+    echo "Container exists with wrong network mode, recreating..." >&2
+    docker rm -f "$CONTAINER_NAME" >/dev/null
+  elif docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    echo "Postgres is already running." >&2
+    docker exec "$CONTAINER_NAME" pg_isready -U postgres -d voidforge &>/dev/null && exit 0
+  else
+    echo "Starting existing postgres container..." >&2
+    docker start "$CONTAINER_NAME" >/dev/null
+  fi
+fi
+
+# Create container if it doesn't exist
+if ! docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+  echo "Creating postgres container..." >&2
+  docker run -d --name "$CONTAINER_NAME" \
+    $NETWORK_ARG \
+    -e POSTGRES_DB=voidforge \
+    -e POSTGRES_USER=postgres \
+    -e "POSTGRES_PASSWORD=$PASSWORD" \
+    postgres:16 >/dev/null
+fi
+
+# Wait for healthy
+echo "Waiting for postgres to be ready..." >&2
+until docker exec "$CONTAINER_NAME" pg_isready -U postgres -d voidforge &>/dev/null; do
+  sleep 1
+done
+
+# Ensure test database exists
+docker exec "$CONTAINER_NAME" psql -U postgres -d voidforge -tc \
+  "SELECT 1 FROM pg_database WHERE datname = 'voidforge_test'" | grep -q 1 || \
+  docker exec "$CONTAINER_NAME" psql -U postgres -d voidforge -c "CREATE DATABASE voidforge_test;" >/dev/null
+
+echo "Postgres is ready on localhost:5432" >&2

--- a/src/Voidforge.Api/Voidforge.Api.csproj
+++ b/src/Voidforge.Api/Voidforge.Api.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <PackageReference Include="Marten" Version="8.37.2" />
     <PackageReference Include="WolverineFx.Http.Marten" Version="5.16.4" />
     <PackageReference Include="WolverineFx.Marten" Version="5.16.4" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.13" />


### PR DESCRIPTION
Adds a devcontainer-aware infrastructure startup skill.

**`.claude/start-infra.sh`** — Bash script that starts PostgreSQL 16:
- Detects devcontainer vs host environment
- In devcontainer: shares the devcontainer's network stack (`--network container:`) so `localhost:5432` works natively
- On host: uses standard port publishing (`-p 5432:5432`)
- Idempotent — safe to run repeatedly
- Creates both `voidforge` and `voidforge_test` databases
- Waits for `pg_isready` before returning

**`.claude/skills/start-infra/SKILL.md`** — OpenCode skill that teaches the model about Voidforge infrastructure.

No application code changed.