### PR TITLE
feat: energy grid — generation, consumption & overload productivity (#24)

### DIFF
--- a/src/Voidforge.Api/Domain/BuildingSpecs.cs
+++ b/src/Voidforge.Api/Domain/BuildingSpecs.cs
@@ -10,4 +10,22 @@ public static class BuildingSpecs
         BuildingType.Drill => 10m,
         _ => 0m,
     };
+
+    // Balance placeholders (TBD during balancing). Homeworld sanity: Generator 100 MW
+    // covers the starting Drill (20) + Refinery (30) with headroom.
+    public static decimal EnergyOutputMw(BuildingType type) => type switch
+    {
+        BuildingType.Generator => 100m,
+        _ => 0m,
+    };
+
+    // The Shipyard draws its full rating while operational; the 5%-idle rule arrives
+    // with ship builds in Phase 3 PR 5 (#27).
+    public static decimal EnergyDrawMw(BuildingType type) => type switch
+    {
+        BuildingType.Drill => 20m,
+        BuildingType.Refinery => 30m,
+        BuildingType.Shipyard => 40m,
+        _ => 0m,
+    };
 }

--- a/src/Voidforge.Api/Domain/Planet.cs
+++ b/src/Voidforge.Api/Domain/Planet.cs
@@ -67,4 +67,28 @@ public sealed class Planet
         IronOre = IronOre.Checkpoint(now);
         IronIngot = IronIngot.Checkpoint(now);
     }
+
+    // Energy is a flow resource: derived on demand from the operational building
+    // composition, never stored (game-design/resources.md). Methods rather than
+    // computed properties so they stay out of the Marten snapshot document.
+    public decimal GetEnergyGenerationMw() => Buildings
+        .Where(b => b.Status == BuildingStatus.Operational)
+        .Sum(b => BuildingSpecs.EnergyOutputMw(b.Type));
+
+    public decimal GetEnergyConsumptionMw() => Buildings
+        .Where(b => b.Status == BuildingStatus.Operational)
+        .Sum(b => BuildingSpecs.EnergyDrawMw(b.Type));
+
+    // In [0, 1]: 1 when demand is met (or there is no demand), generation/consumption
+    // when overloaded, 0 when consumers exist but no generator does.
+    public decimal GetProductivityMultiplier()
+    {
+        var consumption = GetEnergyConsumptionMw();
+        if (consumption == 0)
+        {
+            return 1m;
+        }
+
+        return Math.Min(1m, GetEnergyGenerationMw() / consumption);
+    }
 }

--- a/src/Voidforge.Api/Domain/Planet.cs
+++ b/src/Voidforge.Api/Domain/Planet.cs
@@ -47,19 +47,27 @@ public sealed class Planet
     public void Apply(BuildingPlaced @event)
     {
         Buildings.Add(new BuildingSlot(@event.BuildingType, BuildingStatus.Operational));
+        RebaseRates(@event.PlacedAt);
+    }
 
-        // A building's Iron Ore extraction rate (the Drill's, in Phase 2) is intrinsic to its
-        // type — looked up from BuildingSpecs rather than carried on the event. Checkpoint first
-        // so ore accrued under the previous rate is locked in before the rate changes; multiple
-        // drills are therefore additive.
-        var extractionRate = BuildingSpecs.IronOreRatePerSecond(@event.BuildingType);
-        if (extractionRate != 0)
-        {
-            IronOre = IronOre.Checkpoint(@event.PlacedAt) with
-            {
-                Rate = IronOre.Rate + extractionRate,
-            };
-        }
+    // Pool rates are a pure function of the operational building composition and the
+    // energy productivity multiplier m (spec: plans/phase-3-production-chain-design.md
+    // §2.2). Checkpoint first so value accrued under the old rates is locked in, then
+    // derive the new rates from scratch — incremental deltas would have to un-apply
+    // the previous multiplier. Every composition-changing Apply must end with this.
+    private void RebaseRates(DateTimeOffset at)
+    {
+        IronOre = IronOre.Checkpoint(at);
+        IronIngot = IronIngot.Checkpoint(at);
+
+        var multiplier = GetProductivityMultiplier();
+        var drillExtraction = Buildings
+            .Where(b => b.Status == BuildingStatus.Operational)
+            .Sum(b => BuildingSpecs.IronOreRatePerSecond(b.Type));
+
+        IronOre = IronOre with { Rate = drillExtraction * multiplier };
+        // Refinery conversion lands in #25 (PR 2); until then ingots accrue nothing.
+        IronIngot = IronIngot with { Rate = 0m };
     }
 
     public void CheckpointAllResources(DateTimeOffset now)

