### PR TITLE
feat: pagination contract + paginate GET /api/solar-systems (#29 subset)

### DIFF
--- a/src/Voidforge.Api/Endpoints/SolarSystemEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/SolarSystemEndpoints.cs
@@ -1,22 +1,41 @@
 using Marten;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Voidforge.Api.Documents;
+using Voidforge.Api.Pagination;
 using Wolverine.Http;
 
 namespace Voidforge.Api.Endpoints;
 
 public static class SolarSystemEndpoints
 {
+    // Paginated per the #29 contract. Deterministic order by Name so paging is stable.
+    // Nullable int params distinguish "omitted" (null → default) from "explicitly zero"
+    // (0 → rejected as invalid) so Wolverine's missing-param-as-null binding works correctly.
     [WolverineGet("/api/solar-systems")]
-    public static async Task<IReadOnlyList<SolarSystemResponse>> GetAll(IQuerySession session)
+    public static async Task<Results<Ok<PagedResponse<SolarSystemResponse>>, BadRequest<string>>> GetAll(
+        IQuerySession session,
+        int? page = null,
+        int? pageSize = null)
     {
-        var systems = await session.Query<SolarSystem>().ToListAsync();
+        var parameters = PaginationParameters.Create(
+            page ?? PaginationParameters.DefaultPage,
+            pageSize ?? PaginationParameters.DefaultPageSize);
 
-        return systems.Select(s => new SolarSystemResponse(
-            s.Id,
-            s.Name,
-            s.X,
-            s.Y,
-            s.Z,
-            s.PlanetIds.ToList().AsReadOnly())).ToList();
+        if (parameters is null)
+        {
+            return TypedResults.BadRequest("page and pageSize must be >= 1.");
+        }
+
+        var response = await session.Query<SolarSystem>()
+            .OrderBy(s => s.Name)
+            .ToPagedResponseAsync(parameters, s => new SolarSystemResponse(
+                s.Id,
+                s.Name,
+                s.X,
+                s.Y,
+                s.Z,
+                s.PlanetIds.ToList().AsReadOnly()));
+
+        return TypedResults.Ok(response);
     }
 }

--- a/src/Voidforge.Api/Pagination/PagedResponse.cs
+++ b/src/Voidforge.Api/Pagination/PagedResponse.cs
@@ -1,0 +1,15 @@
+namespace Voidforge.Api.Pagination;
+
+// Generic pagination envelope. TotalPages/HasPrevious/HasNext are computed from the
+// primitive fields so every producer path yields identical metadata. Designed so a
+// future keyset swap stays non-breaking: clients that follow HasNext keep working.
+public sealed record PagedResponse<T>(
+    IReadOnlyList<T> Items,
+    int Page,
+    int PageSize,
+    long TotalItems)
+{
+    public int TotalPages => PageSize <= 0 ? 0 : (int)Math.Ceiling(TotalItems / (double)PageSize);
+    public bool HasPrevious => Page > 1;
+    public bool HasNext => Page < TotalPages;
+}

--- a/src/Voidforge.Api/Pagination/PaginationExtensions.cs
+++ b/src/Voidforge.Api/Pagination/PaginationExtensions.cs
@@ -1,0 +1,36 @@
+using Marten.Pagination;
+
+namespace Voidforge.Api.Pagination;
+
+public static class PaginationExtensions
+{
+    // Document queries: wraps Marten's ToPagedListAsync (items + total count in one
+    // round-trip). The query MUST already carry a deterministic OrderBy. The selector
+    // projects each materialized document to its response DTO.
+    public static async Task<PagedResponse<TResult>> ToPagedResponseAsync<TSource, TResult>(
+        this IQueryable<TSource> query,
+        PaginationParameters parameters,
+        Func<TSource, TResult> selector,
+        CancellationToken token = default)
+    {
+        var paged = await query.ToPagedListAsync(parameters.Page, parameters.PageSize, token);
+        var items = paged.Select(selector).ToList();
+        return new PagedResponse<TResult>(items, parameters.Page, parameters.PageSize, paged.TotalItemCount);
+    }
+
+    // Aggregate child collections (e.g. the ship roster/queue in #27) that are already
+    // materialized in memory. Same envelope; the migration candidate for keyset if a
+    // collection grows large (see api-conventions.md).
+    public static PagedResponse<TResult> ToPagedResponse<TSource, TResult>(
+        this IReadOnlyList<TSource> source,
+        PaginationParameters parameters,
+        Func<TSource, TResult> selector)
+    {
+        var items = source
+            .Skip((parameters.Page - 1) * parameters.PageSize)
+            .Take(parameters.PageSize)
+            .Select(selector)
+            .ToList();
+        return new PagedResponse<TResult>(items, parameters.Page, parameters.PageSize, source.Count);
+    }
+}

--- a/src/Voidforge.Api/Pagination/PaginationParameters.cs
+++ b/src/Voidforge.Api/Pagination/PaginationParameters.cs
@@ -1,0 +1,31 @@
+namespace Voidforge.Api.Pagination;
+
+// Validated pagination query parameters. Created via the factory so the contract
+// (defaults, clamp, rejection) lives in one place and is unit-testable without HTTP.
+public sealed record PaginationParameters
+{
+    public const int DefaultPage = 1;
+    public const int DefaultPageSize = 50;
+    public const int MaxPageSize = 200;
+
+    public int Page { get; }
+    public int PageSize { get; }
+
+    private PaginationParameters(int page, int pageSize)
+    {
+        Page = page;
+        PageSize = pageSize;
+    }
+
+    // Returns null when page < 1 or pageSize < 1 (the caller maps null to 400).
+    // pageSize above MaxPageSize is clamped rather than rejected.
+    public static PaginationParameters? Create(int page = DefaultPage, int pageSize = DefaultPageSize)
+    {
+        if (page < 1 || pageSize < 1)
+        {
+            return null;
+        }
+
+        return new PaginationParameters(page, Math.Min(pageSize, MaxPageSize));
+    }
+}

--- a/src/Voidforge.Tests/Buildings/BuildingEndpointTests.cs
+++ b/src/Voidforge.Tests/Buildings/BuildingEndpointTests.cs
@@ -2,6 +2,7 @@ using Alba;
 using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
+using Voidforge.Api.Pagination;
 using Xunit;
 
 namespace Voidforge.Tests.Buildings;
@@ -173,9 +174,9 @@ public sealed class BuildingEndpointTests
             s.StatusCodeShouldBe(200);
         });
 
