### PR TITLE
refactor: inject TimeProvider (Phase 3 prerequisite)

### DIFF
--- a/src/Voidforge.Api/Endpoints/BuildingEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/BuildingEndpoints.cs
@@ -15,7 +15,8 @@ public static class BuildingEndpoints
         Guid planetId,
         PlaceBuildingRequest request,
         ClaimsPrincipal principal,
-        IDocumentSession session)
+        IDocumentSession session,
+        TimeProvider timeProvider)
     {
         var planet = await session.LoadAsync<Planet>(planetId);
         if (planet is null)
@@ -29,7 +30,7 @@ public static class BuildingEndpoints
             return TypedResults.Forbid();
         }
 
-        var now = DateTimeOffset.UtcNow;
+        var now = timeProvider.GetUtcNow();
 
         BuildingPlaced placed;
         try

--- a/src/Voidforge.Api/Endpoints/PlanetEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/PlanetEndpoints.cs
@@ -8,7 +8,10 @@ namespace Voidforge.Api.Endpoints;
 public static class PlanetEndpoints
 {
     [WolverineGet("/api/planets/{id}")]
-    public static async Task<Results<Ok<PlanetResponse>, NotFound>> GetById(Guid id, IQuerySession session)
+    public static async Task<Results<Ok<PlanetResponse>, NotFound>> GetById(
+        Guid id,
+        IQuerySession session,
+        TimeProvider timeProvider)
     {
         var planet = await session.LoadAsync<Planet>(id);
 
@@ -17,6 +20,6 @@ public static class PlanetEndpoints
             return TypedResults.NotFound();
         }
 
-        return TypedResults.Ok(PlanetResponse.From(planet, DateTimeOffset.UtcNow));
+        return TypedResults.Ok(PlanetResponse.From(planet, timeProvider.GetUtcNow()));
     }
 }

--- a/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
@@ -21,7 +21,8 @@ public static class PlayerEndpoints
     public static async Task<Results<Ok<RegisterPlayerResponse>, Conflict<string>, StatusCodeHttpResult>> Register(
         RegisterPlayerRequest request,
         IDocumentSession session,
-        IOptions<WorldGenOptions> worldGenOptions)
+        IOptions<WorldGenOptions> worldGenOptions,
+        TimeProvider timeProvider)
     {
         var nameTaken = await session.Query<Player>()
             .AnyAsync(p => p.Name == request.Name);
@@ -50,7 +51,7 @@ public static class PlayerEndpoints
         var hashedKey = ApiKeyAuthenticationHandler.HashKey(rawKey);
         var opts = worldGenOptions.Value;
 
-        var now = DateTimeOffset.UtcNow;
+        var now = timeProvider.GetUtcNow();
 
         session.Events.StartStream<Player>(playerId, new PlayerRegistered(request.Name, now));
         // Race: two concurrent registrations can colonize the same planet. Fix with optimistic

--- a/src/Voidforge.Api/Program.cs
+++ b/src/Voidforge.Api/Program.cs
@@ -50,6 +50,7 @@ builder.Services.AddAuthorizationBuilder()
         .Build());
 
 builder.Services.AddWolverineHttp();
+builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(opts =>
 {


### PR DESCRIPTION
Part of #28 (Phase 3). Registers `TimeProvider.System` and injects it into all endpoints in place of direct `DateTimeOffset.UtcNow` reads, per ADR 0001 (handlers must checkpoint at scheduled time; tests need a controllable clock).

No behavior change; existing suite green (51/51). `ApiKey.CreatedAt` initializer deliberately untouched (document timestamp, not game time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)