### PR TITLE
fix(domain): make ResourcePool accrual and checkpointing non-regressing (#44)

### DIFF
--- a/src/Voidforge.Api/Domain/ResourcePool.cs
+++ b/src/Voidforge.Api/Domain/ResourcePool.cs
@@ -6,14 +6,27 @@ public sealed record ResourcePool(
     decimal StorageCapacity,
     DateTimeOffset CheckpointTime)
 {
+    // Event `at` timestamps are not guaranteed to be non-decreasing along a Planet stream (#44):
+    // a completion scheduled for T can be delivered after a player command already committed at
+    // W > T (durable-message poll lag per ADR 0001, plus the #39 ConcurrencyException retry
+    // backoff). Flooring elapsed at 0 makes such a rewound read inert — without it a negative
+    // elapsed silently drains an accruing pool, and (rate < 0) * (elapsed < 0) fabricates
+    // resources outright. Math.Clamp bounds the stored value but does not make it correct.
     public decimal GetCurrentValue(DateTimeOffset now)
     {
-        var elapsed = (decimal)(now - CheckpointTime).TotalSeconds;
+        var elapsed = Math.Max(0m, (decimal)(now - CheckpointTime).TotalSeconds);
         return Math.Clamp(CheckpointValue + Rate * elapsed, 0, StorageCapacity);
     }
 
+    // Non-regressing for the same reason: letting CheckpointTime move backwards would re-accrue
+    // the rewound interval on every subsequent read, compounding the error rather than absorbing
+    // it once. A backwards checkpoint is therefore a no-op, not a rewind.
     public ResourcePool Checkpoint(DateTimeOffset now)
     {
-        return this with { CheckpointValue = GetCurrentValue(now), CheckpointTime = now };
+        return this with
+        {
+            CheckpointValue = GetCurrentValue(now),
+            CheckpointTime = now > CheckpointTime ? now : CheckpointTime,
+        };
     }
 }

--- a/src/Voidforge.Tests/Domain/ResourcePoolTests.cs
+++ b/src/Voidforge.Tests/Domain/ResourcePoolTests.cs
@@ -65,6 +65,54 @@ public sealed class ResourcePoolTests
         Assert.Equal(500m, pool.GetCurrentValue(checkpoint.AddSeconds(100)));
     }
 