-        var systems = await result.ReadAsJsonAsync<List<SolarSystemResponse>>();
+        var systems = await result.ReadAsJsonAsync<PagedResponse<SolarSystemResponse>>();
         Assert.NotNull(systems);
-        var other = systems.SelectMany(sys => sys.PlanetIds).First(id => id != registration.HomeworldId);
+        var other = systems.Items.SelectMany(sys => sys.PlanetIds).First(id => id != registration.HomeworldId);
         return other;
     }
 

--- a/src/Voidforge.Tests/Pagination/PaginationContractTests.cs
+++ b/src/Voidforge.Tests/Pagination/PaginationContractTests.cs
@@ -1,0 +1,78 @@
+using Voidforge.Api.Pagination;
+using Xunit;
+
+namespace Voidforge.Tests.Pagination;
+
+public sealed class PaginationContractTests
+{
+    [Fact]
+    public void CreateAppliesDefaults()
+    {
+        var p = PaginationParameters.Create();
+        Assert.NotNull(p);
+        Assert.Equal(1, p.Page);
+        Assert.Equal(50, p.PageSize);
+    }
+
+    [Fact]
+    public void CreateClampsPageSizeToMaximum()
+    {
+        var p = PaginationParameters.Create(1, 500);
+        Assert.NotNull(p);
+        Assert.Equal(200, p.PageSize);
+    }
+
+    [Fact]
+    public void CreateAcceptsMaximumPageSize()
+    {
+        var p = PaginationParameters.Create(1, 200);
+        Assert.NotNull(p);
+        Assert.Equal(200, p.PageSize);
+    }
+
+    [Theory]
+    [InlineData(0, 50)]
+    [InlineData(-1, 50)]
+    [InlineData(1, 0)]
+    [InlineData(1, -5)]
+    public void CreateRejectsOutOfRangeParameters(int page, int pageSize)
+    {
+        Assert.Null(PaginationParameters.Create(page, pageSize));
+    }
+
+    [Fact]
+    public void EnvelopeComputesMetadata()
+    {
+        var response = new PagedResponse<int>([1, 2, 3], Page: 1, PageSize: 50, TotalItems: 1234);
+        Assert.Equal(25, response.TotalPages);   // ceil(1234 / 50)
+        Assert.False(response.HasPrevious);
+        Assert.True(response.HasNext);
+    }
+
+    [Fact]
+    public void EnvelopeMiddlePageHasBothNeighbours()
+    {
+        var response = new PagedResponse<int>([1], Page: 3, PageSize: 10, TotalItems: 55);
+        Assert.Equal(6, response.TotalPages);     // ceil(55 / 10)
+        Assert.True(response.HasPrevious);
+        Assert.True(response.HasNext);
+    }
+
+    [Fact]
+    public void EnvelopeEmptyResultHasNoPages()
+    {
+        var response = new PagedResponse<int>([], Page: 1, PageSize: 50, TotalItems: 0);
+        Assert.Equal(0, response.TotalPages);
+        Assert.False(response.HasPrevious);
+        Assert.False(response.HasNext);
+    }
+
+    [Fact]
+    public void EnvelopeLastPageHasPreviousButNoNext()
+    {
+        var response = new PagedResponse<int>([1, 2], Page: 3, PageSize: 5, TotalItems: 12);
+        Assert.Equal(3, response.TotalPages);     // ceil(12 / 5)
+        Assert.True(response.HasPrevious);
+        Assert.False(response.HasNext);
+    }
+}

