### PR TITLE
fix(security): bump Swashbuckle to 10.2.3 to patch Microsoft.OpenApi DoS (GHSA-v5pm-xwqc-g5wc)

### DIFF
--- a/src/Voidforge.Api/Voidforge.Api.csproj
+++ b/src/Voidforge.Api/Voidforge.Api.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="Marten" Version="8.37.2" />
     <PackageReference Include="WolverineFx.Http.Marten" Version="5.16.4" />
     <PackageReference Include="WolverineFx.Marten" Version="5.16.4" />


### PR DESCRIPTION
## Summary

The security-audit quality gate flagged a **High** severity transitive vulnerability: `Microsoft.OpenApi` **2.4.1** (pulled in by `Swashbuckle.AspNetCore` 10.1.4) is affected by [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) — uncontrolled recursion (CVSS 7.5) where a small OpenAPI document with circular schema references triggers a stack overflow and process termination.

## Fix

Bump `Swashbuckle.AspNetCore` **10.1.4 → 10.2.3**. Swashbuckle 10.2.3 depends on the patched `Microsoft.OpenApi` **2.7.5** (advisory fixed in `>= 2.7.5`), so the vulnerable version is resolved away purely transitively — no explicit package pin to maintain or remove later.

```
Microsoft.OpenApi  2.4.1  →  2.7.5   (transitive, via Swashbuckle 10.2.3)
```

## Verification

- ✅ `dotnet build` — clean, 0 warnings / 0 errors
- ✅ `dotnet list package --vulnerable --include-transitive` — **no vulnerable packages** in `Voidforge.Api` or `Voidforge.Tests`
- ✅ `dotnet test` — all **51 tests pass**
- ✅ Swagger UI (`/swagger`) and OpenAPI JSON (`/swagger/v1/swagger.json`) confirmed serving correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)