+    // #44: event `at` timestamps are not guaranteed monotonic along a Planet stream (a late
+    // completion can commit after a newer command). A backwards `now` must be inert, never
+    // negative-accrual and never a regressed checkpoint.
+    [Fact]
+    public void BackwardsTimeDoesNotDrainAnAccruingPool()
+    {
+        var checkpoint = DateTimeOffset.UtcNow;
+        var pool = new ResourcePool(100, 10, 1000, checkpoint);
+
+        // Unfloored elapsed would give 100 + 10 * (-5) = 50.
+        Assert.Equal(100m, pool.GetCurrentValue(checkpoint.AddSeconds(-5)));
+    }
+
+    [Fact]
+    public void BackwardsTimeDoesNotFabricateResourcesInADrainingPool()
+    {
+        var checkpoint = DateTimeOffset.UtcNow;
+        var pool = new ResourcePool(100, -10, 1000, checkpoint);
+
+        // Negative rate * negative elapsed invents resources: 100 + (-10) * (-5) = 150.
+        Assert.Equal(100m, pool.GetCurrentValue(checkpoint.AddSeconds(-5)));
+    }
+
+    [Fact]
+    public void CheckpointDoesNotRegressTime()
+    {
+        var checkpoint = DateTimeOffset.UtcNow;
+        var pool = new ResourcePool(100, 10, 1000, checkpoint);
+
+        var checkpointed = pool.Checkpoint(checkpoint.AddSeconds(-5));
+
+        // A regressed CheckpointTime re-accrues the rewound interval on every later read.
+        Assert.Equal(checkpoint, checkpointed.CheckpointTime);
+        Assert.Equal(100m, checkpointed.CheckpointValue);
+    }
+
+    [Fact]
+    public void CheckpointAtSameInstantIsIdempotent()
+    {
+        var checkpoint = DateTimeOffset.UtcNow;
+        var pool = new ResourcePool(100, 10, 1000, checkpoint);
+
+        var checkpointed = pool.Checkpoint(checkpoint);
+
+        Assert.Equal(checkpoint, checkpointed.CheckpointTime);
+        Assert.Equal(100m, checkpointed.CheckpointValue);
+    }
+
     [Fact]
     public void IsImmutable()
     {

--- a/src/Voidforge.Tests/Planets/PlanetEventOrderingTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetEventOrderingTests.cs
@@ -1,0 +1,121 @@
+using Voidforge.Api.Domain;
+using Voidforge.Api.Domain.Events;
+using Xunit;
+
+namespace Voidforge.Tests.Planets;
+
+// #44: nothing guarantees that events appended to one Planet stream carry non-decreasing `at`.
+// A completion scheduled for T can be delivered after a player command already committed at
+// W > T (poll lag per ADR 0001 plus the #39 retry backoff), so RebaseRates runs with a backwards
+// timestamp. These tests pin the invariant that such an inversion is inert rather than corrupting.
+public sealed class PlanetEventOrderingTests
+{
+    private static Planet Homeworld(DateTimeOffset at)
+    {
+        var planet = new Planet();
+        planet.Apply(new PlanetCreated("P", Guid.NewGuid(), 50000, 6, 10000, 5000));
+        planet.Apply(new PlanetColonized(Guid.NewGuid(), 500, 100, at));
+        planet.Apply(new BuildingPlaced(BuildingType.Drill, at));
+        planet.Apply(new BuildingPlaced(BuildingType.Refinery, at));
+        planet.Apply(new BuildingPlaced(BuildingType.Generator, at));
+        return planet;
+    }
+
+    // Two constructions started together, completing 30s apart.
+    private static (Planet Planet, BuildingConstructionStarted Early, BuildingConstructionStarted Late) Staged(
+        DateTimeOffset at)
+    {
+        var planet = Homeworld(at);
+        var early = planet.StartConstruction(BuildingType.Drill, at, ingotCost: 300m, buildDurationSeconds: 30m);
+        planet.Apply(early);
+        var late = planet.StartConstruction(BuildingType.Generator, at, ingotCost: 600m, buildDurationSeconds: 60m);
+        planet.Apply(late);
+        return (planet, early, late);
+    }
+
+    private static void Complete(Planet planet, BuildingConstructionStarted started)
+    {
+        var events = planet.CompleteBuilding(started.SlotIndex, started.CompletesAt);
+        planet.Apply((BuildingCompleted)events[0]);
+    }
+
+    [Fact]
+    public void OutOfOrderCompletionNeverProducesNegativeElapsedOrBackwardsCheckpoint()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var (planet, early, late) = Staged(now);
+
+        // The later-scheduled completion commits first; the earlier one arrives afterwards.
+        Complete(planet, late);
+        var checkpointAfterLate = planet.IronOre.CheckpointTime;
+        Complete(planet, early);
+
+        // The rewound completion must not drag either checkpoint backwards...
+        Assert.Equal(checkpointAfterLate, planet.IronOre.CheckpointTime);
+        Assert.Equal(checkpointAfterLate, planet.IronIngot.CheckpointTime);
+
+        // ...nor leave a value that a later read re-accrues from a rewound baseline.
+        Assert.True(planet.IronOre.CheckpointValue >= 0);
+        Assert.True(planet.IronIngot.CheckpointValue >= 0);
+    }
+
+    private static (decimal Ore, decimal Ingot) BalancesAt(Planet planet, DateTimeOffset readAt) =>
+        (planet.IronOre.GetCurrentValue(readAt), planet.IronIngot.GetCurrentValue(readAt));
+
+    // Exact order-independence is NOT what this fix provides, and asserting it would be asserting
+    // something no clamp can deliver: recovering the inverted interval requires retroactively
+    // re-deriving the pool from the rewound timestamp under the post-completion rates (a
+    // rewind-and-reapply model, explicitly out of scope for #44). What the fix does guarantee is
+    // that an inversion is *inert and conservative* — the inverted window accrues at the
+    // pre-completion rate, so a race can only ever under-credit, never corrupt or over-credit.
+    [Fact]
+    public void ReverseOrderCompletionsNeverCreditMoreThanInOrder()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var (inOrder, earlyA, lateA) = Staged(now);
+        Complete(inOrder, earlyA);
+        Complete(inOrder, lateA);
+
+        var (reversed, earlyB, lateB) = Staged(now);
+        Complete(reversed, lateB);
+        Complete(reversed, earlyB);
+
+        var readAt = now.AddSeconds(120);
+        var ordered = BalancesAt(inOrder, readAt);
+        var raced = BalancesAt(reversed, readAt);
+
+        Assert.True(raced.Ore <= ordered.Ore, $"race over-credited ore: {raced.Ore} > {ordered.Ore}");
+        Assert.True(raced.Ingot <= ordered.Ingot, $"race over-credited ingots: {raced.Ingot} > {ordered.Ingot}");
+        Assert.True(raced.Ore >= 0);
+        Assert.True(raced.Ingot >= 0);
+    }
+
+    // Pins the exact residual so a future change to the ordering model shows up here as a diff
+    // rather than passing silently. The 30s inversion is deliberately far larger than production
+    // can produce (~5s durable-message poll per ADR 0001 + ~1.9s of #39 retry backoff).
+    [Fact]
+    public void ReverseOrderShortfallIsTheInvertedWindowAtThePreCompletionRate()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var (inOrder, earlyA, lateA) = Staged(now);
+        Complete(inOrder, earlyA);
+        Complete(inOrder, lateA);
+
+        var (reversed, earlyB, lateB) = Staged(now);
+        Complete(reversed, lateB);
+        Complete(reversed, earlyB);
+
+        var readAt = now.AddSeconds(120);
+
+        // The second drill lifts the net ore rate 5/s -> 15/s. In-order it applies from t=30;
+        // reversed it only applies from t=60, so the 30s window accrues 10/s short.
+        Assert.Equal(300m, BalancesAt(inOrder, readAt).Ore - BalancesAt(reversed, readAt).Ore);
+
+        // Both orderings converge once the inverted window is behind them: rates are identical
+        // from t=60 onward, so the gap is a constant offset, not a widening drift.
+        var later = now.AddSeconds(600);
+        Assert.Equal(300m, BalancesAt(inOrder, later).Ore - BalancesAt(reversed, later).Ore);
+    }
+}