--- a/src/Voidforge.Api/Endpoints/EnergyResponse.cs
+++ b/src/Voidforge.Api/Endpoints/EnergyResponse.cs
@@ -1,0 +1,9 @@
+namespace Voidforge.Api.Endpoints;
+
+// Energy is a flow resource: computed from the operational building composition at
+// request time, not stored. Nested block on PlanetResponse, reusable by the planet
+// summary DTO planned in #30.
+public sealed record EnergyResponse(
+    decimal GenerationMw,
+    decimal ConsumptionMw,
+    decimal ProductivityMultiplier);

--- a/src/Voidforge.Api/Endpoints/PlanetResponse.cs
+++ b/src/Voidforge.Api/Endpoints/PlanetResponse.cs
@@ -11,6 +11,7 @@ public sealed record PlanetResponse(
     int BuildingSlotCount,
     ResourcePoolResponse IronOre,
     ResourcePoolResponse IronIngot,
+    EnergyResponse Energy,
     IReadOnlyList<BuildingSlotResponse> Buildings)
 {
     public static PlanetResponse From(Planet planet, DateTimeOffset now) => new(
@@ -28,5 +29,9 @@ public sealed record PlanetResponse(
             planet.IronIngot.GetCurrentValue(now),
             planet.IronIngot.Rate,
             planet.IronIngot.StorageCapacity),
+        new EnergyResponse(
+            planet.GetEnergyGenerationMw(),
+            planet.GetEnergyConsumptionMw(),
+            planet.GetProductivityMultiplier()),
         [.. planet.Buildings.Select(b => new BuildingSlotResponse(b.Type, b.Status))]);
 }

--- a/src/Voidforge.Tests/Domain/BuildingSpecsTests.cs
+++ b/src/Voidforge.Tests/Domain/BuildingSpecsTests.cs
@@ -19,4 +19,34 @@ public sealed class BuildingSpecsTests
     {
         Assert.Equal(0m, BuildingSpecs.IronOreRatePerSecond(type));
     }
+
+    [Fact]
+    public void GeneratorOutputsEnergy()
+    {
+        Assert.Equal(100m, BuildingSpecs.EnergyOutputMw(BuildingType.Generator));
+    }
+
+    [Theory]
+    [InlineData(BuildingType.Drill)]
+    [InlineData(BuildingType.Refinery)]
+    [InlineData(BuildingType.Shipyard)]
+    public void NonGeneratorBuildingsOutputNoEnergy(BuildingType type)
+    {
+        Assert.Equal(0m, BuildingSpecs.EnergyOutputMw(type));
+    }
+
+    [Theory]
+    [InlineData(BuildingType.Drill, 20)]
+    [InlineData(BuildingType.Refinery, 30)]
+    [InlineData(BuildingType.Shipyard, 40)]
+    public void EnergyConsumersDrawEnergy(BuildingType type, int expectedMw)
+    {
+        Assert.Equal(expectedMw, BuildingSpecs.EnergyDrawMw(type));
+    }
+
+    [Fact]
+    public void GeneratorDrawsNoEnergy()
+    {
+        Assert.Equal(0m, BuildingSpecs.EnergyDrawMw(BuildingType.Generator));
+    }
 }

