### PR TITLE
test+chore: phase-4 wrap-up — deterministic claim-guard test, comment cleanup (#52)

### DIFF
--- a/src/Voidforge.Api/Endpoints/FleetSummaryResponse.cs
+++ b/src/Voidforge.Api/Endpoints/FleetSummaryResponse.cs
@@ -2,6 +2,7 @@ using Voidforge.Api.Domain;
 
 namespace Voidforge.Api.Endpoints;
 
-// Consumed by Task 5's list endpoints (#48).
+// Lightweight per-fleet projection for the fleet-list endpoints (FleetEndpoints.GetOwnFleets,
+// GetPlanetFleets, #48) — omits ships/cargo/mission detail, which lives on FleetResponse.
 public sealed record FleetSummaryResponse(
     Guid Id, Guid OwnerId, FleetStatus Status, Guid? LocationPlanetId, DateTimeOffset AssembledAt, int ShipCount);

--- a/src/Voidforge.Tests/AppFixture.cs
+++ b/src/Voidforge.Tests/AppFixture.cs
@@ -21,7 +21,7 @@ public sealed class AppFixture : IAsyncLifetime
 
         // Each registration colonizes one planet, and so does a winning fleet Colonize claim.
         // Seed a large world so the suite never exhausts uncolonized planets (which would
-        // surface as 503s across unrelated tests). Bumped 40 -> 80 for Task 5 (#51): the new
+        // surface as 503s across unrelated tests). Bumped 40 -> 80 for #51's race coverage: the new
         // race coverage adds 7 registrations (5 concurrent + 2 for the two-fleet race) plus 1
         // fleet-colonize claim on top of an already wafer-thin margin — a full-suite run at 40
         // (120 planets) landed at exactly 120/120 owned, 503-ing two unrelated Buildings tests

--- a/src/Voidforge.Tests/Cargo/CargoEndpointTests.cs
+++ b/src/Voidforge.Tests/Cargo/CargoEndpointTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Voidforge.Tests.Cargo;
 
-// Task 4 (#50, spec §2.3/§4/§5): cargo loaded at assembly + the manual unload endpoint.
+// #50 (spec §2.3/§4/§5): cargo loaded at assembly + the manual unload endpoint.
 // Amounts are chosen well under the homeworld's starting stock (500 ore / 100 ingots,
 // see WorldGenOptions) for happy paths, and comfortably below a fleet's cargo capacity but
 // above any realistic accrual for the "insufficient stored" 409.
@@ -113,7 +113,7 @@ public sealed class CargoEndpointTests
         });
     }
 
-    // D13 regression (carry-over from Task 4's review): assembling WITHOUT cargo only
+    // D13 regression (carry-over from #50's review): assembling WITHOUT cargo only
     // validates ship ownership, never planet ownership — the inverse of
     // AssembleCargoOnForeignPlanetReturns403EvenThoughShipsAreOwned above, which requests
     // cargo and is correctly refused. Ships owned by the caller but stranded on a foreign

--- a/src/Voidforge.Tests/Cargo/TransportMissionEndpointTests.cs
+++ b/src/Voidforge.Tests/Cargo/TransportMissionEndpointTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Voidforge.Tests.Cargo;
 
-// Task 5 (#50, spec §2.4): Transport mission launch guards + the codebase's first
+// #50 (spec §2.4): Transport mission launch guards + the codebase's first
 // cross-aggregate arrival append (Planet storage credited, Fleet cargo zeroed, one commit).
 [Collection(IntegrationCollection.Name)]
 public sealed class TransportMissionEndpointTests

--- a/src/Voidforge.Tests/Colonize/ClaimRaceTests.cs
+++ b/src/Voidforge.Tests/Colonize/ClaimRaceTests.cs
@@ -11,16 +11,18 @@ using Xunit;
 
 namespace Voidforge.Tests.Colonize;
 
-// Task 4 (#51, closes #19): registration's homeworld assignment now goes through the same
+// #51 (closes #19): registration's homeworld assignment now goes through the same
 // FetchForWriting + null-owner-check guard shape as the fleet Colonize claim (Planet.Claim,
 // D10), wrapped in a bounded re-pick retry with a fresh Marten session per attempt (a failed
 // SaveChangesAsync can't be selectively unwound on a shared session). SequentialRegistration...
 // below is the mechanism smoke test: a plain, uncontested registration must still succeed
 // end-to-end exactly as before the refactor.
-// Task 5 (#51, spec §7 item 4; #50 final-review carry-over): the real concurrency coverage —
+// #51 (spec §7 item 4; #50 final-review carry-over): the real concurrency coverage —
 // two fleets racing to colonize the SAME planet (exactly one winner; exact-equality
 // conservation of the loaded cargo) and five concurrent registrations that never colonize the
-// same homeworld twice.
+// same homeworld twice. ContestedPlanetAppendLosesWithConcurrencyExceptionDeterministically
+// below (#52) strengthens the five-concurrent-registrations coverage with a deterministic,
+// non-probabilistic proof of the same version guard.
 [Collection(IntegrationCollection.Name)]
 public sealed class ClaimRaceTests
 {
@@ -65,8 +67,8 @@ public sealed class ClaimRaceTests
         var registrations = await Task.WhenAll(Enumerable.Range(0, 5).Select(_ => RegisterPlayer()));
 
         // All five requests carry distinct auto-generated names (RegisterPlayer's Guid
-        // suffix) and none may collide on a homeworld — the guarded claim (Task 4) exists
-        // precisely to make that true even when five registrations race the same
+        // suffix) and none may collide on a homeworld — the guarded claim (#51, closes #19)
+        // exists precisely to make that true even when five registrations race the same
         // uncolonized-planet pool concurrently.
         Assert.Equal(5, registrations.Select(r => r.HomeworldId).Distinct().Count());
 
@@ -75,6 +77,43 @@ public sealed class ClaimRaceTests
             var homeworld = await GetPlanetById(registration, registration.HomeworldId);
             Assert.Equal(registration.PlayerId, homeworld.OwnerId);
         }