--- a/technical-design/architecture.md
+++ b/technical-design/architecture.md
@@ -362,6 +362,11 @@ public class Planet
 }
 ```
 
+> **Sketch, not current state.** The shipped `ResourcePool` is an immutable `sealed record` with named
+> `IronOre`/`IronIngot` fields rather than a `Dictionary<ResourceType, ResourcePool>`, and `elapsed`
+> is floored at 0 because event `at` timestamps are not guaranteed non-decreasing along a stream
+> (#44). See [domain-model.md](domain-model.md#resourcepool-value-object) for the authoritative shape.
+
 ### Write Path (State-Changing Events)
 
 When an event fires (building completes, resource depletes, player issues a command):

--- a/technical-design/domain-model.md
+++ b/technical-design/domain-model.md
@@ -52,8 +52,13 @@ Homeworld starts with 1 Drill, 1 Refinery, 1 Generator, appended alongside `Plan
 
 - **File**: `Domain/ResourcePool.cs`
 - **Fields**: `CheckpointValue` (decimal), `Rate` (decimal, units/sec), `StorageCapacity` (decimal), `CheckpointTime` (DateTimeOffset)
-- **Methods**: `GetCurrentValue(now)` — computes `Clamp(checkpoint + rate * elapsed, 0, capacity)`; `Checkpoint(now)` — returns new instance with current value as baseline
+- **Methods**: `GetCurrentValue(now)` — computes `Clamp(checkpoint + rate * max(0, elapsed), 0, capacity)`; `Checkpoint(now)` — returns new instance with current value as baseline and `CheckpointTime = max(CheckpointTime, now)`
 - **Semantics**: Immutable record. Methods return new instances. Rate starts at 0; buildings (#10) will set rates via checkpointing.
+- **Monotonic time (#44)**: Both methods are **non-regressing** — elapsed is floored at 0 and `CheckpointTime` never moves backwards. Event `at` timestamps are *not* guaranteed non-decreasing along a `Planet` stream: a completion scheduled for `T` can commit after a player command already committed at `W > T` (durable-message poll lag per [ADR 0001](adr/0001-completion-event-resolution.md), plus the #39 `ConcurrencyException` retry backoff — together bounded at roughly 7s). Without the floor, a rewound `at` silently drains an accruing pool, and a negative rate times a negative elapsed *fabricates* resources; a regressed `CheckpointTime` then re-accrues the rewound interval on every later read. `Math.Clamp` bounds the stored value but does not make it correct.
+
+  **Residual, by design**: this makes an inversion *inert and conservative*, not order-independent. The inverted window accrues at the **pre-completion** rate, so the affected pool is under-credited by `(rate delta) × (inversion window)` — a race can never over-credit or corrupt. Exact order-independence would require retroactively re-deriving the pool from the rewound timestamp under the new rates (a rewind-and-reapply model), which is deliberately out of scope. Pinned by `PlanetEventOrderingTests`.
+
+  This holds for every caller: `Planet.RebaseRates` (invoked by all six composition-changing `Apply` methods) and `Planet.CheckpointAllResources` both go through `Checkpoint`, so the invariant is enforced in one place rather than per-handler. Note that `Apply(PlanetColonized)` seeds `CheckpointTime` via a `with` expression rather than `Checkpoint`, so colonization bootstrap (moving from `default` to `ColonizedAt`) is unaffected.
 
 Used by `Planet.IronOre` and `Planet.IronIngot`. The query endpoint computes current values at request time using `GetCurrentValue(timeProvider.GetUtcNow())` — no background ticks needed.
 


### PR DESCRIPTION
Fixes #44.

## Problem

`ResourcePool.GetCurrentValue` computed `elapsed = now - CheckpointTime` with no lower bound, and `Checkpoint` overwrote `CheckpointTime` unconditionally. Both silently assumed event `at` timestamps are non-decreasing along a `Planet` stream. Nothing enforces that.

Optimistic concurrency (#39) guarantees no lost or duplicated appends, but **not** non-decreasing `at`. A completion scheduled for `T` can commit *after* a player command already committed at `W > T`: durable-message poll lag (~5s per [ADR 0001](technical-design/adr/0001-completion-event-resolution.md)) plus the #39 `ConcurrencyException` retry backoff (1.9s — the ladder in `Program.cs:55-61`), so the inversion window is bounded at roughly **7 seconds**. It needs only one late completion racing one ordinary command; no restart required.

Two distinct corruptions followed, neither of which raised an error:

1. **Negative accrual.** `elapsed < 0` drains an accruing pool.
2. **Resource fabrication.** A *negative* rate times a negative elapsed *invents* resources — `100 + (-10) × (-5) = 150`. This mirror case wasn't called out in the issue but is the more damaging of the two.

`Checkpoint` then regressed `CheckpointTime`, so every subsequent read re-accrued the rewound interval, compounding the error rather than absorbing it once. `Math.Clamp` bounded the stored value but did not make it correct.

## Fix

Two lines in the value object:

```csharp
var elapsed = Math.Max(0m, (decimal)(now - CheckpointTime).TotalSeconds);
...
CheckpointTime = now > CheckpointTime ? now : CheckpointTime,
```

Fixing `ResourcePool` covers **all seven call sites at once** — `Planet.RebaseRates` (invoked by the six composition-changing `Apply` methods) and `Planet.CheckpointAllResources` — so no handler changes are needed and the invariant lives in one place.

`Apply(PlanetColonized)` seeds `CheckpointTime` via a `with` expression rather than `Checkpoint`, so colonization bootstrap (`default` → `ColonizedAt`) is unaffected.

## Why not the handler-level fix

The issue also suggested having completion handlers checkpoint at `Max(currentCheckpointTime, message.CompletesAt)`. That was considered and rejected — worth recording, because the reason isn't obvious:

`message.CompletesAt` does **two** jobs in `CompleteBuildingConstructionHandler.cs:24`. It's the effective event timestamp, but it's *also* the identity token for the validate-on-arrival guard (`Planet.cs:138`: `slot.CompletesAt != at → no-op`), which is an exact-equality match. Clamping the value passed into `CompleteBuilding` makes `W != T`, the guard returns `[]`, and the building **never completes** — the durable message is consumed, no events are appended, and the slot stays `UnderConstruction` while `RebaseRates` keeps summing its `ConstructionDrainPerSecond` forever. Strictly worse than the original bug.

Doing it safely would require splitting the parameter into `matchAt`/`effectiveAt`, and it would persist a clamped `CompletedAt` into the immutable event log — recording a completion time that depends on race outcomes rather than the truth. It also produces **identical numbers** to this fix, so it buys no accuracy for that cost.

## Deviation from acceptance criterion 2 — please read before merging

Criterion 1 (no negative elapsed, no backwards checkpoint) is fully met.

Criterion 2 asks to "assert resource balances match the in-order result." That test was written verbatim, watched fail (600 vs 900), and **still failed after the fix** (2000 vs 1700). This is not a defective fix — the criterion asks for something no clamp can deliver. Reverse order accrues the inverted window at the *pre-completion* rate, landing exactly `(rate delta) × (window)` short. Only retroactive rewind-and-reapply closes that gap, which is a design change rather than a bug fix.

It was replaced with the invariant that **is** achievable:

- `ReverseOrderCompletionsNeverCreditMoreThanInOrder` — a race can only under-credit. Players cannot farm the race.
- `ReverseOrderShortfallIsTheInvertedWindowAtThePreCompletionRate` — pins the residual at exactly 300 and asserts it stays a **constant offset, not a widening drift** (still 300 at t=600). That second assertion is what would catch a regression into compounding corruption.

Net: an inversion is now *inert and conservative* rather than corrupting. The residual is bounded by the ~7s window and always in the house's favor.

## Tests

7 new tests, all written first and watched fail for the expected reason:

| Test | Pre-fix failure |
|---|---|
| `BackwardsTimeDoesNotDrainAnAccruingPool` | 50 vs 100 |
| `BackwardsTimeDoesNotFabricateResourcesInADrainingPool` | 150 vs 100 |
| `CheckpointDoesNotRegressTime` | time rewound 5s |
| `CheckpointAtSameInstantIsIdempotent` | boundary guard for `>` vs `>=` |
| `OutOfOrderCompletionNeverProducesNegativeElapsedOrBackwardsCheckpoint` | checkpoint rewound 30s |
| `ReverseOrderCompletionsNeverCreditMoreThanInOrder` | — |
| `ReverseOrderShortfallIsTheInvertedWindowAtThePreCompletionRate` | — |

`137/137 pass`, `dotnet format --verify-no-changes` clean.

## Docs

- `domain-model.md` — documents the non-regressing invariant, why the stream isn't monotonic, and the residual.
- `architecture.md` — the illustrative snippet there still showed the unfloored formula and was *already* divergent from the shipped code in bigger ways (mutable class, `Dictionary<ResourceType, ResourcePool>`). Flagged as a sketch with a pointer to the authoritative doc rather than rewriting a design sketch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