--- a/src/Voidforge.Tests/Energy/EnergyGridTests.cs
+++ b/src/Voidforge.Tests/Energy/EnergyGridTests.cs
@@ -1,0 +1,107 @@
+using Alba;
+using Voidforge.Api.Auth;
+using Voidforge.Api.Domain;
+using Voidforge.Api.Endpoints;
+using Xunit;
+
+namespace Voidforge.Tests.Energy;
+
+[Collection(IntegrationCollection.Name)]
+public sealed class EnergyGridTests
+{
+    private readonly IAlbaHost _host;
+
+    public EnergyGridTests(AppFixture fixture)
+    {
+        _host = fixture.Host;
+    }
+
+    [Fact]
+    public async Task HomeworldEnergyBlockReflectsStartingBuildings()
+    {
+        var registration = await RegisterPlayer();
+
+        var planet = await GetPlanet(registration);
+
+        // Starting composition: Generator (100 MW) vs Drill (20) + Refinery (30).
+        Assert.Equal(100m, planet.Energy.GenerationMw);
+        Assert.Equal(50m, planet.Energy.ConsumptionMw);
+        Assert.Equal(1m, planet.Energy.ProductivityMultiplier);
+    }
+
+    [Fact]
+    public async Task OverloadThrottlesDrillRateProportionally()
+    {
+        var registration = await RegisterPlayer();
+
+        // Homeworld: 50 MW draw, 3 free slots. Add Shipyard + Shipyard + Refinery
+        // => consumption 160 vs generation 100 => m = 0.625 exactly.
+        await PlaceBuilding(registration, BuildingType.Shipyard);
+        await PlaceBuilding(registration, BuildingType.Shipyard);
+        await PlaceBuilding(registration, BuildingType.Refinery);
+
+        var planet = await GetPlanet(registration);
+
+        Assert.Equal(0.625m, planet.Energy.ProductivityMultiplier);
+        // One drill at 10/s, throttled: 10 * 0.625.
+        Assert.Equal(6.25m, planet.IronOre.Rate);
+    }
+
+    [Fact]
+    public async Task AddingGeneratorRestoresProductivity()
+    {
+        var registration = await RegisterPlayer();
+
+        // 50 + 40 + 20 = 110 MW draw vs 100 MW => overloaded.
+        await PlaceBuilding(registration, BuildingType.Shipyard);
+        await PlaceBuilding(registration, BuildingType.Drill);
+        var overloaded = await GetPlanet(registration);
+        Assert.True(overloaded.Energy.ProductivityMultiplier < 1m);
+        Assert.True(overloaded.IronOre.Rate < 20m);
+
+        // Second generator: 200 MW vs 110 MW => fully powered again.
+        await PlaceBuilding(registration, BuildingType.Generator);
+        var recovered = await GetPlanet(registration);
+        Assert.Equal(1m, recovered.Energy.ProductivityMultiplier);
+        Assert.Equal(20m, recovered.IronOre.Rate);
+    }
+
+    private async Task PlaceBuilding(RegisterPlayerResponse registration, BuildingType type)
+    {
+        await _host.Scenario(s =>
+        {
+            s.Post.Json(new PlaceBuildingRequest(type))
+                .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(200);
+        });
+    }
+
+    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
+    {
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/planets/{registration.HomeworldId}");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
+        Assert.NotNull(planet);
+        return planet;
+    }
+
+    private async Task<RegisterPlayerResponse> RegisterPlayer()
+    {
+        var result = await _host.Scenario(s =>
+        {
+            s.Post.Json(new RegisterPlayerRequest($"Energy_Test_{Guid.NewGuid():N}"))
+                .ToUrl("/api/players/register");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
+        Assert.NotNull(response);
+        return response;
+    }
+}

--- a/src/Voidforge.Tests/Planets/PlanetAggregateTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetAggregateTests.cs
@@ -96,12 +96,14 @@ public sealed class PlanetAggregateTests
         planet.Apply(new PlanetCreated("P", Guid.NewGuid(), 50000, 6, 10000, 5000));
         planet.Apply(new PlanetColonized(Guid.NewGuid(), 500, 100, placedAt));
 
+        // A powered drill extracts at full rate (Generator 100 MW >= Drill 20 MW).
+        planet.Apply(new BuildingPlaced(BuildingType.Generator, placedAt));
         planet.Apply(new BuildingPlaced(BuildingType.Drill, placedAt));
 
         Assert.Equal(BuildingSpecs.IronOreRatePerSecond(BuildingType.Drill), planet.IronOre.Rate);
-        Assert.Single(planet.Buildings);
-        Assert.Equal(BuildingType.Drill, planet.Buildings[0].Type);
-        Assert.Equal(BuildingStatus.Operational, planet.Buildings[0].Status);
+        Assert.Equal(2, planet.Buildings.Count);
+        Assert.Equal(BuildingType.Drill, planet.Buildings[1].Type);
+        Assert.Equal(BuildingStatus.Operational, planet.Buildings[1].Status);
     }
 
     [Fact]
@@ -112,11 +114,12 @@ public sealed class PlanetAggregateTests
         planet.Apply(new PlanetCreated("P", Guid.NewGuid(), 50000, 6, 10000, 5000));
         planet.Apply(new PlanetColonized(Guid.NewGuid(), 500, 100, placedAt));
 
+        planet.Apply(new BuildingPlaced(BuildingType.Generator, placedAt));
         planet.Apply(new BuildingPlaced(BuildingType.Drill, placedAt));
         planet.Apply(new BuildingPlaced(BuildingType.Drill, placedAt));
 
         Assert.Equal(BuildingSpecs.IronOreRatePerSecond(BuildingType.Drill) * 2, planet.IronOre.Rate);
-        Assert.Equal(2, planet.Buildings.Count);
+        Assert.Equal(3, planet.Buildings.Count);
     }
 
     [Fact]