--- a/src/Voidforge.Tests/Pagination/PaginationContractTests.cs
+++ b/src/Voidforge.Tests/Pagination/PaginationContractTests.cs
@@ -75,4 +75,33 @@ public sealed class PaginationContractTests
         Assert.True(response.HasPrevious);
         Assert.False(response.HasNext);
     }
+
+    [Fact]
+    public void ToPagedResponseSlicesInMemoryList()
+    {
+        IReadOnlyList<int> source = Enumerable.Range(1, 12).ToList();
+        var parameters = PaginationParameters.Create(2, 5)!;
+
+        var response = source.ToPagedResponse(parameters, x => x * 10);
+
+        Assert.Equal([60, 70, 80, 90, 100], response.Items);  // page 2 of size 5 => items 6..10, x10
+        Assert.Equal(2, response.Page);
+        Assert.Equal(5, response.PageSize);
+        Assert.Equal(12, response.TotalItems);
+        Assert.Equal(3, response.TotalPages);
+        Assert.True(response.HasPrevious);
+        Assert.True(response.HasNext);
+    }
+
+    [Fact]
+    public void ToPagedResponseBeyondLastPageReturnsEmptyItemsWithFullTotal()
+    {
+        IReadOnlyList<int> source = Enumerable.Range(1, 3).ToList();
+        var parameters = PaginationParameters.Create(5, 10)!;
+
+        var response = source.ToPagedResponse(parameters, x => x);
+
+        Assert.Empty(response.Items);
+        Assert.Equal(3, response.TotalItems);
+    }
 }