+    }
+
+    // Deterministic counterpart to FiveConcurrentRegistrationsAllSucceedWithDistinctHomeworldsOwnedByTheirRegistrants
+    // above (#52): that test only catches a collision probabilistically (~5% odds per run
+    // against unguarded code, since five concurrent registrations rarely pick the same
+    // planet out of dozens of uncolonized candidates). This test instead forces the collision
+    // by hand — two sessions FetchForWriting the SAME stream before either saves, so both
+    // capture the same expected starting version — which deterministically proves the
+    // version guard that both D10 claim sites (Planet.Claim's fleet-Colonize call and
+    // PlayerEndpoints' registration claim) rely on. It also pins the BASE exception type:
+    // Program.cs's #39 durable-message retry policy and PlayerEndpoints' TryClaimHomeworld
+    // catch clause both key off JasperFx.ConcurrencyException, not the more specific
+    // JasperFx.Events.EventStreamUnexpectedMaxEventIdException Marten actually throws here —
+    // asserting against the base type guards against a future Marten/JasperFx upgrade
+    // narrowing (or changing) the concrete exception type from under that catch machinery.
+    [Fact]
+    public async Task ContestedPlanetAppendLosesWithConcurrencyExceptionDeterministically()
+    {
+        var registration = await RegisterPlayer();
+        var planetId = await UncolonizedPlanetId(registration);
+
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+
+        await using var sessionB = store.LightweightSession();
+        await using var sessionA = store.LightweightSession();
+
+        // Both sessions fetch before either saves, so both arm their optimistic-concurrency
+        // guard against the same starting stream version — the fetch order between A and B
+        // doesn't matter, only that neither has saved yet when the other fetches.
+        var streamB = await sessionB.Events.FetchForWriting<Planet>(planetId);
+        var streamA = await sessionA.Events.FetchForWriting<Planet>(planetId);
+
+        streamB.AppendOne(new PlanetColonized(Guid.NewGuid(), 0, 0, DateTimeOffset.UtcNow));
+        await sessionB.SaveChangesAsync();
+
+        streamA.AppendOne(new PlanetColonized(Guid.NewGuid(), 0, 0, DateTimeOffset.UtcNow));
+        await Assert.ThrowsAnyAsync<ConcurrencyException>(() => sessionA.SaveChangesAsync());
     }
 
     [Fact]
@@ -328,7 +367,7 @@ public sealed class ClaimRaceTests
         => await GetPlanetById(registration, registration.HomeworldId);
 
     // Finds an uncolonized planet through the public solar-systems listing (the real
-    // player-visible read path, per Task 5's brief) rather than a raw store query: walks
+    // player-visible read path, per #51 spec §7 item 4) rather than a raw store query: walks
     // systems in listing order and returns the first planet whose owner is null. Relies on
     // the IntegrationCollection's serialized test execution (no concurrent writer between
     // this scan and the subsequent Launch calls) — must not be copied into a parallel context.

--- a/src/Voidforge.Tests/Colonize/ColonizeMissionTests.cs
+++ b/src/Voidforge.Tests/Colonize/ColonizeMissionTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Voidforge.Tests.Colonize;
 
-// Task 3 (#51, spec §2.4): Colonize mission launch guard (Colony Ship required) + the
+// #51 (spec §2.4): Colonize mission launch guard (Colony Ship required) + the
 // guarded arrival claim (planet owned by the fleet owner, colony ship consumed, cargo
 // delivered) vs. the lost-the-race/already-owned branch (fleet idles Stationed, nothing
 // aboard changes).

--- a/src/Voidforge.Tests/Colonize/FullLoopEndToEndTests.cs
+++ b/src/Voidforge.Tests/Colonize/FullLoopEndToEndTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Voidforge.Tests.Colonize;
 
-// Task 6 (#51, phase-completion e2e, spec §7 item 5): the full loop the epic promises, on the
+// #51 (phase-completion e2e, spec §7 item 5): the full loop the epic promises, on the
 // REAL Wolverine scheduler (no handler-invoked shortcuts — see ClaimRaceTests/ColonizeMissionTests
 // for those), stitched together in one flight: economy (homeworld already producing) -> ships
 // (Shipyard, one Colony Ship + one Cargo Vessel) -> expand (Colonize an uncolonized planet in


### PR DESCRIPTION
Wrap-up window items from #51's final whole-branch review, before the phase-completion PR:

- **Deterministic contested-append test** (`ClaimRaceTests.ContestedPlanetAppendLosesWithConcurrencyExceptionDeterministically`): two sessions `FetchForWriting` the same planet; the second commit deterministically throws `JasperFx.ConcurrencyException` — pins the exception type both D10 claim sites' retry/catch machinery depends on, and strengthens the #19 closure beyond the probabilistic five-registration race.
- **Comment cleanup**: stale plan-document "Task N" references removed from 7 files (comments only; zero behavior change).

246/246 green, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)