@@ -129,7 +132,8 @@ public sealed class PlanetAggregateTests
 
         var rate = BuildingSpecs.IronOreRatePerSecond(BuildingType.Drill);
 
-        // First drill runs for 10s, accumulating rate*10 ore. A second drill is then placed.
+        // First powered drill runs for 10s, accumulating rate*10 ore. Then a second drill lands.
+        planet.Apply(new BuildingPlaced(BuildingType.Generator, colonizedAt));
         planet.Apply(new BuildingPlaced(BuildingType.Drill, colonizedAt));
         var secondPlacedAt = colonizedAt.AddSeconds(10);
         planet.Apply(new BuildingPlaced(BuildingType.Drill, secondPlacedAt));
@@ -138,6 +142,39 @@ public sealed class PlanetAggregateTests
         Assert.Equal(500m + (rate * 10m), planet.IronOre.CheckpointValue);
         Assert.Equal(secondPlacedAt, planet.IronOre.CheckpointTime);
         Assert.Equal(rate * 2, planet.IronOre.Rate);
+    }
+
+    [Fact]
+    public void ApplyBuildingPlacedDrillWithoutGeneratorExtractsNothing()
+    {
+        var placedAt = DateTimeOffset.UtcNow;
+        var planet = new Planet();
+        planet.Apply(new PlanetCreated("P", Guid.NewGuid(), 50000, 6, 10000, 5000));
+        planet.Apply(new PlanetColonized(Guid.NewGuid(), 500, 100, placedAt));
+
+        planet.Apply(new BuildingPlaced(BuildingType.Drill, placedAt));
+
+        Assert.Equal(0m, planet.IronOre.Rate);
+    }
+
+    [Fact]
+    public void ApplyBuildingPlacedOverloadRescalesExistingDrillRates()
+    {
+        var placedAt = DateTimeOffset.UtcNow;
+        var planet = new Planet();
+        planet.Apply(new PlanetCreated("P", Guid.NewGuid(), 50000, 6, 10000, 5000));
+        planet.Apply(new PlanetColonized(Guid.NewGuid(), 500, 100, placedAt));
+
+        // Generator (100) + 4 Drills (80) + Refinery (30) => consumption 110, m = 100/110.
+        planet.Apply(new BuildingPlaced(BuildingType.Generator, placedAt));
+        planet.Apply(new BuildingPlaced(BuildingType.Drill, placedAt));
+        planet.Apply(new BuildingPlaced(BuildingType.Drill, placedAt));
+        planet.Apply(new BuildingPlaced(BuildingType.Drill, placedAt));
+        planet.Apply(new BuildingPlaced(BuildingType.Drill, placedAt));
+        planet.Apply(new BuildingPlaced(BuildingType.Refinery, placedAt));
+
+        var expectedRate = BuildingSpecs.IronOreRatePerSecond(BuildingType.Drill) * 4 * (100m / 110m);
+        Assert.Equal(expectedRate, planet.IronOre.Rate);
     }
 
     [Fact]