--- a/src/Voidforge.Tests/Pagination/SolarSystemPaginationTests.cs
+++ b/src/Voidforge.Tests/Pagination/SolarSystemPaginationTests.cs
@@ -1,0 +1,103 @@
+using Alba;
+using Voidforge.Api.Auth;
+using Voidforge.Api.Endpoints;
+using Voidforge.Api.Pagination;
+using Xunit;
+
+namespace Voidforge.Tests.Pagination;
+
+[Collection(IntegrationCollection.Name)]
+public sealed class SolarSystemPaginationTests
+{
+    private readonly IAlbaHost _host;
+
+    public SolarSystemPaginationTests(AppFixture fixture)
+    {
+        _host = fixture.Host;
+    }
+
+    [Fact]
+    public async Task ReturnsPagedEnvelopeOrderedByName()
+    {
+        var apiKey = await RegisterAndGetKey();
+
+        var page = await GetPage(apiKey, "?page=1&pageSize=5");
+
+        Assert.Equal(5, page.Items.Count);
+        Assert.Equal(1, page.Page);
+        Assert.Equal(5, page.PageSize);
+        Assert.True(page.TotalItems >= 40);            // fixture seeds 40 systems
+        Assert.False(page.HasPrevious);
+        Assert.True(page.HasNext);
+        // Deterministic order: names non-decreasing.
+        var names = page.Items.Select(i => i.Name).ToList();
+        Assert.Equal(names.OrderBy(n => n, StringComparer.Ordinal), names);
+    }
+
+    [Fact]
+    public async Task SecondPageHasPreviousAndDiffersFromFirst()
+    {
+        var apiKey = await RegisterAndGetKey();
+
+        var first = await GetPage(apiKey, "?page=1&pageSize=5");
+        var second = await GetPage(apiKey, "?page=2&pageSize=5");
+
+        Assert.True(second.HasPrevious);
+        Assert.Equal(2, second.Page);
+        Assert.NotEqual(first.Items[0].Id, second.Items[0].Id);
+    }
+
+    [Fact]
+    public async Task ClampsPageSizeToMaximum()
+    {
+        var apiKey = await RegisterAndGetKey();
+
+        var page = await GetPage(apiKey, "?pageSize=500");
+
+        Assert.Equal(200, page.PageSize);
+    }
+
+    [Theory]
+    [InlineData("?page=0")]
+    [InlineData("?pageSize=0")]
+    [InlineData("?page=-1")]
+    public async Task RejectsInvalidParameters(string query)
+    {
+        var apiKey = await RegisterAndGetKey();
+
+        await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/solar-systems{query}");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, apiKey);
+            s.StatusCodeShouldBe(400);
+        });
+    }
+
+    private async Task<PagedResponse<SolarSystemResponse>> GetPage(string apiKey, string query)
+    {
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/solar-systems{query}");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, apiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var page = await result.ReadAsJsonAsync<PagedResponse<SolarSystemResponse>>();
+        Assert.NotNull(page);
+        return page;
+    }
+
+    private async Task<string> RegisterAndGetKey()
+    {
+        var result = await _host.Scenario(s =>
+        {
+            s.Post.Json(new RegisterPlayerRequest($"Pg_Test_{Guid.NewGuid():N}"))
+                .ToUrl("/api/players/register");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
+        Assert.NotNull(response);
+        return response.ApiKey;
+    }
+}

--- a/src/Voidforge.Tests/Planets/PlanetEndpointTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetEndpointTests.cs
@@ -2,6 +2,7 @@ using Alba;
 using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
+using Voidforge.Api.Pagination;
 using Xunit;
 
 namespace Voidforge.Tests.Planets;
@@ -28,9 +29,9 @@ public sealed class PlanetEndpointTests
             s.StatusCodeShouldBe(200);
         });
 
-        var systems = await result.ReadAsJsonAsync<List<SolarSystemResponse>>();
+        var systems = await result.ReadAsJsonAsync<PagedResponse<SolarSystemResponse>>();
         Assert.NotNull(systems);
-        Assert.NotEmpty(systems);
+        Assert.NotEmpty(systems.Items);
     }
 
     [Fact]