--- a/src/Voidforge.Tests/Planets/PlanetEnergyTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetEnergyTests.cs
@@ -1,0 +1,79 @@
+using Voidforge.Api.Domain;
+using Voidforge.Api.Domain.Events;
+using Xunit;
+
+namespace Voidforge.Tests.Planets;
+
+public sealed class PlanetEnergyTests
+{
+    private static Planet CreateColonizedPlanet()
+    {
+        var planet = new Planet();
+        planet.Apply(new PlanetCreated("P", Guid.NewGuid(), 50000, 6, 10000, 5000));
+        planet.Apply(new PlanetColonized(Guid.NewGuid(), 500, 100, DateTimeOffset.UtcNow));
+        return planet;
+    }
+
+    private static void Place(Planet planet, params BuildingType[] types)
+    {
+        var at = DateTimeOffset.UtcNow;
+        foreach (var type in types)
+        {
+            planet.Apply(new BuildingPlaced(type, at));
+        }
+    }
+
+    [Fact]
+    public void EmptyPlanetHasNoEnergyAndFullProductivity()
+    {
+        var planet = CreateColonizedPlanet();
+
+        Assert.Equal(0m, planet.GetEnergyGenerationMw());
+        Assert.Equal(0m, planet.GetEnergyConsumptionMw());
+        Assert.Equal(1m, planet.GetProductivityMultiplier());
+    }
+
+    [Fact]
+    public void GeneratorOnlyGivesGenerationWithoutConsumption()
+    {
+        var planet = CreateColonizedPlanet();
+        Place(planet, BuildingType.Generator);
+
+        Assert.Equal(100m, planet.GetEnergyGenerationMw());
+        Assert.Equal(0m, planet.GetEnergyConsumptionMw());
+        Assert.Equal(1m, planet.GetProductivityMultiplier());
+    }
+
+    [Fact]
+    public void ExactlyBalancedLoadKeepsFullProductivity()
+    {
+        // Generator 100 MW vs 5 Drills x 20 MW = 100 MW.
+        var planet = CreateColonizedPlanet();
+        Place(planet, BuildingType.Generator, BuildingType.Drill, BuildingType.Drill,
+            BuildingType.Drill, BuildingType.Drill, BuildingType.Drill);
+
+        Assert.Equal(100m, planet.GetEnergyConsumptionMw());
+        Assert.Equal(1m, planet.GetProductivityMultiplier());
+    }
+
+    [Fact]
+    public void OverloadScalesProductivityProportionally()
+    {
+        // Generator 100 MW vs 4 Drills (80) + Refinery (30) = 110 MW.
+        var planet = CreateColonizedPlanet();
+        Place(planet, BuildingType.Generator, BuildingType.Drill, BuildingType.Drill,
+            BuildingType.Drill, BuildingType.Drill, BuildingType.Refinery);
+
+        Assert.Equal(110m, planet.GetEnergyConsumptionMw());
+        Assert.Equal(100m / 110m, planet.GetProductivityMultiplier());
+    }
+
+    [Fact]
+    public void ConsumersWithoutGeneratorGetZeroProductivity()
+    {
+        var planet = CreateColonizedPlanet();
+        Place(planet, BuildingType.Drill);
+
+        Assert.Equal(0m, planet.GetProductivityMultiplier());
+    }
+}

--- a/technical-design/domain-model.md
+++ b/technical-design/domain-model.md
@@ -29,12 +29,15 @@ Created during registration via `session.Events.StartStream<Player>(...)`.
 
 Created during world seeding via `session.Events.StartStream<Planet>(...)`. `OwnerId` starts null (uncolonized).
 
-`Apply(BuildingPlaced)` appends a `BuildingSlot` and, for any building with an extraction rate (the `Drill` in Phase 2), checkpoints `IronOre` at `PlacedAt` before adding the rate — so accumulated ore is locked in at the old rate and multiple drills are additive. The rate is looked up from `BuildingSpecs`, not carried on the event, so replay stays deterministic and balance values live in one place.
+`Apply(BuildingPlaced)` appends a `BuildingSlot` and calls `RebaseRates(at)`: both pools are checkpointed at the event instant (locking in value accrued under the old rates), then rates are re-derived from scratch as a pure function of the operational building composition × the energy productivity multiplier. Wholesale re-derivation (not incremental deltas) is required because the multiplier rescales every operational consumer whenever any building changes. Every composition-changing `Apply` must end with `RebaseRates`.
+
+**Energy** is a flow resource — derived on demand, never stored: `GetEnergyGenerationMw()` (Σ operational Generator output), `GetEnergyConsumptionMw()` (Σ operational consumer draw), `GetProductivityMultiplier()` (`1` when demand is met, `generation/consumption` when overloaded, `0` with consumers but no generator; range `[0, 1]`). These are methods, not computed properties, to stay out of the Marten snapshot document. Surfaced via the `EnergyResponse` block on `PlanetResponse`.
 
 ### Buildings (Value Objects)
 
 - **Files**: `Domain/BuildingType.cs` (`Drill`, `Refinery`, `Shipyard`, `Generator`), `Domain/BuildingStatus.cs` (`Operational` — grows to `UnderConstruction` in Phase 3, `Halted` in Phase 5), `Domain/BuildingSlot.cs` (`record BuildingSlot(BuildingType Type, BuildingStatus Status)`)
 - **`BuildingSpecs`** (`Domain/BuildingSpecs.cs`): intrinsic, balance-tunable stats per building type — `IronOreRatePerSecond(type)` (Drill = 10 units/sec; others 0). These are domain rules, not world-gen knobs. Units are **per second** to match `ResourcePool` (which accrues over elapsed `TotalSeconds`).
+  Energy specs (Phase 3, #24): `EnergyOutputMw(type)` (Generator = 100 MW) and `EnergyDrawMw(type)` (Drill 20 / Refinery 30 / Shipyard 40 MW; Shipyard's 5%-idle rule arrives with #27). Balance placeholders, TBD during balancing.
 - **Phase 2 semantics**: Placement is instant and free; no construction time, cost, or energy yet. Only the `Drill` has behavior (sets the planet's Iron Ore extraction rate). `Refinery` and `Generator` are placed but inert. Available slots = `BuildingSlotCount - Buildings.Count`.
 - **Placement**: `POST /api/planets/{planetId}/buildings` (`BuildingEndpoints.cs`). The endpoint owns the application concerns — existence (404) and ownership/authorization (403) — then delegates to `Planet.PlaceBuilding`, mapping `NoFreeSlotsException` to 409. The slot invariant itself lives in the domain.
 
@@ -47,7 +50,7 @@ Homeworld starts with 1 Drill, 1 Refinery, 1 Generator, appended alongside `Plan
 - **Methods**: `GetCurrentValue(now)` — computes `Clamp(checkpoint + rate * elapsed, 0, capacity)`; `Checkpoint(now)` — returns new instance with current value as baseline
 - **Semantics**: Immutable record. Methods return new instances. Rate starts at 0; buildings (#10) will set rates via checkpointing.
 
-Used by `Planet.IronOre` and `Planet.IronIngot`. The query endpoint computes current values at request time using `GetCurrentValue(DateTimeOffset.UtcNow)` — no background ticks needed.
+Used by `Planet.IronOre` and `Planet.IronIngot`. The query endpoint computes current values at request time using `GetCurrentValue(timeProvider.GetUtcNow())` — no background ticks needed.
 
 ## Documents
 


### PR DESCRIPTION
Part of #28 / closes #24 when phase-3 merges to main.

- `BuildingSpecs.EnergyOutputMw`/`EnergyDrawMw` (placeholder balance values: Generator 100 MW out; Drill 20 / Refinery 30 / Shipyard 40 MW draw)
- `Planet` energy balance methods + productivity multiplier `m ∈ [0, 1]` (methods, not properties — kept out of the Marten snapshot)
- `RebaseRates(at)`: pool rates re-derived wholesale from composition × `m` at every change instant (replaces Phase 2 incremental wiring)
- `EnergyResponse` block on `PlanetResponse`
- **Behavior change:** a Drill without a Generator now extracts nothing (`m = 0`)
- Depends on the TimeProvider refactor (PR #32, already merged to phase-3)

Design: `plans/phase-3-production-chain-design.md` §2.1–§2.2. Suite 69/69 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)