--- a/technical-design/api-conventions.md
+++ b/technical-design/api-conventions.md
@@ -1,0 +1,39 @@
+# API Conventions
+
+## Pagination
+
+Every collection-returning endpoint uses one pagination contract (introduced in #29).
+
+### Request
+- `page` — int, default `1`, minimum `1`.
+- `pageSize` — int, default `50`, minimum `1`, maximum `200`.
+
+Policy: `page < 1` or `pageSize < 1` → `400 Bad Request`; `pageSize > 200` is **clamped** to `200` (not rejected).
+
+### Response envelope — `PagedResponse<T>`
+```json
+{
+  "items": [ /* T[] */ ],
+  "page": 1,
+  "pageSize": 50,
+  "totalItems": 1234,
+  "totalPages": 25,
+  "hasPrevious": false,
+  "hasNext": true
+}
+```
+`totalPages`, `hasPrevious`, `hasNext` are computed from `totalItems`/`page`/`pageSize`.
+
+### Deterministic order (correctness requirement)
+Pagination is only correct over a deterministic sort. Every paginated endpoint MUST apply an explicit default order before paging (never rely on storage order) and document it. Current defaults:
+- `GET /api/solar-systems` — by `Name`.
+
+### Producers (`Voidforge.Api/Pagination/PaginationExtensions.cs`)
+- `IQueryable<T>.ToPagedResponseAsync(parameters, selector)` — document queries; wraps Marten `ToPagedListAsync` (items + count in one round-trip).
+- `IReadOnlyList<T>.ToPagedResponse(parameters, selector)` — already-materialized aggregate child collections (e.g. the ship roster/queue in #27).
+
+### Definition of done
+Any new collection endpoint MUST adopt this contract. Bounded inline collections (a planet's fixed building slots, the energy block) stay embedded on their parent resource; unbounded ones (ship roster, shipyard queue) get dedicated paginated endpoints.
+
+### Migration path to keyset (not built yet)
+For large/append-heavy collections, an endpoint may later switch to keyset/cursor paging. The envelope is designed so that swap is non-breaking: clients that follow `hasNext` (rather than computing pages from `totalItems`) keep working. Build keyset per-endpoint only when its access pattern demands it.

--- a/technical-design/architecture.md
+++ b/technical-design/architecture.md
@@ -100,6 +100,8 @@ app.MapWolverineEndpoints(opts => opts.RequireAuthorizeOnAll());
 
 **Post-MVP:** Add JWT (OAuth2/OIDC) for the official web client with support for external identity providers (Discord, Google). API keys remain available for third-party clients and bots. Both auth schemes coexist via ASP.NET Core's multi-scheme authentication.
 
+> Collection endpoints follow the shared pagination contract — see [`api-conventions.md`](api-conventions.md).
+
 ### Real-time Push: Polling Only (MVP)
 
 For MVP, clients poll the API for state updates. The lazy calculation model makes this natural — every query returns the current computed state regardless of when it's called.


### PR DESCRIPTION
Part of #28 (Phase 3). Implements the subset of #29 that Phase 3 needs (PR 5's ship roster/queue endpoints depend on this contract).

- `Pagination/PaginationParameters` (page≥1 default 1; pageSize≥1 default 50, clamped at 200; invalid → 400)
- `Pagination/PagedResponse<T>` envelope (`items, page, pageSize, totalItems` + computed `totalPages/hasPrevious/hasNext`)
- Two producers: `IQueryable<T>.ToPagedResponseAsync` (Marten) and `IReadOnlyList<T>.ToPagedResponse` (in-memory, for #27 roster/queue)
- Retrofit `GET /api/solar-systems` (ordered by `Name`)
- Convention documented in `technical-design/api-conventions.md`

**⚠️ Breaking change:** `GET /api/solar-systems` now returns the `PagedResponse` envelope instead of a bare JSON array. **The generated frontend client must be regenerated.** (Two backend test consumers already reconciled.)

**Note:** Wolverine HTTP binds omitted `int` query params as `0`, so the endpoint uses `int? page/pageSize` (null → default, explicit 0 → 400) — the reusable pattern for #27's endpoints.

Remaining #29/#30 (new list endpoints, summary DTOs, leaderboard, keyset) stay out of Phase 3. Suite 97/97 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)