### PR TITLE
test: extract shared integration-test helpers (#62)

### DIFF
--- a/plans/phase-5/62-test-helpers.md
+++ b/plans/phase-5/62-test-helpers.md
@@ -1,0 +1,535 @@
+# #62 — Shared Integration-Test Helpers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the helper methods duplicated across 21 integration-test files into shared test support, and centralize the suite's poll intervals/timeouts as named constants.
+
+**Architecture:** Extension methods on `IAlbaHost` in `Voidforge.Tests/Support/` — not a base class. Test classes keep their `[Collection]` attribute, constructor, and `_host` field untouched; each file's diff is "delete the private-helper region, prefix helper calls with `_host.`". All helpers take the `RegisterPlayerResponse` explicitly (no hidden state), so extensions compose exactly like the private methods did.
+
+**Tech Stack:** .NET 9, xUnit 2.9, Alba 8.4, Marten. Analyzers: Roslynator + Meziantou, `TreatWarningsAsErrors`, MA0048 (one public type per file).
+
+**Spec:** Issue #62; `plans/phase-5-hardening-design.md` §8 wave 0. Test-only churn — no production code changes.
+
+## Global Constraints
+
+- `TreatWarningsAsErrors` — new files must be analyzer-clean.
+- MA0048 — one public type per file (`IntegrationApiExtensions.cs`, `TestTimeouts.cs`).
+- **No behavior change to what tests assert.** Two deliberate, safe unifications (documented in decisions 2-3 below); everything else byte-equivalent.
+- Never run `dotnet test` concurrently with anything (shared test DB; quality-gate Stop hook also runs the suite).
+- Commits: conventional, suffixed `(#62)`.
+
+## Plan-level decisions
+
+1. **Extensions over inheritance.** A base class would force ctor chaining in 21 files, an `_host` → `Host` sweep through hundreds of inline scenarios, and reliance on xUnit inheriting `[Collection]`. Extensions touch none of that.
+2. **`BuildRosterShip` unifies on ensure + roster-diff** (the ClaimRace/Colonize variant): call idempotent `EnsureOperationalShipyard`, snapshot roster ids, queue, return the first *new* id. This subsumes: variant A (no shipyard yet → ensure builds it; empty roster → diff returns the only ship), variant D in `FleetRoundTripTests` (shipyard already built → ensure is a no-op, no second shipyard), and typed variant B directly. `BuildRosterShips(count)` covers the batch case (30 s deadline, as today).
+3. **`FindPlanetOtherThan` unifies on `?pageSize=200`** (`ShipEndpointTests` form). `BuildingEndpointTests`' copy omitted the page size and relied on the default page containing a non-home planet — strictly less reliable; unifying is a safe behavior change.
+4. **Stays local (race- or file-specific):** `ClaimRaceTests.ArriveWithRetry` + `BuildAndLaunchColonizeFleet`; `ColonizeMissionTests.UncolonizedPlanetId` (raw-Marten single-file variant); `MoveMissionEndToEndTests.PickPlanetInAnotherSolarSystem` (ignores ownership — different semantics); `PlayerRegistrationTests` (asserts raw registration responses — untouched); the `Try*`/`*Status` wrappers in `Concurrency/*` (semantic names stay, bodies delegate to the shared `PostForStatus` primitive); `ColonizeSecondPlanetForOwner` (2 files, raw-Marten world mutation with a do-not-parallelize warning — the pair collapses when #67's fixtures land, not worth a `Store`-reaching shared helper now).
+5. **Poll cadence unchanged** (500 ms), but named. Tightening intervals to speed the suite is deliberately out of scope — it changes DB load during polls and belongs with evidence, not inside a mechanical refactor.
+6. **`RegisterPlayer` keeps per-file name prefixes** as an explicit argument — they make test-DB forensics readable; deriving from the class name risks tripping any name-length validation.
+
+## File Structure
+
+```text
+src/Voidforge.Tests/Support/
+  TestTimeouts.cs                (new — named poll interval + timeout constants)
+  IntegrationApiExtensions.cs    (new — all shared helpers as IAlbaHost extensions)
+plans/phase-5/62-test-helpers.md (this plan)
+technical-design/testing.md      (modify — document the Support layer)
+21 test files                    (modify — delete private helpers, prefix calls with _host.)
+```
+
+---
+
+### Task 1: Support files
+
+**Files:**
+- Create: `src/Voidforge.Tests/Support/TestTimeouts.cs`
+- Create: `src/Voidforge.Tests/Support/IntegrationApiExtensions.cs`
+
+**Interfaces produced:** every signature below — later tasks rely on them verbatim.
+
+- [ ] **Step 1: Write `TestTimeouts.cs`**
+
+```csharp
+namespace Voidforge.Tests.Support;
+
+/// <summary>
+/// Canonical wall-clock poll cadence and deadlines for the integration suite.
+/// These time out real HTTP polling — unrelated to the app's injected TimeProvider.
+/// </summary>
+public static class TestTimeouts
+{
+    /// <summary>Delay between successive polls.</summary>
+    public static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>Building/ship construction completing onto the planet.</summary>
+    public static readonly TimeSpan Completion = TimeSpan.FromSeconds(20);
+
+    /// <summary>Resource stock recovering after a spend, and multi-ship queue settling.</summary>
+    public static readonly TimeSpan StockRecovery = TimeSpan.FromSeconds(30);
+
+    /// <summary>Draining a multi-ship build queue.</summary>
+    public static readonly TimeSpan QueueDrain = TimeSpan.FromSeconds(40);
+
+    /// <summary>Real-scheduler fleet arrival (short hops).</summary>
+    public static readonly TimeSpan Arrival = TimeSpan.FromSeconds(30);
+
+    /// <summary>Full-loop end-to-end arrival (longest travel in the suite).</summary>
+    public static readonly TimeSpan FullLoopArrival = TimeSpan.FromSeconds(60);
+}
+```
+
+- [ ] **Step 2: Write `IntegrationApiExtensions.cs`**
+
+```csharp
+using Alba;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Voidforge.Api.Auth;
+using Voidforge.Api.Domain;
+using Voidforge.Api.Endpoints;
+using Voidforge.Api.Handlers;
+using Xunit;
+
+namespace Voidforge.Tests.Support;
+
+/// <summary>
+/// Shared API-driving helpers for the integration suite (#62). All helpers assert
+/// success (200) unless the name says otherwise; polling helpers return the last
+/// state on timeout so the caller's assertion reports the failure.
+/// </summary>
+public static class IntegrationApiExtensions
+{
+    public static async Task<RegisterPlayerResponse> RegisterPlayer(this IAlbaHost host, string namePrefix)
+    {
+        var result = await host.Scenario(s =>
+        {
+            s.Post.Json(new RegisterPlayerRequest($"{namePrefix}{Guid.NewGuid():N}"))
+                .ToUrl("/api/players/register");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
+        Assert.NotNull(response);
+        return response;
+    }
+
+    public static async Task<T> GetJson<T>(this IAlbaHost host, RegisterPlayerResponse asWhom, string url)
+    {
+        var result = await host.Scenario(s =>
+        {
+            s.Get.Url(url);
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, asWhom.ApiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var response = await result.ReadAsJsonAsync<T>();
+        Assert.NotNull(response);
+        return response;
+    }
+
+    public static Task<PlanetResponse> GetPlanet(this IAlbaHost host, RegisterPlayerResponse registration)
+        => host.GetPlanetById(registration, registration.HomeworldId);
+
+    public static Task<PlanetResponse> GetPlanetById(this IAlbaHost host, RegisterPlayerResponse asWhom, Guid planetId)
+        => host.GetJson<PlanetResponse>(asWhom, $"/api/planets/{planetId}");
+
+    public static Task<PagedResponse<RosterShipResponse>> GetRoster(
+        this IAlbaHost host, RegisterPlayerResponse registration, Guid? planetId = null)
+        => host.GetJson<PagedResponse<RosterShipResponse>>(
+            registration, $"/api/planets/{planetId ?? registration.HomeworldId}/ships?pageSize=200");
+
+    public static async Task<ShipBuildResponse> QueueShip(
+        this IAlbaHost host, RegisterPlayerResponse registration, ShipType type)
+    {
+        var result = await host.Scenario(s =>
+        {
+            s.Post.Json(new QueueShipRequest(type))
+                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
+        Assert.NotNull(build);
+        return build;
+    }
+
+    /// <summary>Places a Shipyard only if the planet has none, then polls until it is Operational.</summary>
+    public static async Task EnsureOperationalShipyard(this IAlbaHost host, RegisterPlayerResponse registration)
+    {
+        var planet = await host.GetPlanet(registration);
+        if (!planet.Buildings.Any(b => b.Type == BuildingType.Shipyard))
+        {
+            await host.Scenario(s =>
+            {
+                s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
+                    .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
+                s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+                s.StatusCodeShouldBe(200);
+            });
+        }
+
+        await host.PollUntil(
+            registration,
+            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
+            TestTimeouts.Completion);
+    }
+
+    /// <summary>
+    /// Ensures an operational shipyard, queues one ship, and returns the id of the ship
+    /// that newly appears on the roster (diff-based, so pre-existing roster ships are fine).
+    /// </summary>
+    public static async Task<Guid> BuildRosterShip(
+        this IAlbaHost host, RegisterPlayerResponse registration, ShipType type = ShipType.CargoVessel)
+    {
+        await host.EnsureOperationalShipyard(registration);
+
+        var before = await host.GetRoster(registration);
+        var known = before.Items.Select(s => s.Id).ToHashSet();
+        await host.QueueShip(registration, type);
+
+        var deadline = DateTime.UtcNow + TestTimeouts.Completion;
+        do
+        {
+            var roster = await host.GetRoster(registration);
+            var added = roster.Items.FirstOrDefault(s => !known.Contains(s.Id));
+            if (added is not null)
+            {
+                return added.Id;
+            }
+
+            await Task.Delay(TestTimeouts.PollInterval);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        throw new InvalidOperationException("Ship did not complete onto the roster in time.");
+    }
+
+    /// <summary>Queues <paramref name="count"/> CargoVessels and waits for all of them to reach the roster.</summary>
+    public static async Task<IReadOnlyList<Guid>> BuildRosterShips(
+        this IAlbaHost host, RegisterPlayerResponse registration, int count)
+    {
+        await host.EnsureOperationalShipyard(registration);
+
+        var before = await host.GetRoster(registration);
+        var known = before.Items.Select(s => s.Id).ToHashSet();
+        for (var i = 0; i < count; i++)
+        {
+            await host.QueueShip(registration, ShipType.CargoVessel);
+        }
+
+        var deadline = DateTime.UtcNow + TestTimeouts.StockRecovery;
+        do
+        {
+            var roster = await host.GetRoster(registration);
+            var added = roster.Items.Where(s => !known.Contains(s.Id)).Select(s => s.Id).ToList();
+            if (added.Count >= count)
+            {
+                return added;
+            }
+
+            await Task.Delay(TestTimeouts.PollInterval);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        throw new InvalidOperationException($"Queued {count} ships did not all reach the roster in time.");
+    }
+
+    public static async Task<FleetResponse> AssembleFleet(
+        this IAlbaHost host,
+        RegisterPlayerResponse registration,
+        IReadOnlyList<Guid> shipIds,
+        CargoRequest? cargo = null,
+        Guid? planetId = null)
+    {
+        var result = await host.Scenario(s =>
+        {
+            s.Post.Json(new AssembleFleetRequest(shipIds, cargo))
+                .ToUrl($"/api/planets/{planetId ?? registration.HomeworldId}/fleets");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
+        Assert.NotNull(fleet);
+        return fleet;
+    }
+
+    public static async Task<FleetResponse> Launch(
+        this IAlbaHost host,
+        RegisterPlayerResponse registration,
+        Guid fleetId,
+        MissionType mission,
+        Guid destinationPlanetId)
+    {
+        var result = await host.Scenario(s =>
+        {
+            s.Post.Json(new LaunchMissionRequest(mission, destinationPlanetId))
+                .ToUrl($"/api/fleets/{fleetId}/missions");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
+        Assert.NotNull(fleet);
+        return fleet;
+    }
+
+    public static async Task<FleetResponse> Disband(
+        this IAlbaHost host, RegisterPlayerResponse registration, Guid fleetId)
+    {
+        var result = await host.Scenario(s =>
+        {
+            s.Post.Url($"/api/fleets/{fleetId}/disband");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
+        Assert.NotNull(fleet);
+        return fleet;
+    }
+
+    public static async Task Unload(this IAlbaHost host, RegisterPlayerResponse registration, Guid fleetId)
+    {
+        await host.Scenario(s =>
+        {
+            s.Post.Url($"/api/fleets/{fleetId}/unload");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(200);
+        });
+    }
+
+    /// <summary>Polls the planet until ore and ingot stocks reach the minimums; asserts on timeout.</summary>
+    public static async Task<PlanetResponse> WaitForStock(
+        this IAlbaHost host, RegisterPlayerResponse registration, decimal minOre, decimal minIngot)
+    {
+        var planet = await host.PollUntil(
+            registration,
+            p => p.IronOre.CurrentValue >= minOre && p.IronIngot.CurrentValue >= minIngot,
+            TestTimeouts.StockRecovery);
+
+        Assert.True(
+            planet.IronOre.CurrentValue >= minOre && planet.IronIngot.CurrentValue >= minIngot,
+            $"Stock did not recover in time: ore={planet.IronOre.CurrentValue} (need {minOre}), " +
+            $"ingot={planet.IronIngot.CurrentValue} (need {minIngot}).");
+
+        return planet;
+    }
+
+    /// <summary>
+    /// Polls the planet (homeworld unless <paramref name="planetId"/> is given) until the
+    /// predicate holds. Returns the last-seen state on timeout — callers assert and report.
+    /// </summary>
+    public static async Task<PlanetResponse> PollUntil(
+        this IAlbaHost host,
+        RegisterPlayerResponse registration,
+        Func<PlanetResponse, bool> predicate,
+        TimeSpan timeout,
+        Guid? planetId = null)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        PlanetResponse planet;
+        do
+        {
+            planet = await host.GetPlanetById(registration, planetId ?? registration.HomeworldId);
+            if (predicate(planet))
+            {
+                return planet;
+            }
+
+            await Task.Delay(TestTimeouts.PollInterval);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        return planet;
+    }
+
+    public static async Task<FleetResponse> PollFleetUntil(
+        this IAlbaHost host,
+        RegisterPlayerResponse registration,
+        Guid fleetId,
+        Func<FleetResponse, bool> predicate,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        FleetResponse fleet;
+        do
+        {
+            fleet = await host.GetJson<FleetResponse>(registration, $"/api/fleets/{fleetId}");
+            if (predicate(fleet))
+            {
+                return fleet;
+            }
+
+            await Task.Delay(TestTimeouts.PollInterval);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        return fleet;
+    }
+
+    /// <summary>
+    /// Launches the mission, then completes the arrival immediately by invoking the
+    /// handler directly with the scheduled ArrivesAt — no wall-clock wait.
+    /// </summary>
+    public static async Task<FleetResponse> LaunchAndArriveInstantly(
+        this IAlbaHost host,
+        RegisterPlayerResponse registration,
+        Guid fleetId,
+        MissionType mission,
+        Guid destinationPlanetId)
+    {
+        var launched = await host.Launch(registration, fleetId, mission, destinationPlanetId);
+        Assert.NotNull(launched.ArrivesAt);
+
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession();
+        await CompleteFleetArrivalHandler.Handle(
+            new CompleteFleetArrival(fleetId, launched.ArrivesAt.Value), session);
+
+        return await host.GetJson<FleetResponse>(registration, $"/api/fleets/{fleetId}");
+    }
+
+    /// <summary>POSTs and returns the raw status code — for race tests that expect non-200s.</summary>
+    public static async Task<int> PostForStatus(
+        this IAlbaHost host, RegisterPlayerResponse registration, string url, object payload)
+    {
+        var result = await host.Scenario(s =>
+        {
+            s.Post.Json(payload).ToUrl(url);
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.IgnoreStatusCode();
+        });
+
+        return result.Context.Response.StatusCode;
+    }
+
+    /// <summary>First planet in the universe that is not the caller's homeworld.</summary>
+    public static async Task<Guid> FindPlanetOtherThan(this IAlbaHost host, RegisterPlayerResponse registration)
+    {
+        var systems = await host.GetJson<PagedResponse<SolarSystemResponse>>(
+            registration, "/api/solar-systems?pageSize=200");
+        var planetId = systems.Items
+            .SelectMany(sys => sys.PlanetIds)
+            .First(id => id != registration.HomeworldId);
+        return planetId;
+    }
+
+    /// <summary>
+    /// Scans the public API for an unowned planet, optionally excluding one solar system.
+    /// Throws if the universe has none.
+    /// </summary>
+    public static async Task<Guid> FindUncolonizedPlanet(
+        this IAlbaHost host, RegisterPlayerResponse asWhom, Guid? excludeSystemId = null)
+    {
+        var systems = await host.GetJson<PagedResponse<SolarSystemResponse>>(
+            asWhom, "/api/solar-systems?pageSize=200");
+        foreach (var system in systems.Items)
+        {
+            if (system.Id == excludeSystemId)
+            {
+                continue;
+            }
+
+            foreach (var planetId in system.PlanetIds)
+            {
+                var planet = await host.GetPlanetById(asWhom, planetId);
+                if (planet.OwnerId is null)
+                {
+                    return planetId;
+                }
+            }
+        }
+
+        throw new InvalidOperationException("No uncolonized planet found in the universe.");
+    }
+}
+```
+
+> Compile-check note: exact DTO namespaces (`RegisterPlayerRequest`, `SolarSystemResponse`, `CompleteFleetArrival`, `CompleteFleetArrivalHandler`, `CargoRequest`) must match the API project — fix usings on first build, do not fully-qualify inline. The `Unload`/`Disband` POST-without-body shape must match the existing local helpers (verify one before deleting).
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build src/Voidforge.slnx`
+Expected: clean (analyzers on). Nothing consumes the new files yet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Voidforge.Tests/Support plans/phase-5/62-test-helpers.md
+git commit -m "test: shared integration-test helper extensions + named timeouts (#62)"
+```
+
+---
+
+### Task 2: Migrate Fleets/ + Concurrency/ (4 files)
+
+**Files:** `Fleets/FleetEndpointTests.cs`, `Fleets/FleetRoundTripTests.cs`, `Concurrency/FleetConcurrencyTests.cs`, `Concurrency/SameStreamConcurrencyTests.cs`
+
+- [ ] **Step 1:** In each file: add `using Voidforge.Tests.Support;`, delete the private copies of `RegisterPlayer`/`GetJson`/`GetPlanet`/`GetRoster`/`QueueShip`/`BuildOperationalShipyard`/`BuildRosterShip`/`AssembleFleet`/`Disband`/`PollUntil`, prefix every call with `_host.` and pass each file's existing name-prefix literal to `RegisterPlayer("…")`. Replace hardcoded `TimeSpan.FromSeconds(20/30)` poll args at call sites with `TestTimeouts.Completion` / `TestTimeouts.StockRecovery`.
+- [ ] **Step 2:** File-specific: `FleetRoundTripTests` — its local `BuildRosterShip` (variant D) is deleted; the body's one explicit `BuildOperationalShipyard` call becomes `_host.EnsureOperationalShipyard`; the shared diff-based helper preserves its semantics. `FleetConcurrencyTests`/`SameStreamConcurrencyTests` — keep `TryAssemble`/`TryDisband`/`TryLaunch`/`QueueShipStatus` as local one-liners delegating to `_host.PostForStatus(...)`.
+- [ ] **Step 3:** `dotnet build src/Voidforge.slnx` → clean.
+- [ ] **Step 4:** Commit: `test: migrate Fleets + Concurrency suites to shared helpers (#62)`
+
+---
+
+### Task 3: Migrate Cargo/ (3 files)
+
+**Files:** `Cargo/CargoEndpointTests.cs`, `Cargo/TransportMissionEndToEndTests.cs`, `Cargo/TransportMissionEndpointTests.cs`
+
+- [ ] **Step 1:** Same mechanical sweep as Task 2 (including `Launch`, `Unload`, `WaitForStock`, `PollFleetUntil`, `GetPlanetById`, `LaunchAndArriveInstantly`).
+- [ ] **Step 2:** File-specific: `CargoEndpointTests` — `BuildRosterShips(count)` maps to the shared batch helper; `MoveAndArriveInstantly` becomes a local one-liner over `_host.LaunchAndArriveInstantly(reg, fleetId, MissionType.Move, dest)` (ignore the return); its `WaitForStock` callers keep using the returned planet. `TransportMissionEndpointTests` keeps `ColonizeSecondPlanetForOwner` local (decision 4). `_arrivalTimeout` fields switch to `TestTimeouts.Arrival`.
+- [ ] **Step 3:** `dotnet build src/Voidforge.slnx` → clean.
+- [ ] **Step 4:** Commit: `test: migrate Cargo suites to shared helpers (#62)`
+
+---
+
+### Task 4: Migrate Colonize/ (3 files)
+
+**Files:** `Colonize/ClaimRaceTests.cs`, `Colonize/ColonizeMissionTests.cs`, `Colonize/FullLoopEndToEndTests.cs`
+
+- [ ] **Step 1:** Same mechanical sweep. `EnsureOperationalShipyard` copies delete cleanly (shared one is the same shape). Typed `BuildRosterShip(reg, type)` calls map 1:1.
+- [ ] **Step 2:** File-specific: `ClaimRaceTests` keeps `ArriveWithRetry` + `BuildAndLaunchColonizeFleet` local; its `UncolonizedPlanetId(asWhom)` becomes `_host.FindUncolonizedPlanet(asWhom)`. `ColonizeMissionTests` keeps its raw-Marten `UncolonizedPlanetId()` local (decision 4) and keeps `ColonizeSecondPlanetForOwner` local. `FullLoopEndToEndTests` — `UncolonizedPlanetInAnotherSystem(asWhom, homeSystemId)` becomes `_host.FindUncolonizedPlanet(asWhom, excludeSystemId: homeSystemId)`; `_arrivalTimeout` → `TestTimeouts.FullLoopArrival`.
+- [ ] **Step 3:** `dotnet build src/Voidforge.slnx` → clean.
+- [ ] **Step 4:** Commit: `test: migrate Colonize suites to shared helpers (#62)`
+
+---
+
+### Task 5: Migrate Travel/ (3 files)
+
+**Files:** `Travel/FleetMissionEndpointTests.cs`, `Travel/MoveMissionEndToEndTests.cs`, `Travel/PlanetCoordinateApiTests.cs`
+
+- [ ] **Step 1:** Same mechanical sweep.
+- [ ] **Step 2:** File-specific: `MoveMissionEndToEndTests` — `GetRosterAt(reg, planetId)` → `_host.GetRoster(reg, planetId)`; its `PollUntil` variant maps to the shared one (homeworld default); `Task Disband` callers call the shared `Disband` and discard the result with `_ =`; keeps `PickPlanetInAnotherSolarSystem` local; `_arrivalTimeout` → `TestTimeouts.Arrival`. `PlanetCoordinateApiTests` — only `RegisterPlayer` migrates; the `_planetSpread` ctor stays.
+- [ ] **Step 3:** `dotnet build src/Voidforge.slnx` → clean.
+- [ ] **Step 4:** Commit: `test: migrate Travel suites to shared helpers (#62)`
+
+---
+
+### Task 6: Migrate remaining suites (7 files)
+
+**Files:** `Buildings/BuildingEndpointTests.cs`, `Construction/BuildingConstructionCompletionTests.cs`, `Energy/EnergyGridTests.cs`, `Ships/ShipConstructionCompletionTests.cs`, `Ships/ShipEndpointTests.cs`, `Planets/PlanetEndpointTests.cs`, `Pagination/SolarSystemPaginationTests.cs`
+
+- [ ] **Step 1:** Same mechanical sweep (`RegisterPlayer`, `GetPlanet`, `PollUntil`, `QueueShip`, `GetRoster`, `BuildOperationalShipyard` → `EnsureOperationalShipyard`, `CancelBuild` stays local in `ShipConstructionCompletionTests`).
+- [ ] **Step 2:** File-specific: both `FindPlanetOtherThan` copies → shared (Buildings' gains `pageSize=200`, decision 3). `ShipConstructionCompletionTests` 40 s timeouts → `TestTimeouts.QueueDrain`. `SolarSystemPaginationTests` — `RegisterAndGetKey()` becomes `(await _host.RegisterPlayer("Pg_Test_")).ApiKey`; `GetPage(string apiKey, …)` stays local. `PlayerRegistrationTests` is deliberately untouched.
+- [ ] **Step 3:** `dotnet build src/Voidforge.slnx` → clean. Then grep for leftovers: `grep -rn "private async Task<RegisterPlayerResponse> RegisterPlayer\|private async Task<PlanetResponse> PollUntil" src/Voidforge.Tests` → no hits.
+- [ ] **Step 4:** Commit: `test: migrate remaining suites to shared helpers; drop last duplicates (#62)`
+
+---
+
+### Task 7: Full suite, format, docs
+
+- [ ] **Step 1:** `timeout 900 dotnet test src/Voidforge.slnx` → all green (no concurrent runs; Wolverine teardown hang is cosmetic per `testing.md`).
+- [ ] **Step 2:** `dotnet format src/Voidforge.slnx` → commit any churn.
+- [ ] **Step 3:** Update `technical-design/testing.md`: add a "Shared helpers (`Support/`)" section — `IntegrationApiExtensions` (all API-driving helpers, assert-200, poll-return-last), `TestTimeouts` (named cadences), and the rule: *new integration tests must use the shared helpers; add to them rather than re-declaring privately*.
+- [ ] **Step 4:** Commit: `test+docs: shared-helper conventions in testing.md (#62)`
+
+---
+
+### Task 8: PR and merge
+
+- [ ] **Step 1:** Push `chore/62-test-helpers`; open PR → base `phase-5`, title `test: extract shared integration-test helpers (#62)`, body: summary + decisions 1-6 + "Closes #62".
+- [ ] **Step 2:** `gh pr checks --watch` → green.
+- [ ] **Step 3:** `gh pr merge --merge`.

--- a/src/Voidforge.Tests/Buildings/BuildingEndpointTests.cs
+++ b/src/Voidforge.Tests/Buildings/BuildingEndpointTests.cs
@@ -2,7 +2,7 @@ using Alba;
 using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
-using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Buildings;
@@ -20,8 +20,8 @@ public sealed class BuildingEndpointTests
     [Fact]
     public async Task PlaceBuildingStartsConstruction()
     {
-        var registration = await RegisterPlayer();
-        var before = await GetPlanet(registration);
+        var registration = await _host.RegisterPlayer("Building_Test_");
+        var before = await _host.GetPlanet(registration);
 
         var result = await _host.Scenario(s =>
         {
@@ -48,7 +48,7 @@ public sealed class BuildingEndpointTests
     [Fact]
     public async Task UnderConstructionBuildingDrainsIngotsOverTime()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Building_Test_");
 
         await _host.Scenario(s =>
         {
@@ -58,10 +58,10 @@ public sealed class BuildingEndpointTests
             s.StatusCodeShouldBe(200);
         });
 
-        var first = await GetPlanet(registration);
+        var first = await _host.GetPlanet(registration);
         Assert.Equal(BuildingStatus.UnderConstruction, first.Buildings[^1].Status);
         await Task.Delay(1000);
-        var second = await GetPlanet(registration);
+        var second = await _host.GetPlanet(registration);
 
         // With the short test build durations, drain exceeds the homeworld's +10/s ingot
         // production, so the stored ingot value falls while UnderConstruction.
@@ -72,8 +72,8 @@ public sealed class BuildingEndpointTests
     [Fact]
     public async Task PlaceBuildingOnUnownedPlanetReturns403()
     {
-        var registration = await RegisterPlayer();
-        var foreignPlanetId = await FindPlanetOtherThan(registration);
+        var registration = await _host.RegisterPlayer("Building_Test_");
+        var foreignPlanetId = await _host.FindPlanetOtherThan(registration);
 
         await _host.Scenario(s =>
         {
@@ -87,7 +87,7 @@ public sealed class BuildingEndpointTests
     [Fact]
     public async Task PlaceBuildingOnNonExistentPlanetReturns404()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Building_Test_");
 
         await _host.Scenario(s =>
         {
@@ -112,8 +112,8 @@ public sealed class BuildingEndpointTests
     [Fact]
     public async Task PlaceBuildingInOccupiedSlotsReturns409()
     {
-        var registration = await RegisterPlayer();
-        var planet = await GetPlanet(registration);
+        var registration = await _host.RegisterPlayer("Building_Test_");
+        var planet = await _host.GetPlanet(registration);
 
         // Fill remaining slots, then the next placement must be rejected.
         var freeSlots = planet.BuildingSlotCount - planet.Buildings.Count;
@@ -135,48 +135,5 @@ public sealed class BuildingEndpointTests
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
             s.StatusCodeShouldBe(409);
         });
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
-        Assert.NotNull(planet);
-        return planet;
-    }
-
-    private async Task<Guid> FindPlanetOtherThan(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url("/api/solar-systems");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var systems = await result.ReadAsJsonAsync<PagedResponse<SolarSystemResponse>>();
-        Assert.NotNull(systems);
-        var other = systems.Items.SelectMany(sys => sys.PlanetIds).First(id => id != registration.HomeworldId);
-        return other;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Building_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Cargo/CargoEndpointTests.cs
+++ b/src/Voidforge.Tests/Cargo/CargoEndpointTests.cs
@@ -1,11 +1,8 @@
 using Alba;
-using Marten;
-using Microsoft.Extensions.DependencyInjection;
 using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
-using Voidforge.Api.Domain.Events;
 using Voidforge.Api.Endpoints;
-using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Cargo;
@@ -27,20 +24,20 @@ public sealed class CargoEndpointTests
     [Fact]
     public async Task AssembleWithCargoReturns200AndDecrementsOriginStorage()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
+        var owner = await _host.RegisterPlayer("Cargo_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
         // Shipyard/ship construction drains ingots hard (test-host drain rates exceed the
         // homeworld's +10/s production) — wait for it to recover past what we're about to
         // load, plus margin, before taking the "before" snapshot.
-        var before = await WaitForStock(owner, 150m, 100m);
+        var before = await _host.WaitForStock(owner, 150m, 100m);
 
-        var fleet = await AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
+        var fleet = await _host.AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
 
         Assert.Equal(100m, fleet.CargoIronOre);
         Assert.Equal(50m, fleet.CargoIronIngot);
         Assert.Equal(500m, fleet.CargoCapacity);   // one CargoVessel, spec §6 default
 
-        var after = await GetPlanet(owner);
+        var after = await _host.GetPlanet(owner);
         // Production continues (Drill/Refinery) between reads, so allow slack either side
         // of the exact 100/50 the load subtracted.
         Assert.InRange(before.IronOre.CurrentValue - after.IronOre.CurrentValue, 90m, 130m);
@@ -50,10 +47,10 @@ public sealed class CargoEndpointTests
     [Fact]
     public async Task AssembleWithNoCargoLeavesFleetEmptyAndSkipsValidation()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
+        var owner = await _host.RegisterPlayer("Cargo_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
 
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
         Assert.Equal(0m, fleet.CargoIronOre);
         Assert.Equal(0m, fleet.CargoIronIngot);
@@ -62,8 +59,8 @@ public sealed class CargoEndpointTests
     [Fact]
     public async Task AssembleCargoExceedingCapacityReturns400()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);   // one CargoVessel: capacity 500
+        var owner = await _host.RegisterPlayer("Cargo_Test_");
+        var shipId = await _host.BuildRosterShip(owner);   // one CargoVessel: capacity 500
 
         await _host.Scenario(s =>
         {
@@ -77,8 +74,8 @@ public sealed class CargoEndpointTests
     [Fact]
     public async Task AssembleWithNegativeCargoAmountReturns400()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
+        var owner = await _host.RegisterPlayer("Cargo_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
 
         await _host.Scenario(s =>
         {
@@ -92,15 +89,15 @@ public sealed class CargoEndpointTests
     [Fact]
     public async Task AssembleCargoOnForeignPlanetReturns403EvenThoughShipsAreOwned()
     {
-        var owner = await RegisterPlayer();
-        var foreign = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);   // no cargo yet
+        var owner = await _host.RegisterPlayer("Cargo_Test_");
+        var foreign = await _host.RegisterPlayer("Cargo_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);   // no cargo yet
 
         // Move (cargo-free) to the foreign homeworld, resolved instantly via the
         // handler-invoked pattern (avoids waiting on the real scheduled arrival).
         await MoveAndArriveInstantly(owner, fleet.Id, foreign.HomeworldId);
-        await Disband(owner, fleet.Id);   // ships land on the foreign planet's roster (D13: still owner-owned)
+        await _host.Disband(owner, fleet.Id);   // ships land on the foreign planet's roster (D13: still owner-owned)
 
         // Re-assemble on the foreign planet: ship ownership passes (owner still owns the
         // ships), but the cargo request requires owning the planet too.
@@ -121,18 +118,18 @@ public sealed class CargoEndpointTests
     [Fact]
     public async Task AssembleWithoutCargoOnForeignPlanetReturns200()
     {
-        var owner = await RegisterPlayer();
-        var foreign = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);   // no cargo yet
+        var owner = await _host.RegisterPlayer("Cargo_Test_");
+        var foreign = await _host.RegisterPlayer("Cargo_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);   // no cargo yet
 
         // Move (cargo-free) to the foreign homeworld, resolved instantly via the
         // handler-invoked pattern (avoids waiting on the real scheduled arrival).
         await MoveAndArriveInstantly(owner, fleet.Id, foreign.HomeworldId);
-        await Disband(owner, fleet.Id);   // ships land on the foreign planet's roster (D13: still owner-owned)
+        await _host.Disband(owner, fleet.Id);   // ships land on the foreign planet's roster (D13: still owner-owned)
 
         // The roster is on the foreign planet now, not owner's own homeworld.
-        var reassembled = await AssembleFleet(owner, [shipId], planetId: foreign.HomeworldId);
+        var reassembled = await _host.AssembleFleet(owner, [shipId], planetId: foreign.HomeworldId);
 
         Assert.Equal(0m, reassembled.CargoIronOre);
         Assert.Equal(0m, reassembled.CargoIronIngot);
@@ -142,8 +139,8 @@ public sealed class CargoEndpointTests
     [Fact]
     public async Task AssembleCargoExceedingStoredAmountReturns409()
     {
-        var owner = await RegisterPlayer();
-        var shipIds = await BuildRosterShips(owner, 2);   // two CargoVessels: capacity 1000
+        var owner = await _host.RegisterPlayer("Cargo_Test_");
+        var shipIds = await _host.BuildRosterShips(owner, 2);   // two CargoVessels: capacity 1000
 
         // 900 ingots is comfortably under the 1000 capacity ceiling but far above anything
         // the homeworld could have accrued (starts at 100, +10/s net) during test setup.
@@ -159,9 +156,9 @@ public sealed class CargoEndpointTests
     [Fact]
     public async Task UnloadWithNoCargoAboardReturns409()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);   // no cargo
+        var owner = await _host.RegisterPlayer("Cargo_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);   // no cargo
 
         await _host.Scenario(s =>
         {
@@ -178,10 +175,10 @@ public sealed class CargoEndpointTests
     [Fact]
     public async Task DisbandWithCargoAboardReturns409()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        await WaitForStock(owner, 150m, 100m);
-        var fleet = await AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
+        var owner = await _host.RegisterPlayer("Cargo_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        await _host.WaitForStock(owner, 150m, 100m);
+        var fleet = await _host.AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
 
         await _host.Scenario(s =>
         {
@@ -194,10 +191,10 @@ public sealed class CargoEndpointTests
     [Fact]
     public async Task UnloadAtAForeignPlanetReturns403()
     {
-        var owner = await RegisterPlayer();
-        var foreign = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId], new CargoRequest(50m, 0m));
+        var owner = await _host.RegisterPlayer("Cargo_Test_");
+        var foreign = await _host.RegisterPlayer("Cargo_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId], new CargoRequest(50m, 0m));
 
         // Cargo rides along on a Move (spec §2.4); resolved instantly.
         await MoveAndArriveInstantly(owner, fleet.Id, foreign.HomeworldId);
@@ -213,231 +210,27 @@ public sealed class CargoEndpointTests
     [Fact]
     public async Task AssembleThenUnloadRoundTripRestoresOriginStorage()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var beforeAssemble = await WaitForStock(owner, 150m, 100m);
+        var owner = await _host.RegisterPlayer("Cargo_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var beforeAssemble = await _host.WaitForStock(owner, 150m, 100m);
 
-        var fleet = await AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
-        var afterAssemble = await GetPlanet(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
+        var afterAssemble = await _host.GetPlanet(owner);
         Assert.True(afterAssemble.IronOre.CurrentValue < beforeAssemble.IronOre.CurrentValue);
 
-        var unloaded = await Unload(owner, fleet.Id);
+        var unloaded = await _host.Unload(owner, fleet.Id);
         Assert.Equal(0m, unloaded.CargoIronOre);
         Assert.Equal(0m, unloaded.CargoIronIngot);
 
-        var afterUnload = await GetPlanet(owner);
+        var afterUnload = await _host.GetPlanet(owner);
         // The 100/50 that left comes back (net of whatever accrued meanwhile).
         Assert.InRange(afterUnload.IronOre.CurrentValue - afterAssemble.IronOre.CurrentValue, 90m, 130m);
         Assert.InRange(afterUnload.IronIngot.CurrentValue - afterAssemble.IronIngot.CurrentValue, 30m, 80m);
     }
 
-    private async Task MoveAndArriveInstantly(RegisterPlayerResponse registration, Guid fleetId, Guid destinationPlanetId)
-    {
-        var launched = await _host.Scenario(s =>
-        {
-            s.Post.Json(new LaunchMissionRequest(MissionType.Move, destinationPlanetId))
-                .ToUrl($"/api/fleets/{fleetId}/missions");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await launched.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(response);
-        Assert.NotNull(response.ArrivesAt);
-
-        // Handler-invoked resolution (spec §7 testing strategy item 2) — verifies the
-        // handler → stream append path without waiting on the real scheduled envelope.
-        var store = _host.Services.GetRequiredService<IDocumentStore>();
-        await using var session = store.LightweightSession();
-        await CompleteFleetArrivalHandler.Handle(new CompleteFleetArrival(fleetId, response.ArrivesAt.Value), session);
-    }
-
-    private async Task<FleetResponse> Unload(RegisterPlayerResponse registration, Guid fleetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Url($"/api/fleets/{fleetId}/unload");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    private async Task<FleetResponse> Disband(RegisterPlayerResponse registration, Guid fleetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Url($"/api/fleets/{fleetId}/disband");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    // planetId defaults to the registration's own homeworld; callers reassembling a roster
-    // stranded on a foreign planet (D13) pass that planet's id explicitly instead.
-    private async Task<FleetResponse> AssembleFleet(
-        RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds, CargoRequest? cargo = null, Guid? planetId = null)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds, cargo)).ToUrl($"/api/planets/{planetId ?? registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    // Builds an operational shipyard, queues one CargoVessel (~2s build in the test host),
-    // and polls the roster until it appears. Returns the completed ship's id.
-    private async Task<Guid> BuildRosterShip(RegisterPlayerResponse registration)
-    {
-        var ships = await BuildRosterShips(registration, 1);
-        return ships[0];
-    }
-
-    // Same as above, but queues `count` CargoVessels in parallel on one shipyard
-    // (ShipyardParallelBuilds allows up to 3) and waits for all of them to land on the roster.
-    private async Task<IReadOnlyList<Guid>> BuildRosterShips(RegisterPlayerResponse registration, int count)
-    {
-        await BuildOperationalShipyard(registration);
-        for (var i = 0; i < count; i++)
-        {
-            await QueueShip(registration, ShipType.CargoVessel);
-        }
-
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
-        do
-        {
-            var roster = await GetRoster(registration);
-            if (roster.Items.Count >= count)
-            {
-                return [.. roster.Items.Take(count).Select(r => r.Id)];
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        throw new InvalidOperationException("Ships did not complete onto the roster in time.");
-    }
-
-    private async Task BuildOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        await _host.Scenario(s =>
-        {
-            s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        await PollUntil(
-            registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRoster(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}/ships?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var roster = await result.ReadAsJsonAsync<PagedResponse<RosterShipResponse>>();
-        Assert.NotNull(roster);
-        return roster;
-    }
-
-    // Waits for the homeworld's stored ore/ingot to reach at least the given amounts.
-    // Necessary because shipyard/ship construction (test-host drain rates) can crush the
-    // ingot pool to near zero for several seconds before production recovers it.
-    private async Task<PlanetResponse> WaitForStock(RegisterPlayerResponse registration, decimal minOre, decimal minIngot)
-    {
-        var planet = await PollUntil(
-            registration,
-            p => p.IronOre.CurrentValue >= minOre && p.IronIngot.CurrentValue >= minIngot,
-            TimeSpan.FromSeconds(30));
-
-        Assert.True(
-            planet.IronOre.CurrentValue >= minOre && planet.IronIngot.CurrentValue >= minIngot,
-            $"Stock did not recover in time: ore={planet.IronOre.CurrentValue} (need {minOre}), " +
-            $"ingot={planet.IronIngot.CurrentValue} (need {minIngot}).");
-        return planet;
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
-        Assert.NotNull(planet);
-        return planet;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Cargo_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
-    }
+    // Handler-invoked resolution (spec §7 testing strategy item 2) — verifies the
+    // handler → stream append path without waiting on the real scheduled envelope.
+    private Task<FleetResponse> MoveAndArriveInstantly(
+        RegisterPlayerResponse registration, Guid fleetId, Guid destinationPlanetId)
+        => _host.LaunchAndArriveInstantly(registration, fleetId, MissionType.Move, destinationPlanetId);
 }

--- a/src/Voidforge.Tests/Cargo/TransportMissionEndToEndTests.cs
+++ b/src/Voidforge.Tests/Cargo/TransportMissionEndToEndTests.cs
@@ -1,8 +1,7 @@
 using Alba;
-using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
-using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Cargo;
@@ -24,7 +23,7 @@ namespace Voidforge.Tests.Cargo;
 [Collection(IntegrationCollection.Name)]
 public sealed class TransportMissionEndToEndTests
 {
-    private static readonly TimeSpan _arrivalTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan _arrivalTimeout = TestTimeouts.Arrival;
 
     private readonly IAlbaHost _host;
 
@@ -36,17 +35,17 @@ public sealed class TransportMissionEndToEndTests
     [Fact]
     public async Task CargoRidesAMoveRoundTripThenManualUnloadRestoresHomeStorage()
     {
-        var owner = await RegisterPlayer();
-        var foreign = await RegisterPlayer();   // a real, owned "foreign" planet to Move to and back from
-        var shipId = await BuildRosterShip(owner);
+        var owner = await _host.RegisterPlayer("TransportE2E_");
+        var foreign = await _host.RegisterPlayer("TransportE2E_");   // a real, owned "foreign" planet to Move to and back from
+        var shipId = await _host.BuildRosterShip(owner);
         // Shipyard/ship construction drains ingots hard in the test host — wait for stock to
         // clear a safety margin above what's about to be loaded (mirrors CargoEndpointTests).
-        await WaitForStock(owner, 150m, 100m);
+        await _host.WaitForStock(owner, 150m, 100m);
 
-        var fleet = await AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
+        var fleet = await _host.AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
         Assert.Equal(100m, fleet.CargoIronOre);
         Assert.Equal(50m, fleet.CargoIronIngot);
-        var afterAssemble = await GetPlanet(owner);
+        var afterAssemble = await _host.GetPlanet(owner);
 
         // Outbound leg: real scheduler, cargo rides along untouched (Move never auto-delivers).
         await LaunchAndAwaitStationedAt(owner, fleet.Id, foreign.HomeworldId);
@@ -56,7 +55,7 @@ public sealed class TransportMissionEndToEndTests
 
         // Manual unload at home: stationed, owner owns both the fleet and the planet, cargo
         // aboard — every guard on POST /api/fleets/{id}/unload is satisfied.
-        var unloaded = await Unload(owner, fleet.Id);
+        var unloaded = await _host.Unload(owner, fleet.Id);
         Assert.Equal(0m, unloaded.CargoIronOre);
         Assert.Equal(0m, unloaded.CargoIronIngot);
 
@@ -66,7 +65,7 @@ public sealed class TransportMissionEndToEndTests
         // symmetric +/- band. Since nothing drains either pool once the roster ship's build
         // completes (no active construction, shipyard idle), the only sound assertion is a
         // lower bound on the delta: the loaded amounts came back, plus whatever accrued.
-        var afterUnload = await GetPlanet(owner);
+        var afterUnload = await _host.GetPlanet(owner);
         Assert.True(
             afterUnload.IronOre.CurrentValue - afterAssemble.IronOre.CurrentValue >= 100m,
             $"Expected at least the 100 ore that was unloaded back: before={afterAssemble.IronOre.CurrentValue}, " +
@@ -83,12 +82,12 @@ public sealed class TransportMissionEndToEndTests
     private async Task<FleetResponse> LaunchAndAwaitStationedAt(
         RegisterPlayerResponse registration, Guid fleetId, Guid destinationPlanetId)
     {
-        var launched = await Launch(registration, fleetId, MissionType.Move, destinationPlanetId);
+        var launched = await _host.Launch(registration, fleetId, MissionType.Move, destinationPlanetId);
         Assert.Equal(FleetStatus.InTransit, launched.Status);
         Assert.Equal(100m, launched.CargoIronOre);
         Assert.Equal(50m, launched.CargoIronIngot);
 
-        var arrived = await PollFleetUntil(
+        var arrived = await _host.PollFleetUntil(
             registration,
             fleetId,
             f => f.Status == FleetStatus.Stationed && f.LocationPlanetId == destinationPlanetId,
@@ -99,204 +98,5 @@ public sealed class TransportMissionEndToEndTests
         Assert.Equal(100m, arrived.CargoIronOre);
         Assert.Equal(50m, arrived.CargoIronIngot);
         return arrived;
-    }
-
-    private async Task<FleetResponse> Launch(
-        RegisterPlayerResponse registration, Guid fleetId, MissionType mission, Guid destinationPlanetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new LaunchMissionRequest(mission, destinationPlanetId)).ToUrl($"/api/fleets/{fleetId}/missions");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task<FleetResponse> Unload(RegisterPlayerResponse registration, Guid fleetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Url($"/api/fleets/{fleetId}/unload");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    private async Task<FleetResponse> PollFleetUntil(
-        RegisterPlayerResponse registration, Guid fleetId, Func<FleetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        FleetResponse fleet;
-        do
-        {
-            fleet = await GetJson<FleetResponse>(registration, $"/api/fleets/{fleetId}");
-            if (predicate(fleet))
-            {
-                return fleet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return fleet;
-    }
-
-    private async Task<FleetResponse> AssembleFleet(
-        RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds, CargoRequest? cargo = null)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds, cargo)).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    // Builds an operational shipyard, queues one CargoVessel (~2s build in the test host), and
-    // polls the roster until it appears. Returns the completed ship's id.
-    private async Task<Guid> BuildRosterShip(RegisterPlayerResponse registration)
-    {
-        await BuildOperationalShipyard(registration);
-        await QueueShip(registration, ShipType.CargoVessel);
-
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
-        do
-        {
-            var roster = await GetRoster(registration);
-            if (roster.Items.Count > 0)
-            {
-                return roster.Items[0].Id;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        throw new InvalidOperationException("Ship did not complete onto the roster in time.");
-    }
-
-    private async Task BuildOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        await _host.Scenario(s =>
-        {
-            s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        await PollUntil(
-            registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRoster(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}/ships?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var roster = await result.ReadAsJsonAsync<PagedResponse<RosterShipResponse>>();
-        Assert.NotNull(roster);
-        return roster;
-    }
-
-    // Waits for the homeworld's stored ore/ingot to reach at least the given amounts.
-    // Necessary because shipyard/ship construction (test-host drain rates) can crush the
-    // ingot pool to near zero for several seconds before production recovers it.
-    private async Task WaitForStock(RegisterPlayerResponse registration, decimal minOre, decimal minIngot)
-    {
-        var planet = await PollUntil(
-            registration,
-            p => p.IronOre.CurrentValue >= minOre && p.IronIngot.CurrentValue >= minIngot,
-            TimeSpan.FromSeconds(30));
-
-        Assert.True(
-            planet.IronOre.CurrentValue >= minOre && planet.IronIngot.CurrentValue >= minIngot,
-            $"Stock did not recover in time: ore={planet.IronOre.CurrentValue} (need {minOre}), " +
-            $"ingot={planet.IronIngot.CurrentValue} (need {minIngot}).");
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-        => await GetJson<PlanetResponse>(registration, $"/api/planets/{registration.HomeworldId}");
-
-    private async Task<T> GetJson<T>(RegisterPlayerResponse registration, string url)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url(url);
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<T>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"TransportE2E_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Cargo/TransportMissionEndpointTests.cs
+++ b/src/Voidforge.Tests/Cargo/TransportMissionEndpointTests.cs
@@ -5,7 +5,7 @@ using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Domain.Events;
 using Voidforge.Api.Endpoints;
-using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Cargo;
@@ -25,10 +25,10 @@ public sealed class TransportMissionEndpointTests
     [Fact]
     public async Task LaunchTransportToForeignDestinationReturns403()
     {
-        var owner = await RegisterPlayer();
-        var foreign = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("Transport_Test_");
+        var foreign = await _host.RegisterPlayer("Transport_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
         await _host.Scenario(s =>
         {
@@ -42,14 +42,14 @@ public sealed class TransportMissionEndpointTests
     [Fact]
     public async Task LaunchTransportToOwnDestinationReturns200AndTransitionsToInTransit()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("Transport_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
         // #51 makes a second owned planet reachable via the API (colonization) — arranged
         // directly here since Transport's same-owner destination requirement needs one now.
         var destinationId = await ColonizeSecondPlanetForOwner(owner);
 
-        var launched = await Launch(owner, fleet.Id, MissionType.Transport, destinationId);
+        var launched = await _host.Launch(owner, fleet.Id, MissionType.Transport, destinationId);
 
         Assert.Equal(FleetStatus.InTransit, launched.Status);
         Assert.Equal(destinationId, launched.DestinationPlanetId);
@@ -59,20 +59,20 @@ public sealed class TransportMissionEndpointTests
     [Fact]
     public async Task HandlerInvokedTransportArrivalCreditsDestinationAndZeroesFleetCargo()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        await WaitForStock(owner, 150m, 100m);
-        var fleet = await AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
+        var owner = await _host.RegisterPlayer("Transport_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        await _host.WaitForStock(owner, 150m, 100m);
+        var fleet = await _host.AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
         var destinationId = await ColonizeSecondPlanetForOwner(owner);   // empty storage: full headroom
 
-        var arrived = await LaunchAndArriveInstantly(owner, fleet.Id, MissionType.Transport, destinationId);
+        var arrived = await _host.LaunchAndArriveInstantly(owner, fleet.Id, MissionType.Transport, destinationId);
 
         Assert.Equal(FleetStatus.Stationed, arrived.Status);
         Assert.Equal(destinationId, arrived.LocationPlanetId);
         Assert.Equal(0m, arrived.CargoIronOre);
         Assert.Equal(0m, arrived.CargoIronIngot);
 
-        var destination = await GetPlanetById(owner, destinationId);
+        var destination = await _host.GetPlanetById(owner, destinationId);
         Assert.Equal(100m, destination.IronOre.CurrentValue);
         Assert.Equal(50m, destination.IronIngot.CurrentValue);
     }
@@ -80,13 +80,13 @@ public sealed class TransportMissionEndpointTests
     [Fact]
     public async Task DuplicateTransportArrivalIsANoOpAndDoesNotDoubleDeliverCargo()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        await WaitForStock(owner, 150m, 100m);
-        var fleet = await AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
+        var owner = await _host.RegisterPlayer("Transport_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        await _host.WaitForStock(owner, 150m, 100m);
+        var fleet = await _host.AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
         var destinationId = await ColonizeSecondPlanetForOwner(owner);   // empty storage: full headroom
 
-        var launched = await Launch(owner, fleet.Id, MissionType.Transport, destinationId);
+        var launched = await _host.Launch(owner, fleet.Id, MissionType.Transport, destinationId);
         Assert.NotNull(launched.ArrivesAt);
         var arrivesAt = launched.ArrivesAt.Value;
 
@@ -96,10 +96,10 @@ public sealed class TransportMissionEndpointTests
             await CompleteFleetArrivalHandler.Handle(new CompleteFleetArrival(fleet.Id, arrivesAt), firstSession);
         }
 
-        var afterFirst = await GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
+        var afterFirst = await _host.GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
         Assert.Equal(0m, afterFirst.CargoIronOre);
         Assert.Equal(0m, afterFirst.CargoIronIngot);
-        var destinationAfterFirst = await GetPlanetById(owner, destinationId);
+        var destinationAfterFirst = await _host.GetPlanetById(owner, destinationId);
         Assert.Equal(100m, destinationAfterFirst.IronOre.CurrentValue);
         Assert.Equal(50m, destinationAfterFirst.IronIngot.CurrentValue);
 
@@ -111,13 +111,13 @@ public sealed class TransportMissionEndpointTests
             await CompleteFleetArrivalHandler.Handle(new CompleteFleetArrival(fleet.Id, arrivesAt), secondSession);
         }
 
-        var afterDuplicate = await GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
+        var afterDuplicate = await _host.GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
         Assert.Equal(FleetStatus.Stationed, afterDuplicate.Status);
         Assert.Equal(destinationId, afterDuplicate.LocationPlanetId);
         Assert.Equal(0m, afterDuplicate.CargoIronOre);
         Assert.Equal(0m, afterDuplicate.CargoIronIngot);
 
-        var destinationAfterDuplicate = await GetPlanetById(owner, destinationId);
+        var destinationAfterDuplicate = await _host.GetPlanetById(owner, destinationId);
         Assert.Equal(destinationAfterFirst.IronOre.CurrentValue, destinationAfterDuplicate.IronOre.CurrentValue);
         Assert.Equal(destinationAfterFirst.IronIngot.CurrentValue, destinationAfterDuplicate.IronIngot.CurrentValue);
     }
@@ -125,15 +125,15 @@ public sealed class TransportMissionEndpointTests
     [Fact]
     public async Task HandlerInvokedTransportArrivalWithFullDestinationStorageLeavesCargoAboard()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        await WaitForStock(owner, 150m, 100m);
-        var fleet = await AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
+        var owner = await _host.RegisterPlayer("Transport_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        await _host.WaitForStock(owner, 150m, 100m);
+        var fleet = await _host.AssembleFleet(owner, [shipId], new CargoRequest(100m, 50m));
         // Colonize the destination already at its storage cap (WorldGenOptions defaults:
         // 10000 ore / 5000 ingot) so AcceptCargoDelivery has zero headroom for either pool.
         var destinationId = await ColonizeSecondPlanetForOwner(owner, ironOreStored: 10_000, ironIngotStored: 5_000);
 
-        var arrived = await LaunchAndArriveInstantly(owner, fleet.Id, MissionType.Transport, destinationId);
+        var arrived = await _host.LaunchAndArriveInstantly(owner, fleet.Id, MissionType.Transport, destinationId);
 
         Assert.Equal(FleetStatus.Stationed, arrived.Status);
         Assert.Equal(destinationId, arrived.LocationPlanetId);
@@ -141,7 +141,7 @@ public sealed class TransportMissionEndpointTests
         Assert.Equal(100m, arrived.CargoIronOre);
         Assert.Equal(50m, arrived.CargoIronIngot);
 
-        var destination = await GetPlanetById(owner, destinationId);
+        var destination = await _host.GetPlanetById(owner, destinationId);
         Assert.Equal(10_000m, destination.IronOre.CurrentValue);
         Assert.Equal(5_000m, destination.IronIngot.CurrentValue);
     }
@@ -149,49 +149,19 @@ public sealed class TransportMissionEndpointTests
     [Fact]
     public async Task HandlerInvokedMoveArrivalWithCargoLeavesCargoUntouched()
     {
-        var owner = await RegisterPlayer();
-        var beta = await RegisterPlayer();   // another colonized planet to Move to
-        var shipId = await BuildRosterShip(owner);
-        await WaitForStock(owner, 150m, 100m);
-        var fleet = await AssembleFleet(owner, [shipId], new CargoRequest(80m, 20m));
+        var owner = await _host.RegisterPlayer("Transport_Test_");
+        var beta = await _host.RegisterPlayer("Transport_Test_");   // another colonized planet to Move to
+        var shipId = await _host.BuildRosterShip(owner);
+        await _host.WaitForStock(owner, 150m, 100m);
+        var fleet = await _host.AssembleFleet(owner, [shipId], new CargoRequest(80m, 20m));
 
-        var arrived = await LaunchAndArriveInstantly(owner, fleet.Id, MissionType.Move, beta.HomeworldId);
+        var arrived = await _host.LaunchAndArriveInstantly(owner, fleet.Id, MissionType.Move, beta.HomeworldId);
 
         Assert.Equal(FleetStatus.Stationed, arrived.Status);
         Assert.Equal(beta.HomeworldId, arrived.LocationPlanetId);
         // Move never auto-delivers cargo (spec §2.4) — only Transport/Colonize do.
         Assert.Equal(80m, arrived.CargoIronOre);
         Assert.Equal(20m, arrived.CargoIronIngot);
-    }
-
-    private async Task<FleetResponse> Launch(
-        RegisterPlayerResponse registration, Guid fleetId, MissionType mission, Guid destinationPlanetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new LaunchMissionRequest(mission, destinationPlanetId)).ToUrl($"/api/fleets/{fleetId}/missions");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    // Launches the mission, then resolves arrival via the handler-invoked pattern (spec §7
-    // testing strategy item 2), bypassing the real scheduled envelope.
-    private async Task<FleetResponse> LaunchAndArriveInstantly(
-        RegisterPlayerResponse registration, Guid fleetId, MissionType mission, Guid destinationPlanetId)
-    {
-        var launched = await Launch(registration, fleetId, mission, destinationPlanetId);
-        Assert.NotNull(launched.ArrivesAt);
-
-        var store = _host.Services.GetRequiredService<IDocumentStore>();
-        await using var session = store.LightweightSession();
-        await CompleteFleetArrivalHandler.Handle(new CompleteFleetArrival(fleetId, launched.ArrivesAt.Value), session);
-
-        return await GetJson<FleetResponse>(registration, $"/api/fleets/{fleetId}");
     }
 
     // Test arrangement, not production code: #51 (colonization) is the API path that will
@@ -215,158 +185,5 @@ public sealed class TransportMissionEndpointTests
         await session.SaveChangesAsync();
 
         return planetId;
-    }
-
-    private async Task<FleetResponse> AssembleFleet(
-        RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds, CargoRequest? cargo = null)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds, cargo)).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    // Builds an operational shipyard, queues one CargoVessel (~2s build in the test host),
-    // and polls the roster until it appears. Returns the completed ship's id.
-    private async Task<Guid> BuildRosterShip(RegisterPlayerResponse registration)
-    {
-        await BuildOperationalShipyard(registration);
-        await QueueShip(registration, ShipType.CargoVessel);
-
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
-        do
-        {
-            var roster = await GetRoster(registration);
-            if (roster.Items.Count > 0)
-            {
-                return roster.Items[0].Id;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        throw new InvalidOperationException("Ship did not complete onto the roster in time.");
-    }
-
-    private async Task BuildOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        await _host.Scenario(s =>
-        {
-            s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        await PollUntil(
-            registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRoster(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}/ships?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var roster = await result.ReadAsJsonAsync<PagedResponse<RosterShipResponse>>();
-        Assert.NotNull(roster);
-        return roster;
-    }
-
-    // Waits for the homeworld's stored ore/ingot to reach at least the given amounts.
-    // Necessary because shipyard/ship construction (test-host drain rates) can crush the
-    // ingot pool to near zero for several seconds before production recovers it.
-    private async Task WaitForStock(RegisterPlayerResponse registration, decimal minOre, decimal minIngot)
-    {
-        var planet = await PollUntil(
-            registration,
-            p => p.IronOre.CurrentValue >= minOre && p.IronIngot.CurrentValue >= minIngot,
-            TimeSpan.FromSeconds(30));
-
-        Assert.True(
-            planet.IronOre.CurrentValue >= minOre && planet.IronIngot.CurrentValue >= minIngot,
-            $"Stock did not recover in time: ore={planet.IronOre.CurrentValue} (need {minOre}), " +
-            $"ingot={planet.IronIngot.CurrentValue} (need {minIngot}).");
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-        => await GetPlanetById(registration, registration.HomeworldId);
-
-    private async Task<PlanetResponse> GetPlanetById(RegisterPlayerResponse asWhom, Guid planetId)
-        => await GetJson<PlanetResponse>(asWhom, $"/api/planets/{planetId}");
-
-    private async Task<T> GetJson<T>(RegisterPlayerResponse registration, string url)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url(url);
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<T>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Transport_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Colonize/ClaimRaceTests.cs
+++ b/src/Voidforge.Tests/Colonize/ClaimRaceTests.cs
@@ -2,11 +2,10 @@ using Alba;
 using JasperFx;
 using Marten;
 using Microsoft.Extensions.DependencyInjection;
-using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Domain.Events;
 using Voidforge.Api.Endpoints;
-using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Colonize;
@@ -49,13 +48,13 @@ public sealed class ClaimRaceTests
     [Fact]
     public async Task SequentialRegistrationStillSucceedsAndOwnsItsHomeworld()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("ClaimRace_Test_");
 
         Assert.NotEqual(Guid.Empty, registration.PlayerId);
         Assert.StartsWith("vf_", registration.ApiKey, StringComparison.Ordinal);
         Assert.NotEqual(Guid.Empty, registration.HomeworldId);
 
-        var homeworld = await GetPlanetById(registration, registration.HomeworldId);
+        var homeworld = await _host.GetPlanetById(registration, registration.HomeworldId);
         Assert.Equal(registration.PlayerId, homeworld.OwnerId);
         Assert.True(homeworld.IronOre.CurrentValue > 0);
         Assert.True(homeworld.IronIngot.CurrentValue > 0);
@@ -64,7 +63,8 @@ public sealed class ClaimRaceTests
     [Fact]
     public async Task FiveConcurrentRegistrationsAllSucceedWithDistinctHomeworldsOwnedByTheirRegistrants()
     {
-        var registrations = await Task.WhenAll(Enumerable.Range(0, 5).Select(_ => RegisterPlayer()));
+        var registrations = await Task.WhenAll(
+            Enumerable.Range(0, 5).Select(_ => _host.RegisterPlayer("ClaimRace_Test_")));
 
         // All five requests carry distinct auto-generated names (RegisterPlayer's Guid
         // suffix) and none may collide on a homeworld — the guarded claim (#51, closes #19)
@@ -74,7 +74,7 @@ public sealed class ClaimRaceTests
 
         foreach (var registration in registrations)
         {
-            var homeworld = await GetPlanetById(registration, registration.HomeworldId);
+            var homeworld = await _host.GetPlanetById(registration, registration.HomeworldId);
             Assert.Equal(registration.PlayerId, homeworld.OwnerId);
         }
     }
@@ -95,8 +95,8 @@ public sealed class ClaimRaceTests
     [Fact]
     public async Task ContestedPlanetAppendLosesWithConcurrencyExceptionDeterministically()
     {
-        var registration = await RegisterPlayer();
-        var planetId = await UncolonizedPlanetId(registration);
+        var registration = await _host.RegisterPlayer("ClaimRace_Test_");
+        var planetId = await _host.FindUncolonizedPlanet(registration);
 
         var store = _host.Services.GetRequiredService<IDocumentStore>();
 
@@ -119,9 +119,9 @@ public sealed class ClaimRaceTests
     [Fact]
     public async Task TwoFleetsRacingToColonizeTheSamePlanetYieldExactlyOneWinnerWithConservedCargo()
     {
-        var alpha = await RegisterPlayer();
-        var beta = await RegisterPlayer();
-        var destinationId = await UncolonizedPlanetId(alpha);
+        var alpha = await _host.RegisterPlayer("ClaimRace_Test_");
+        var beta = await _host.RegisterPlayer("ClaimRace_Test_");
+        var destinationId = await _host.FindUncolonizedPlanet(alpha);
 
         var (alphaFleet, alphaArrivesAt) = await BuildAndLaunchColonizeFleet(alpha, destinationId);
         var (betaFleet, betaArrivesAt) = await BuildAndLaunchColonizeFleet(beta, destinationId);
@@ -134,7 +134,7 @@ public sealed class ClaimRaceTests
             ArriveWithRetry(store, alphaFleet.Id, alphaArrivesAt),
             ArriveWithRetry(store, betaFleet.Id, betaArrivesAt));
 
-        var destination = await GetPlanetById(alpha, destinationId);
+        var destination = await _host.GetPlanetById(alpha, destinationId);
         Assert.True(
             destination.OwnerId == alpha.PlayerId || destination.OwnerId == beta.PlayerId,
             "Exactly one racer must own the destination planet after both arrivals resolve.");
@@ -145,8 +145,8 @@ public sealed class ClaimRaceTests
         var winnerFleetId = winnerIsAlpha ? alphaFleet.Id : betaFleet.Id;
         var loserFleetId = winnerIsAlpha ? betaFleet.Id : alphaFleet.Id;
 
-        var winnerFleet = await GetJson<FleetResponse>(winner, $"/api/fleets/{winnerFleetId}");
-        var loserFleet = await GetJson<FleetResponse>(loser, $"/api/fleets/{loserFleetId}");
+        var winnerFleet = await _host.GetJson<FleetResponse>(winner, $"/api/fleets/{winnerFleetId}");
+        var loserFleet = await _host.GetJson<FleetResponse>(loser, $"/api/fleets/{loserFleetId}");
 
         // Winner: the Colony Ship is consumed (each fleet carried exactly one Colony Ship, so
         // it is trivially also the oldest — ConsumeColonyShip's deterministic pick is proven
@@ -208,216 +208,15 @@ public sealed class ClaimRaceTests
     private async Task<(FleetResponse Fleet, DateTimeOffset ArrivesAt)> BuildAndLaunchColonizeFleet(
         RegisterPlayerResponse registration, Guid destinationId)
     {
-        var colonyShipId = await BuildRosterShip(registration, ShipType.ColonyShip);
-        var cargoVesselId = await BuildRosterShip(registration, ShipType.CargoVessel);
-        await WaitForStock(registration, 150m, 100m);
-        var fleet = await AssembleFleet(
+        var colonyShipId = await _host.BuildRosterShip(registration, ShipType.ColonyShip);
+        var cargoVesselId = await _host.BuildRosterShip(registration, ShipType.CargoVessel);
+        await _host.WaitForStock(registration, 150m, 100m);
+        var fleet = await _host.AssembleFleet(
             registration, [colonyShipId, cargoVesselId], new CargoRequest(_raceCargoIronOre, _raceCargoIronIngot));
 
-        var launched = await Launch(registration, fleet.Id, MissionType.Colonize, destinationId);
+        var launched = await _host.Launch(registration, fleet.Id, MissionType.Colonize, destinationId);
         Assert.NotNull(launched.ArrivesAt);
 
         return (launched, launched.ArrivesAt.Value);
-    }
-
-    private async Task<FleetResponse> Launch(
-        RegisterPlayerResponse registration, Guid fleetId, MissionType mission, Guid destinationPlanetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new LaunchMissionRequest(mission, destinationPlanetId)).ToUrl($"/api/fleets/{fleetId}/missions");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task<FleetResponse> AssembleFleet(
-        RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds, CargoRequest? cargo = null)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds, cargo)).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    // Builds an operational shipyard (once per homeworld — reused across calls) and queues
-    // one ship of the requested type, polling the roster until a ship absent from the
-    // pre-queue roster snapshot appears. Mirrors ColonizeMissionTests.BuildRosterShip so a
-    // homeworld can accumulate both a Colony Ship and a Cargo Vessel across two calls.
-    private async Task<Guid> BuildRosterShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var before = (await GetRoster(registration)).Items.Select(i => i.Id).ToHashSet();
-
-        await EnsureOperationalShipyard(registration);
-        await QueueShip(registration, type);
-
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
-        do
-        {
-            var roster = await GetRoster(registration);
-            var added = roster.Items.Where(i => !before.Contains(i.Id)).ToList();
-            if (added.Count > 0)
-            {
-                return added[0].Id;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        throw new InvalidOperationException("Ship did not complete onto the roster in time.");
-    }
-
-    private async Task EnsureOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        var planet = await GetPlanet(registration);
-        if (!planet.Buildings.Any(b => b.Type == BuildingType.Shipyard))
-        {
-            await _host.Scenario(s =>
-            {
-                s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                    .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-                s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-                s.StatusCodeShouldBe(200);
-            });
-        }
-
-        await PollUntil(
-            registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRoster(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}/ships?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var roster = await result.ReadAsJsonAsync<PagedResponse<RosterShipResponse>>();
-        Assert.NotNull(roster);
-        return roster;
-    }
-
-    // Waits for the homeworld's stored ore/ingot to reach at least the given amounts.
-    // Necessary because shipyard/ship construction (test-host drain rates) can crush the
-    // ingot pool to near zero for several seconds before production recovers it.
-    private async Task WaitForStock(RegisterPlayerResponse registration, decimal minOre, decimal minIngot)
-    {
-        var planet = await PollUntil(
-            registration,
-            p => p.IronOre.CurrentValue >= minOre && p.IronIngot.CurrentValue >= minIngot,
-            TimeSpan.FromSeconds(30));
-
-        Assert.True(
-            planet.IronOre.CurrentValue >= minOre && planet.IronIngot.CurrentValue >= minIngot,
-            $"Stock did not recover in time: ore={planet.IronOre.CurrentValue} (need {minOre}), " +
-            $"ingot={planet.IronIngot.CurrentValue} (need {minIngot}).");
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-        => await GetPlanetById(registration, registration.HomeworldId);
-
-    // Finds an uncolonized planet through the public solar-systems listing (the real
-    // player-visible read path, per #51 spec §7 item 4) rather than a raw store query: walks
-    // systems in listing order and returns the first planet whose owner is null. Relies on
-    // the IntegrationCollection's serialized test execution (no concurrent writer between
-    // this scan and the subsequent Launch calls) — must not be copied into a parallel context.
-    private async Task<Guid> UncolonizedPlanetId(RegisterPlayerResponse asWhom)
-    {
-        var systems = await GetJson<PagedResponse<SolarSystemResponse>>(asWhom, "/api/solar-systems?pageSize=200");
-
-        foreach (var system in systems.Items)
-        {
-            foreach (var planetId in system.PlanetIds)
-            {
-                var planet = await GetPlanetById(asWhom, planetId);
-                if (planet.OwnerId is null)
-                {
-                    return planet.Id;
-                }
-            }
-        }
-
-        throw new InvalidOperationException("No uncolonized planet found across the listed solar systems.");
-    }
-
-    private async Task<PlanetResponse> GetPlanetById(RegisterPlayerResponse asWhom, Guid planetId)
-        => await GetJson<PlanetResponse>(asWhom, $"/api/planets/{planetId}");
-
-    private async Task<T> GetJson<T>(RegisterPlayerResponse registration, string url)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url(url);
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<T>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"ClaimRace_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Colonize/ColonizeMissionTests.cs
+++ b/src/Voidforge.Tests/Colonize/ColonizeMissionTests.cs
@@ -5,7 +5,7 @@ using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Domain.Events;
 using Voidforge.Api.Endpoints;
-using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Colonize;
@@ -27,10 +27,10 @@ public sealed class ColonizeMissionTests
     [Fact]
     public async Task LaunchColonizeWithoutAColonyShipAboardReturns409()
     {
-        var owner = await RegisterPlayer();
-        var foreign = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner, ShipType.CargoVessel);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("Colonize_Test_");
+        var foreign = await _host.RegisterPlayer("Colonize_Test_");
+        var shipId = await _host.BuildRosterShip(owner, ShipType.CargoVessel);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
         await _host.Scenario(s =>
         {
@@ -44,12 +44,12 @@ public sealed class ColonizeMissionTests
     [Fact]
     public async Task LaunchColonizeWithAColonyShipAboardReturns200AndTransitionsToInTransit()
     {
-        var owner = await RegisterPlayer();
-        var colonyShipId = await BuildRosterShip(owner, ShipType.ColonyShip);
-        var fleet = await AssembleFleet(owner, [colonyShipId]);
+        var owner = await _host.RegisterPlayer("Colonize_Test_");
+        var colonyShipId = await _host.BuildRosterShip(owner, ShipType.ColonyShip);
+        var fleet = await _host.AssembleFleet(owner, [colonyShipId]);
         var destinationId = await UncolonizedPlanetId();
 
-        var launched = await Launch(owner, fleet.Id, MissionType.Colonize, destinationId);
+        var launched = await _host.Launch(owner, fleet.Id, MissionType.Colonize, destinationId);
 
         Assert.Equal(FleetStatus.InTransit, launched.Status);
         Assert.Equal(destinationId, launched.DestinationPlanetId);
@@ -59,14 +59,14 @@ public sealed class ColonizeMissionTests
     [Fact]
     public async Task HandlerInvokedColonizeArrivalAtAnUncolonizedPlanetClaimsItConsumesTheColonyShipAndDeliversCargo()
     {
-        var owner = await RegisterPlayer();
-        var colonyShipId = await BuildRosterShip(owner, ShipType.ColonyShip);
-        var cargoVesselId = await BuildRosterShip(owner, ShipType.CargoVessel);
-        await WaitForStock(owner, 150m, 100m);
-        var fleet = await AssembleFleet(owner, [colonyShipId, cargoVesselId], new CargoRequest(100m, 50m));
+        var owner = await _host.RegisterPlayer("Colonize_Test_");
+        var colonyShipId = await _host.BuildRosterShip(owner, ShipType.ColonyShip);
+        var cargoVesselId = await _host.BuildRosterShip(owner, ShipType.CargoVessel);
+        await _host.WaitForStock(owner, 150m, 100m);
+        var fleet = await _host.AssembleFleet(owner, [colonyShipId, cargoVesselId], new CargoRequest(100m, 50m));
         var destinationId = await UncolonizedPlanetId();
 
-        var arrived = await LaunchAndArriveInstantly(owner, fleet.Id, MissionType.Colonize, destinationId);
+        var arrived = await _host.LaunchAndArriveInstantly(owner, fleet.Id, MissionType.Colonize, destinationId);
 
         Assert.Equal(FleetStatus.Stationed, arrived.Status);
         Assert.Equal(destinationId, arrived.LocationPlanetId);
@@ -75,7 +75,7 @@ public sealed class ColonizeMissionTests
         Assert.Equal(0m, arrived.CargoIronOre);
         Assert.Equal(0m, arrived.CargoIronIngot);
 
-        var destination = await GetPlanetById(owner, destinationId);
+        var destination = await _host.GetPlanetById(owner, destinationId);
         Assert.Equal(owner.PlayerId, destination.OwnerId);
         Assert.Equal(100m, destination.IronOre.CurrentValue);
         Assert.Equal(50m, destination.IronIngot.CurrentValue);
@@ -84,14 +84,14 @@ public sealed class ColonizeMissionTests
     [Fact]
     public async Task HandlerInvokedColonizeArrivalAtAnAlreadyOwnedPlanetLeavesOwnerShipAndCargoIntactAndFleetStationed()
     {
-        var owner = await RegisterPlayer();
-        var colonyShipId = await BuildRosterShip(owner, ShipType.ColonyShip);
-        var cargoVesselId = await BuildRosterShip(owner, ShipType.CargoVessel);
-        await WaitForStock(owner, 150m, 100m);
-        var fleet = await AssembleFleet(owner, [colonyShipId, cargoVesselId], new CargoRequest(100m, 50m));
+        var owner = await _host.RegisterPlayer("Colonize_Test_");
+        var colonyShipId = await _host.BuildRosterShip(owner, ShipType.ColonyShip);
+        var cargoVesselId = await _host.BuildRosterShip(owner, ShipType.CargoVessel);
+        await _host.WaitForStock(owner, 150m, 100m);
+        var fleet = await _host.AssembleFleet(owner, [colonyShipId, cargoVesselId], new CargoRequest(100m, 50m));
         var destinationId = await ColonizeSecondPlanetForOwner(owner);   // already owned before arrival
 
-        var arrived = await LaunchAndArriveInstantly(owner, fleet.Id, MissionType.Colonize, destinationId);
+        var arrived = await _host.LaunchAndArriveInstantly(owner, fleet.Id, MissionType.Colonize, destinationId);
 
         Assert.Equal(FleetStatus.Stationed, arrived.Status);
         Assert.Equal(destinationId, arrived.LocationPlanetId);
@@ -100,7 +100,7 @@ public sealed class ColonizeMissionTests
         Assert.Equal(100m, arrived.CargoIronOre);                     // cargo intact: never delivered
         Assert.Equal(50m, arrived.CargoIronIngot);
 
-        var destination = await GetPlanetById(owner, destinationId);
+        var destination = await _host.GetPlanetById(owner, destinationId);
         Assert.Equal(owner.PlayerId, destination.OwnerId);   // owner unchanged
         Assert.Equal(0m, destination.IronOre.CurrentValue);
         Assert.Equal(0m, destination.IronIngot.CurrentValue);
@@ -109,14 +109,14 @@ public sealed class ColonizeMissionTests
     [Fact]
     public async Task DuplicateColonizeArrivalIsANoOpAndDoesNotDoubleClaimOrDoubleDeliverCargo()
     {
-        var owner = await RegisterPlayer();
-        var colonyShipId = await BuildRosterShip(owner, ShipType.ColonyShip);
-        var cargoVesselId = await BuildRosterShip(owner, ShipType.CargoVessel);
-        await WaitForStock(owner, 150m, 100m);
-        var fleet = await AssembleFleet(owner, [colonyShipId, cargoVesselId], new CargoRequest(100m, 50m));
+        var owner = await _host.RegisterPlayer("Colonize_Test_");
+        var colonyShipId = await _host.BuildRosterShip(owner, ShipType.ColonyShip);
+        var cargoVesselId = await _host.BuildRosterShip(owner, ShipType.CargoVessel);
+        await _host.WaitForStock(owner, 150m, 100m);
+        var fleet = await _host.AssembleFleet(owner, [colonyShipId, cargoVesselId], new CargoRequest(100m, 50m));
         var destinationId = await UncolonizedPlanetId();
 
-        var launched = await Launch(owner, fleet.Id, MissionType.Colonize, destinationId);
+        var launched = await _host.Launch(owner, fleet.Id, MissionType.Colonize, destinationId);
         Assert.NotNull(launched.ArrivesAt);
         var arrivesAt = launched.ArrivesAt.Value;
 
@@ -126,11 +126,11 @@ public sealed class ColonizeMissionTests
             await CompleteFleetArrivalHandler.Handle(new CompleteFleetArrival(fleet.Id, arrivesAt), firstSession);
         }
 
-        var afterFirst = await GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
+        var afterFirst = await _host.GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
         Assert.DoesNotContain(afterFirst.Ships, s => s.Id == colonyShipId);
         Assert.Equal(0m, afterFirst.CargoIronOre);
         Assert.Equal(0m, afterFirst.CargoIronIngot);
-        var destinationAfterFirst = await GetPlanetById(owner, destinationId);
+        var destinationAfterFirst = await _host.GetPlanetById(owner, destinationId);
         Assert.Equal(owner.PlayerId, destinationAfterFirst.OwnerId);
         Assert.Equal(100m, destinationAfterFirst.IronOre.CurrentValue);
         Assert.Equal(50m, destinationAfterFirst.IronIngot.CurrentValue);
@@ -144,47 +144,17 @@ public sealed class ColonizeMissionTests
             await CompleteFleetArrivalHandler.Handle(new CompleteFleetArrival(fleet.Id, arrivesAt), secondSession);
         }
 
-        var afterDuplicate = await GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
+        var afterDuplicate = await _host.GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
         Assert.Equal(FleetStatus.Stationed, afterDuplicate.Status);
         Assert.Equal(destinationId, afterDuplicate.LocationPlanetId);
         Assert.Equal(afterFirst.Ships.Select(s => s.Id).OrderBy(id => id), afterDuplicate.Ships.Select(s => s.Id).OrderBy(id => id));
         Assert.Equal(0m, afterDuplicate.CargoIronOre);
         Assert.Equal(0m, afterDuplicate.CargoIronIngot);
 
-        var destinationAfterDuplicate = await GetPlanetById(owner, destinationId);
+        var destinationAfterDuplicate = await _host.GetPlanetById(owner, destinationId);
         Assert.Equal(destinationAfterFirst.OwnerId, destinationAfterDuplicate.OwnerId);
         Assert.Equal(destinationAfterFirst.IronOre.CurrentValue, destinationAfterDuplicate.IronOre.CurrentValue);
         Assert.Equal(destinationAfterFirst.IronIngot.CurrentValue, destinationAfterDuplicate.IronIngot.CurrentValue);
-    }
-
-    private async Task<FleetResponse> Launch(
-        RegisterPlayerResponse registration, Guid fleetId, MissionType mission, Guid destinationPlanetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new LaunchMissionRequest(mission, destinationPlanetId)).ToUrl($"/api/fleets/{fleetId}/missions");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    // Launches the mission, then resolves arrival via the handler-invoked pattern (spec §7
-    // testing strategy item 2), bypassing the real scheduled envelope.
-    private async Task<FleetResponse> LaunchAndArriveInstantly(
-        RegisterPlayerResponse registration, Guid fleetId, MissionType mission, Guid destinationPlanetId)
-    {
-        var launched = await Launch(registration, fleetId, mission, destinationPlanetId);
-        Assert.NotNull(launched.ArrivesAt);
-
-        var store = _host.Services.GetRequiredService<IDocumentStore>();
-        await using var session = store.LightweightSession();
-        await CompleteFleetArrivalHandler.Handle(new CompleteFleetArrival(fleetId, launched.ArrivesAt.Value), session);
-
-        return await GetJson<FleetResponse>(registration, $"/api/fleets/{fleetId}");
     }
 
     // Raw query for a planet nobody owns yet — the Colonize mission's natural destination.
@@ -223,168 +193,5 @@ public sealed class ColonizeMissionTests
         await session.SaveChangesAsync();
 
         return planetId;
-    }
-
-    private async Task<FleetResponse> AssembleFleet(
-        RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds, CargoRequest? cargo = null)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds, cargo)).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    // Builds an operational shipyard (once per homeworld — reused across calls) and queues
-    // one ship of the requested type, polling the roster until a ship absent from the
-    // pre-queue roster snapshot appears. Extends TransportMissionEndpointTests'
-    // CargoVessel-only helper with a ShipType parameter and before/after roster diffing so
-    // a homeworld can accumulate both a Colony Ship and a Cargo Vessel across two calls.
-    private async Task<Guid> BuildRosterShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var before = (await GetRoster(registration)).Items.Select(i => i.Id).ToHashSet();
-
-        await EnsureOperationalShipyard(registration);
-        await QueueShip(registration, type);
-
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
-        do
-        {
-            var roster = await GetRoster(registration);
-            var added = roster.Items.Where(i => !before.Contains(i.Id)).ToList();
-            if (added.Count > 0)
-            {
-                return added[0].Id;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        throw new InvalidOperationException("Ship did not complete onto the roster in time.");
-    }
-
-    private async Task EnsureOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        var planet = await GetPlanet(registration);
-        if (!planet.Buildings.Any(b => b.Type == BuildingType.Shipyard))
-        {
-            await _host.Scenario(s =>
-            {
-                s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                    .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-                s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-                s.StatusCodeShouldBe(200);
-            });
-        }
-
-        await PollUntil(
-            registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRoster(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}/ships?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var roster = await result.ReadAsJsonAsync<PagedResponse<RosterShipResponse>>();
-        Assert.NotNull(roster);
-        return roster;
-    }
-
-    // Waits for the homeworld's stored ore/ingot to reach at least the given amounts.
-    // Necessary because shipyard/ship construction (test-host drain rates) can crush the
-    // ingot pool to near zero for several seconds before production recovers it.
-    private async Task WaitForStock(RegisterPlayerResponse registration, decimal minOre, decimal minIngot)
-    {
-        var planet = await PollUntil(
-            registration,
-            p => p.IronOre.CurrentValue >= minOre && p.IronIngot.CurrentValue >= minIngot,
-            TimeSpan.FromSeconds(30));
-
-        Assert.True(
-            planet.IronOre.CurrentValue >= minOre && planet.IronIngot.CurrentValue >= minIngot,
-            $"Stock did not recover in time: ore={planet.IronOre.CurrentValue} (need {minOre}), " +
-            $"ingot={planet.IronIngot.CurrentValue} (need {minIngot}).");
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-        => await GetPlanetById(registration, registration.HomeworldId);
-
-    private async Task<PlanetResponse> GetPlanetById(RegisterPlayerResponse asWhom, Guid planetId)
-        => await GetJson<PlanetResponse>(asWhom, $"/api/planets/{planetId}");
-
-    private async Task<T> GetJson<T>(RegisterPlayerResponse registration, string url)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url(url);
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<T>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Colonize_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Colonize/FullLoopEndToEndTests.cs
+++ b/src/Voidforge.Tests/Colonize/FullLoopEndToEndTests.cs
@@ -1,8 +1,7 @@
 using Alba;
-using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
-using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Colonize;
@@ -29,7 +28,7 @@ public sealed class FullLoopEndToEndTests
     private const decimal _transportCargoIronOre = 100m;
     private const decimal _transportCargoIronIngot = 50m;
 
-    private static readonly TimeSpan _arrivalTimeout = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan _arrivalTimeout = TestTimeouts.FullLoopArrival;
 
     private readonly IAlbaHost _host;
 
@@ -41,8 +40,8 @@ public sealed class FullLoopEndToEndTests
     [Fact]
     public async Task EconomyToShipsToExpansionToSupplyingTheColonyCompletesTheFullLoop()
     {
-        var settler = await RegisterPlayer();
-        var homeworld = await GetPlanetById(settler, settler.HomeworldId);
+        var settler = await _host.RegisterPlayer("FullLoopE2E_");
+        var homeworld = await _host.GetPlanetById(settler, settler.HomeworldId);
 
         var destinationId = await ColonizeAnUncolonizedPlanetInAnotherSystem(settler, homeworld.SolarSystemId);
         await SupplyTheColonyViaTransport(settler, destinationId);
@@ -54,20 +53,20 @@ public sealed class FullLoopEndToEndTests
     // Vessel at the new colony. Returns the colonized planet's id for the Transport leg.
     private async Task<Guid> ColonizeAnUncolonizedPlanetInAnotherSystem(RegisterPlayerResponse settler, Guid homeSystemId)
     {
-        var colonyShipId = await BuildRosterShip(settler, ShipType.ColonyShip);
-        var cargoVesselId = await BuildRosterShip(settler, ShipType.CargoVessel);
-        await WaitForStock(settler, 150m, 100m);
+        var colonyShipId = await _host.BuildRosterShip(settler, ShipType.ColonyShip);
+        var cargoVesselId = await _host.BuildRosterShip(settler, ShipType.CargoVessel);
+        await _host.WaitForStock(settler, 150m, 100m);
 
-        var colonizeFleet = await AssembleFleet(
+        var colonizeFleet = await _host.AssembleFleet(
             settler, [colonyShipId, cargoVesselId], new CargoRequest(_colonizeCargoIronOre, _colonizeCargoIronIngot));
-        var destinationId = await UncolonizedPlanetInAnotherSystem(settler, homeSystemId);
+        var destinationId = await _host.FindUncolonizedPlanet(settler, excludeSystemId: homeSystemId);
 
-        var launchedColonize = await Launch(settler, colonizeFleet.Id, MissionType.Colonize, destinationId);
+        var launchedColonize = await _host.Launch(settler, colonizeFleet.Id, MissionType.Colonize, destinationId);
         Assert.Equal(FleetStatus.InTransit, launchedColonize.Status);
         Assert.Equal(destinationId, launchedColonize.DestinationPlanetId);
         Assert.Equal(MissionType.Colonize, launchedColonize.Mission);
 
-        var arrivedColonize = await PollFleetUntil(
+        var arrivedColonize = await _host.PollFleetUntil(
             settler,
             colonizeFleet.Id,
             f => f.Status == FleetStatus.Stationed && f.LocationPlanetId == destinationId,
@@ -80,7 +79,7 @@ public sealed class FullLoopEndToEndTests
         Assert.Equal(0m, arrivedColonize.CargoIronOre);           // auto-unloaded into the colony
         Assert.Equal(0m, arrivedColonize.CargoIronIngot);
 
-        var colony = await GetPlanetById(settler, destinationId);
+        var colony = await _host.GetPlanetById(settler, destinationId);
         Assert.Equal(settler.PlayerId, colony.OwnerId);
         // Planet.Claim seeds zero stores AND zero production rate (a fresh colony has no
         // buildings), so the exact-equality assertion is safe: nothing accrues between the
@@ -92,7 +91,7 @@ public sealed class FullLoopEndToEndTests
 
         // Disband the surviving Cargo Vessel at the new colony (cargo is already empty, so
         // D11's cargo-aboard guard doesn't block it).
-        var disbanded = await Disband(settler, colonizeFleet.Id);
+        var disbanded = await _host.Disband(settler, colonizeFleet.Id);
         Assert.Equal(FleetStatus.Disbanded, disbanded.Status);
 
         return destinationId;
@@ -104,18 +103,18 @@ public sealed class FullLoopEndToEndTests
     // planet via Move). Still a zero-production colony, so exact-equality delivery math holds.
     private async Task SupplyTheColonyViaTransport(RegisterPlayerResponse settler, Guid destinationId)
     {
-        var secondCargoVesselId = await BuildRosterShip(settler, ShipType.CargoVessel);
-        await WaitForStock(settler, 150m, 100m);
+        var secondCargoVesselId = await _host.BuildRosterShip(settler, ShipType.CargoVessel);
+        await _host.WaitForStock(settler, 150m, 100m);
 
-        var transportFleet = await AssembleFleet(
+        var transportFleet = await _host.AssembleFleet(
             settler, [secondCargoVesselId], new CargoRequest(_transportCargoIronOre, _transportCargoIronIngot));
 
-        var launchedTransport = await Launch(settler, transportFleet.Id, MissionType.Transport, destinationId);
+        var launchedTransport = await _host.Launch(settler, transportFleet.Id, MissionType.Transport, destinationId);
         Assert.Equal(FleetStatus.InTransit, launchedTransport.Status);
         Assert.Equal(destinationId, launchedTransport.DestinationPlanetId);
         Assert.Equal(MissionType.Transport, launchedTransport.Mission);
 
-        var arrivedTransport = await PollFleetUntil(
+        var arrivedTransport = await _host.PollFleetUntil(
             settler,
             transportFleet.Id,
             f => f.Status == FleetStatus.Stationed && f.LocationPlanetId == destinationId,
@@ -126,250 +125,9 @@ public sealed class FullLoopEndToEndTests
         Assert.Equal(0m, arrivedTransport.CargoIronOre);      // auto-delivered on arrival
         Assert.Equal(0m, arrivedTransport.CargoIronIngot);
 
-        var colonyAfterTransport = await GetPlanetById(settler, destinationId);
+        var colonyAfterTransport = await _host.GetPlanetById(settler, destinationId);
         Assert.Equal(settler.PlayerId, colonyAfterTransport.OwnerId);
         Assert.Equal(_colonizeCargoIronOre + _transportCargoIronOre, colonyAfterTransport.IronOre.CurrentValue);
         Assert.Equal(_colonizeCargoIronIngot + _transportCargoIronIngot, colonyAfterTransport.IronIngot.CurrentValue);
-    }
-
-    private async Task<FleetResponse> Launch(
-        RegisterPlayerResponse registration, Guid fleetId, MissionType mission, Guid destinationPlanetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new LaunchMissionRequest(mission, destinationPlanetId)).ToUrl($"/api/fleets/{fleetId}/missions");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task<FleetResponse> AssembleFleet(
-        RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds, CargoRequest? cargo = null)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds, cargo)).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    private async Task<FleetResponse> Disband(RegisterPlayerResponse registration, Guid fleetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Url($"/api/fleets/{fleetId}/disband");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    private async Task<FleetResponse> PollFleetUntil(
-        RegisterPlayerResponse registration, Guid fleetId, Func<FleetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        FleetResponse fleet;
-        do
-        {
-            fleet = await GetJson<FleetResponse>(registration, $"/api/fleets/{fleetId}");
-            if (predicate(fleet))
-            {
-                return fleet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return fleet;
-    }
-
-    // Builds an operational shipyard (once per homeworld — reused across calls) and queues one
-    // ship of the requested type, polling the roster until a ship absent from the pre-queue
-    // roster snapshot appears. Mirrors ColonizeMissionTests/ClaimRaceTests' BuildRosterShip so a
-    // homeworld can accumulate a Colony Ship, then a Cargo Vessel, then (after the first fleet's
-    // ships have left the roster via assembly) a second Cargo Vessel across three calls.
-    private async Task<Guid> BuildRosterShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var before = (await GetRoster(registration)).Items.Select(i => i.Id).ToHashSet();
-
-        await EnsureOperationalShipyard(registration);
-        await QueueShip(registration, type);
-
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
-        do
-        {
-            var roster = await GetRoster(registration);
-            var added = roster.Items.Where(i => !before.Contains(i.Id)).ToList();
-            if (added.Count > 0)
-            {
-                return added[0].Id;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        throw new InvalidOperationException("Ship did not complete onto the roster in time.");
-    }
-
-    private async Task EnsureOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        var planet = await GetPlanet(registration);
-        if (!planet.Buildings.Any(b => b.Type == BuildingType.Shipyard))
-        {
-            await _host.Scenario(s =>
-            {
-                s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                    .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-                s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-                s.StatusCodeShouldBe(200);
-            });
-        }
-
-        await PollUntil(
-            registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRoster(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}/ships?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var roster = await result.ReadAsJsonAsync<PagedResponse<RosterShipResponse>>();
-        Assert.NotNull(roster);
-        return roster;
-    }
-
-    // Waits for the homeworld's stored ore/ingot to reach at least the given amounts.
-    // Necessary because shipyard/ship construction (test-host drain rates) can crush the ingot
-    // pool to near zero for several seconds before production recovers it.
-    private async Task WaitForStock(RegisterPlayerResponse registration, decimal minOre, decimal minIngot)
-    {
-        var planet = await PollUntil(
-            registration,
-            p => p.IronOre.CurrentValue >= minOre && p.IronIngot.CurrentValue >= minIngot,
-            TimeSpan.FromSeconds(30));
-
-        Assert.True(
-            planet.IronOre.CurrentValue >= minOre && planet.IronIngot.CurrentValue >= minIngot,
-            $"Stock did not recover in time: ore={planet.IronOre.CurrentValue} (need {minOre}), " +
-            $"ingot={planet.IronIngot.CurrentValue} (need {minIngot}).");
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-        => await GetPlanetById(registration, registration.HomeworldId);
-
-    // Finds an uncolonized planet in a DIFFERENT solar system than the caller's homeworld,
-    // through the public solar-systems listing (the real player-visible read path, matching
-    // ClaimRaceTests.UncolonizedPlanetId) rather than a raw store query. Relies on the
-    // IntegrationCollection's serialized test execution (no concurrent writer between this scan
-    // and the subsequent launches) — must not be copied into a parallel context.
-    private async Task<Guid> UncolonizedPlanetInAnotherSystem(RegisterPlayerResponse asWhom, Guid homeSystemId)
-    {
-        var systems = await GetJson<PagedResponse<SolarSystemResponse>>(asWhom, "/api/solar-systems?pageSize=200");
-
-        foreach (var system in systems.Items)
-        {
-            if (system.Id == homeSystemId)
-            {
-                continue;
-            }
-
-            foreach (var planetId in system.PlanetIds)
-            {
-                var planet = await GetPlanetById(asWhom, planetId);
-                if (planet.OwnerId is null)
-                {
-                    return planet.Id;
-                }
-            }
-        }
-
-        throw new InvalidOperationException("No uncolonized planet found in another solar system across the listed solar systems.");
-    }
-
-    private async Task<PlanetResponse> GetPlanetById(RegisterPlayerResponse asWhom, Guid planetId)
-        => await GetJson<PlanetResponse>(asWhom, $"/api/planets/{planetId}");
-
-    private async Task<T> GetJson<T>(RegisterPlayerResponse registration, string url)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url(url);
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<T>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"FullLoopE2E_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Concurrency/FleetConcurrencyTests.cs
+++ b/src/Voidforge.Tests/Concurrency/FleetConcurrencyTests.cs
@@ -3,6 +3,7 @@ using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
 using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Concurrency;
@@ -25,9 +26,9 @@ public sealed class FleetConcurrencyTests
     [Fact]
     public async Task ConcurrentAssemblesOfTheSameShipYieldExactlyOneFleet()
     {
-        var registration = await RegisterPlayer();
-        await BuildOperationalShipyard(registration);
-        var shipId = await BuildRosterShip(registration);
+        var registration = await _host.RegisterPlayer("FleetConcurrency_");
+        await _host.EnsureOperationalShipyard(registration);
+        var shipId = await _host.BuildRosterShip(registration);
 
         var attempts = await Task.WhenAll(
             TryAssemble(registration, [shipId]),
@@ -38,7 +39,7 @@ public sealed class FleetConcurrencyTests
         Assert.Equal(1, attempts.Count(status => status == 200));
         Assert.Equal(1, attempts.Count(status => status == 409));
 
-        var fleets = await GetJson<PagedResponse<FleetSummaryResponse>>(registration, "/api/fleets");
+        var fleets = await _host.GetJson<PagedResponse<FleetSummaryResponse>>(registration, "/api/fleets");
         var fleet = Assert.Single(fleets.Items);
         Assert.Equal(1, fleet.ShipCount);
     }
@@ -46,10 +47,10 @@ public sealed class FleetConcurrencyTests
     [Fact]
     public async Task ConcurrentLaunchesYieldExactlyOneDeparture()
     {
-        var owner = await RegisterPlayer();
-        var beta = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("FleetConcurrency_");
+        var beta = await _host.RegisterPlayer("FleetConcurrency_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
         var attempts = await Task.WhenAll(
             TryLaunch(owner, fleet.Id, beta.HomeworldId),
@@ -61,7 +62,7 @@ public sealed class FleetConcurrencyTests
         Assert.Equal(1, attempts.Count(status => status == 200));
         Assert.Equal(1, attempts.Count(status => status == 409));
 
-        var fetched = await GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
+        var fetched = await _host.GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
         Assert.Equal(FleetStatus.InTransit, fetched.Status);
         Assert.NotNull(fetched.ArrivesAt);
     }
@@ -69,10 +70,10 @@ public sealed class FleetConcurrencyTests
     [Fact]
     public async Task ConcurrentDisbandsOfTheSameFleetYieldExactlyOneSuccess()
     {
-        var registration = await RegisterPlayer();
-        await BuildOperationalShipyard(registration);
-        var shipId = await BuildRosterShip(registration);
-        var fleet = await AssembleFleet(registration, [shipId]);
+        var registration = await _host.RegisterPlayer("FleetConcurrency_");
+        await _host.EnsureOperationalShipyard(registration);
+        var shipId = await _host.BuildRosterShip(registration);
+        var fleet = await _host.AssembleFleet(registration, [shipId]);
 
         var attempts = await Task.WhenAll(
             TryDisband(registration, fleet.Id),
@@ -84,24 +85,19 @@ public sealed class FleetConcurrencyTests
         Assert.Equal(1, attempts.Count(status => status == 200));
         Assert.Equal(1, attempts.Count(status => status is 409 or 404));
 
-        var roster = await GetRoster(registration);
+        var roster = await _host.GetRoster(registration);
         Assert.Single(roster.Items, s => s.Id == shipId);
     }
 
     // Fire an Assemble command and return only its status code (no auto-assert).
-    private async Task<int> TryAssemble(RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds)).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.IgnoreStatusCode();
-        });
-
-        return result.Context.Response.StatusCode;
-    }
+    private Task<int> TryAssemble(RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds)
+        => _host.PostForStatus(
+            registration,
+            $"/api/planets/{registration.HomeworldId}/fleets",
+            new AssembleFleetRequest(shipIds));
 
     // Fire a Disband command and return only its status code (no auto-assert).
+    // Stays hand-rolled: disband POSTs without a JSON body, which PostForStatus always sends.
     private async Task<int> TryDisband(RegisterPlayerResponse registration, Guid fleetId)
     {
         var result = await _host.Scenario(s =>
@@ -115,160 +111,9 @@ public sealed class FleetConcurrencyTests
     }
 
     // Fire a Launch (Move) command and return only its status code (no auto-assert).
-    private async Task<int> TryLaunch(RegisterPlayerResponse registration, Guid fleetId, Guid destinationPlanetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new LaunchMissionRequest(MissionType.Move, destinationPlanetId))
-                .ToUrl($"/api/fleets/{fleetId}/missions");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.IgnoreStatusCode();
-        });
-
-        return result.Context.Response.StatusCode;
-    }
-
-    private async Task<FleetResponse> AssembleFleet(RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds)).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    // Builds an operational shipyard, queues one CargoVessel (~2s build), and polls the
-    // roster until it appears. Returns the completed ship's id.
-    private async Task<Guid> BuildRosterShip(RegisterPlayerResponse registration)
-    {
-        await BuildOperationalShipyard(registration);
-        await QueueShip(registration, ShipType.CargoVessel);
-
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
-        do
-        {
-            var roster = await GetRoster(registration);
-            if (roster.Items.Count > 0)
-            {
-                return roster.Items[0].Id;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        throw new InvalidOperationException("Ship did not complete onto the roster in time.");
-    }
-
-    private async Task BuildOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        await _host.Scenario(s =>
-        {
-            s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        await PollUntil(
+    private Task<int> TryLaunch(RegisterPlayerResponse registration, Guid fleetId, Guid destinationPlanetId)
+        => _host.PostForStatus(
             registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRoster(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}/ships?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var roster = await result.ReadAsJsonAsync<PagedResponse<RosterShipResponse>>();
-        Assert.NotNull(roster);
-        return roster;
-    }
-
-    private async Task<T> GetJson<T>(RegisterPlayerResponse registration, string url)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url(url);
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<T>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
-        Assert.NotNull(planet);
-        return planet;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"FleetConcurrency_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
-    }
+            $"/api/fleets/{fleetId}/missions",
+            new LaunchMissionRequest(MissionType.Move, destinationPlanetId));
 }

--- a/src/Voidforge.Tests/Concurrency/SameStreamConcurrencyTests.cs
+++ b/src/Voidforge.Tests/Concurrency/SameStreamConcurrencyTests.cs
@@ -2,6 +2,7 @@ using Alba;
 using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Concurrency;
@@ -23,7 +24,7 @@ public sealed class SameStreamConcurrencyTests
     [Fact]
     public async Task ConcurrentCommandsOnOnePlanetConflictAs409NotServerError()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Concurrency_");
 
         // Fire batches of concurrent Queue commands at the same planet stream. With optimistic
         // concurrency a colliding append fails cleanly (409); without it the appends collide on the
@@ -50,14 +51,14 @@ public sealed class SameStreamConcurrencyTests
 
         // Consistency: exactly the winning appends landed — no lost or duplicated writes. (No shipyard,
         // so every queued ship stays Queued and none complete.)
-        var planet = await GetPlanet(registration);
+        var planet = await _host.GetPlanet(registration);
         Assert.Equal(successes, planet.QueueLength);
     }
 
     [Fact]
     public async Task HttpCommandsRacingAScheduledCompletionRemainConsistent()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Concurrency_");
 
         // Start a Drill: its construction schedules a CompleteBuildingConstruction (~5s) on this
         // planet stream — the "race partner" for the HTTP appends below.
@@ -83,10 +84,10 @@ public sealed class SameStreamConcurrencyTests
 
         // Eventual consistency: the scheduled building completion was applied — never dropped by a
         // conflict (the handler retried) — and every winning queue append landed exactly once.
-        var settled = await PollUntil(
+        var settled = await _host.PollUntil(
             registration,
             p => p.Buildings.Any(b => b.Type == BuildingType.Drill && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(30));
+            TestTimeouts.StockRecovery);
 
         Assert.Contains(settled.Buildings, b => b.Type == BuildingType.Drill && b.Status == BuildingStatus.Operational);
         Assert.Equal(successes, settled.QueueLength);
@@ -104,64 +105,9 @@ public sealed class SameStreamConcurrencyTests
     }
 
     // Fire a Queue command and return only its status code (no auto-assert).
-    private async Task<int> QueueShipStatus(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(ShipType.CargoVessel))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.IgnoreStatusCode();
-        });
-
-        return result.Context.Response.StatusCode;
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
-        Assert.NotNull(planet);
-        return planet;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Concurrency_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
-    }
+    private Task<int> QueueShipStatus(RegisterPlayerResponse registration)
+        => _host.PostForStatus(
+            registration,
+            $"/api/planets/{registration.HomeworldId}/ship-queue",
+            new QueueShipRequest(ShipType.CargoVessel));
 }

--- a/src/Voidforge.Tests/Construction/BuildingConstructionCompletionTests.cs
+++ b/src/Voidforge.Tests/Construction/BuildingConstructionCompletionTests.cs
@@ -2,6 +2,7 @@ using Alba;
 using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Construction;
@@ -19,8 +20,8 @@ public sealed class BuildingConstructionCompletionTests
     [Fact]
     public async Task PlacedGeneratorBecomesOperationalAndRaisesGeneration()
     {
-        var registration = await RegisterPlayer();
-        var before = await GetPlanet(registration);
+        var registration = await _host.RegisterPlayer("Construct_Test_");
+        var before = await _host.GetPlanet(registration);
         Assert.Equal(100m, before.Energy.GenerationMw);   // homeworld generator only
 
         await _host.Scenario(s =>
@@ -34,63 +35,14 @@ public sealed class BuildingConstructionCompletionTests
         // Wolverine's scheduler polls ~every 5s; the build duration is short (test config).
         // Poll until the durable CompleteBuildingConstruction message fires and the slot
         // flips Operational.
-        var operational = await PollUntil(
+        var operational = await _host.PollUntil(
             registration,
             p => p.Buildings[^1].Status == BuildingStatus.Operational,
-            timeout: TimeSpan.FromSeconds(20));
+            timeout: TestTimeouts.Completion);
 
         Assert.Equal(BuildingStatus.Operational, operational.Buildings[^1].Status);
         Assert.Null(operational.Buildings[^1].EtaCompletionUtc);
         // Completion switched on the second generator's output: 100 -> 200 MW.
         Assert.Equal(200m, operational.Energy.GenerationMw);
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        // Test wall-clock timeout — unrelated to the app's injected TimeProvider.
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;   // final state; the caller's assertions report the failure
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
-        Assert.NotNull(planet);
-        return planet;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Construct_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Energy/EnergyGridTests.cs
+++ b/src/Voidforge.Tests/Energy/EnergyGridTests.cs
@@ -1,6 +1,5 @@
 using Alba;
-using Voidforge.Api.Auth;
-using Voidforge.Api.Endpoints;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Energy;
@@ -18,9 +17,9 @@ public sealed class EnergyGridTests
     [Fact]
     public async Task HomeworldEnergyBlockReflectsStartingBuildings()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Energy_Test_");
 
-        var planet = await GetPlanet(registration);
+        var planet = await _host.GetPlanet(registration);
 
         // Starting composition: Generator (100 MW) vs Drill (20) + Refinery (30).
         Assert.Equal(100m, planet.Energy.GenerationMw);
@@ -39,15 +38,15 @@ public sealed class EnergyGridTests
     [Fact]
     public async Task HomeworldRefineryProducesIngotsAtTwiceOreConsumption()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Energy_Test_");
 
-        var first = await GetPlanet(registration);
+        var first = await _host.GetPlanet(registration);
         // Homeworld: drill inflow 10, refinery demand 5, m=1 => net ore +5/s, ingots +10/s.
         Assert.Equal(5m, first.IronOre.Rate);
         Assert.Equal(10m, first.IronIngot.Rate);
 
         await Task.Delay(1000);
-        var second = await GetPlanet(registration);
+        var second = await _host.GetPlanet(registration);
 
         // Both pools rise (refineries convert the inflow, not the stored buffer, so net ore
         // stays positive); ingots climb at twice the effective ore consumption.
@@ -55,33 +54,5 @@ public sealed class EnergyGridTests
             $"Expected ingots to rise: {first.IronIngot.CurrentValue} -> {second.IronIngot.CurrentValue}");
         Assert.True(second.IronOre.CurrentValue > first.IronOre.CurrentValue,
             $"Expected net ore to rise: {first.IronOre.CurrentValue} -> {second.IronOre.CurrentValue}");
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
-        Assert.NotNull(planet);
-        return planet;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Energy_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Fleets/FleetEndpointTests.cs
+++ b/src/Voidforge.Tests/Fleets/FleetEndpointTests.cs
@@ -3,6 +3,7 @@ using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
 using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Fleets;
@@ -20,7 +21,7 @@ public sealed class FleetEndpointTests
     [Fact]
     public async Task AssembleWithEmptyShipIdsReturns400()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Fleet_Test_");
         await _host.Scenario(s =>
         {
             s.Post.Json(new AssembleFleetRequest([])).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
@@ -32,7 +33,7 @@ public sealed class FleetEndpointTests
     [Fact]
     public async Task AssembleWithNullShipIdsReturns400()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Fleet_Test_");
         await _host.Scenario(s =>
         {
             s.Post.Json(new { }).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
@@ -44,7 +45,7 @@ public sealed class FleetEndpointTests
     [Fact]
     public async Task AssembleUnknownPlanetReturns404()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Fleet_Test_");
         await _host.Scenario(s =>
         {
             s.Post.Json(new AssembleFleetRequest([Guid.NewGuid()])).ToUrl($"/api/planets/{Guid.NewGuid()}/fleets");
@@ -56,7 +57,7 @@ public sealed class FleetEndpointTests
     [Fact]
     public async Task AssembleShipNotOnRosterReturns409()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Fleet_Test_");
         await _host.Scenario(s =>
         {
             s.Post.Json(new AssembleFleetRequest([Guid.NewGuid()])).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
@@ -68,9 +69,9 @@ public sealed class FleetEndpointTests
     [Fact]
     public async Task AssembleSomeoneElsesShipsReturns403()
     {
-        var owner = await RegisterPlayer();          // builds the ships
-        var intruder = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);   // shipyard + 1 CargoVessel, waits for roster
+        var owner = await _host.RegisterPlayer("Fleet_Test_");          // builds the ships
+        var intruder = await _host.RegisterPlayer("Fleet_Test_");
+        var shipId = await _host.BuildRosterShip(owner);   // shipyard + 1 CargoVessel, waits for roster
 
         await _host.Scenario(s =>
         {
@@ -83,7 +84,7 @@ public sealed class FleetEndpointTests
     [Fact]
     public async Task DisbandUnknownFleetReturns404()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Fleet_Test_");
         await _host.Scenario(s =>
         {
             s.Post.Url($"/api/fleets/{Guid.NewGuid()}/disband");
@@ -95,10 +96,10 @@ public sealed class FleetEndpointTests
     [Fact]
     public async Task DisbandForeignFleetReturns403()
     {
-        var owner = await RegisterPlayer();
-        var intruder = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("Fleet_Test_");
+        var intruder = await _host.RegisterPlayer("Fleet_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
         await _host.Scenario(s =>
         {
@@ -111,10 +112,10 @@ public sealed class FleetEndpointTests
     [Fact]
     public async Task AssembleRosterShipsProducesAStationedFleet()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
+        var owner = await _host.RegisterPlayer("Fleet_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
 
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
         Assert.Equal(FleetStatus.Stationed, fleet.Status);
         Assert.Equal(owner.HomeworldId, fleet.LocationPlanetId);
@@ -123,16 +124,16 @@ public sealed class FleetEndpointTests
         Assert.Equal(shipId, fleetShip.Id);
 
         // The ship left the planet's roster.
-        var roster = await GetRoster(owner);
+        var roster = await _host.GetRoster(owner);
         Assert.DoesNotContain(roster.Items, r => r.Id == shipId);
     }
 
     [Fact]
     public async Task DisbandReturnsShipsToTheRoster()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("Fleet_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
         var result = await _host.Scenario(s =>
         {
@@ -146,16 +147,16 @@ public sealed class FleetEndpointTests
         Assert.Equal(FleetStatus.Disbanded, disbanded.Status);
         Assert.Empty(disbanded.Ships);
 
-        var roster = await GetRoster(owner);
+        var roster = await _host.GetRoster(owner);
         Assert.Contains(roster.Items, r => r.Id == shipId);
     }
 
     [Fact]
     public async Task DisbandTwiceReturns409()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("Fleet_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
         await _host.Scenario(s =>
         {
@@ -175,15 +176,15 @@ public sealed class FleetEndpointTests
     [Fact]
     public async Task OwnFleetsListIsPaginatedAndScopedToCaller()
     {
-        var a = await RegisterPlayer();
-        var b = await RegisterPlayer();
-        var shipId = await BuildRosterShip(a);
-        var fleet = await AssembleFleet(a, [shipId]);
+        var a = await _host.RegisterPlayer("Fleet_Test_");
+        var b = await _host.RegisterPlayer("Fleet_Test_");
+        var shipId = await _host.BuildRosterShip(a);
+        var fleet = await _host.AssembleFleet(a, [shipId]);
 
-        var page = await GetJson<PagedResponse<FleetSummaryResponse>>(b, "/api/fleets");
+        var page = await _host.GetJson<PagedResponse<FleetSummaryResponse>>(b, "/api/fleets");
         Assert.DoesNotContain(page.Items, f => f.Id == fleet.Id);   // b sees only own fleets
 
-        var own = await GetJson<PagedResponse<FleetSummaryResponse>>(a, "/api/fleets");
+        var own = await _host.GetJson<PagedResponse<FleetSummaryResponse>>(a, "/api/fleets");
         var summary = Assert.Single(own.Items, f => f.Id == fleet.Id);
         Assert.Equal(1, summary.ShipCount);
     }
@@ -191,12 +192,12 @@ public sealed class FleetEndpointTests
     [Fact]
     public async Task FleetDetailIsUniverseVisible()
     {
-        var a = await RegisterPlayer();
-        var b = await RegisterPlayer();
-        var shipId = await BuildRosterShip(a);
-        var fleet = await AssembleFleet(a, [shipId]);
+        var a = await _host.RegisterPlayer("Fleet_Test_");
+        var b = await _host.RegisterPlayer("Fleet_Test_");
+        var shipId = await _host.BuildRosterShip(a);
+        var fleet = await _host.AssembleFleet(a, [shipId]);
 
-        var detail = await GetJson<FleetResponse>(b, $"/api/fleets/{fleet.Id}");
+        var detail = await _host.GetJson<FleetResponse>(b, $"/api/fleets/{fleet.Id}");
         Assert.Equal(fleet.Id, detail.Id);
         Assert.Single(detail.Ships);
     }
@@ -204,184 +205,26 @@ public sealed class FleetEndpointTests
     [Fact]
     public async Task PlanetFleetsListsStationedFleets()
     {
-        var a = await RegisterPlayer();
-        var shipId = await BuildRosterShip(a);
-        var fleet = await AssembleFleet(a, [shipId]);
+        var a = await _host.RegisterPlayer("Fleet_Test_");
+        var shipId = await _host.BuildRosterShip(a);
+        var fleet = await _host.AssembleFleet(a, [shipId]);
 
-        var page = await GetJson<PagedResponse<FleetSummaryResponse>>(a, $"/api/planets/{a.HomeworldId}/fleets");
+        var page = await _host.GetJson<PagedResponse<FleetSummaryResponse>>(a, $"/api/planets/{a.HomeworldId}/fleets");
         Assert.Contains(page.Items, f => f.Id == fleet.Id);
     }
 
     [Fact]
     public async Task DisbandedFleetsAreExcludedFromListsUnlessRequested()
     {
-        var a = await RegisterPlayer();
-        var shipId = await BuildRosterShip(a);
-        var fleet = await AssembleFleet(a, [shipId]);
-        await Disband(a, fleet.Id);
+        var a = await _host.RegisterPlayer("Fleet_Test_");
+        var shipId = await _host.BuildRosterShip(a);
+        var fleet = await _host.AssembleFleet(a, [shipId]);
+        await _host.Disband(a, fleet.Id);
 
-        var live = await GetJson<PagedResponse<FleetSummaryResponse>>(a, "/api/fleets");
+        var live = await _host.GetJson<PagedResponse<FleetSummaryResponse>>(a, "/api/fleets");
         Assert.DoesNotContain(live.Items, f => f.Id == fleet.Id);
 
-        var history = await GetJson<PagedResponse<FleetSummaryResponse>>(a, "/api/fleets?status=Disbanded");
+        var history = await _host.GetJson<PagedResponse<FleetSummaryResponse>>(a, "/api/fleets?status=Disbanded");
         Assert.Contains(history.Items, f => f.Id == fleet.Id);
-    }
-
-    // Builds an operational shipyard, queues one CargoVessel (~2s build), and polls the
-    // roster until it appears. Returns the completed ship's id.
-    private async Task<Guid> BuildRosterShip(RegisterPlayerResponse registration)
-    {
-        await BuildOperationalShipyard(registration);
-        await QueueShip(registration, ShipType.CargoVessel);
-
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
-        do
-        {
-            var roster = await GetRoster(registration);
-            if (roster.Items.Count > 0)
-            {
-                return roster.Items[0].Id;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        throw new InvalidOperationException("Ship did not complete onto the roster in time.");
-    }
-
-    private async Task<FleetResponse> AssembleFleet(RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds)).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    private async Task<FleetResponse> Disband(RegisterPlayerResponse registration, Guid fleetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Url($"/api/fleets/{fleetId}/disband");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    private async Task<T> GetJson<T>(RegisterPlayerResponse registration, string url)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url(url);
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<T>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task BuildOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        await _host.Scenario(s =>
-        {
-            s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        await PollUntil(
-            registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRoster(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}/ships?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var roster = await result.ReadAsJsonAsync<PagedResponse<RosterShipResponse>>();
-        Assert.NotNull(roster);
-        return roster;
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
-        Assert.NotNull(planet);
-        return planet;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Fleet_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Fleets/FleetRoundTripTests.cs
+++ b/src/Voidforge.Tests/Fleets/FleetRoundTripTests.cs
@@ -1,8 +1,6 @@
 using Alba;
-using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
-using Voidforge.Api.Endpoints;
-using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Fleets;
@@ -22,168 +20,23 @@ public sealed class FleetRoundTripTests
     [Fact]
     public async Task ShipsRoundTripThroughAFleet()
     {
-        var registration = await RegisterPlayer();
-        await BuildOperationalShipyard(registration);
-        var ship1 = await BuildRosterShip(registration);
-        var ship2 = await BuildRosterShip(registration);
+        var registration = await _host.RegisterPlayer("FleetRT_");
+        await _host.EnsureOperationalShipyard(registration);
+        var ship1 = await _host.BuildRosterShip(registration);
+        var ship2 = await _host.BuildRosterShip(registration);
 
-        var rosterBefore = await GetRoster(registration);
+        var rosterBefore = await _host.GetRoster(registration);
         Assert.Equal(2, rosterBefore.TotalItems);
 
-        var fleet = await AssembleFleet(registration, [ship1, ship2]);
+        var fleet = await _host.AssembleFleet(registration, [ship1, ship2]);
         Assert.Equal(FleetStatus.Stationed, fleet.Status);
         Assert.Equal(2, fleet.Ships.Count);
-        Assert.Equal(0, (await GetRoster(registration)).TotalItems);  // roster shrank
+        Assert.Equal(0, (await _host.GetRoster(registration)).TotalItems);  // roster shrank
 
-        await Disband(registration, fleet.Id);
+        await _host.Disband(registration, fleet.Id);
 
-        var rosterAfter = await GetRoster(registration);
+        var rosterAfter = await _host.GetRoster(registration);
         Assert.Equal(2, rosterAfter.TotalItems);                      // ships returned
         Assert.All(rosterAfter.Items, s => Assert.Equal(registration.PlayerId, s.OwnerId));
-    }
-
-    // Builds an operational shipyard, queues one CargoVessel (~2s build), and polls the
-    // roster until a new ship appears. Returns the completed ship's id.
-    private async Task<Guid> BuildRosterShip(RegisterPlayerResponse registration)
-    {
-        var before = await GetRoster(registration);
-        await QueueShip(registration, ShipType.CargoVessel);
-
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
-        do
-        {
-            var roster = await GetRoster(registration);
-            var newShip = roster.Items.FirstOrDefault(s => before.Items.All(b => b.Id != s.Id));
-            if (newShip is not null)
-            {
-                return newShip.Id;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        throw new InvalidOperationException("Ship did not complete onto the roster in time.");
-    }
-
-    private async Task<FleetResponse> AssembleFleet(RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds)).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    private async Task<FleetResponse> Disband(RegisterPlayerResponse registration, Guid fleetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Url($"/api/fleets/{fleetId}/disband");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    private async Task BuildOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        await _host.Scenario(s =>
-        {
-            s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        await PollUntil(
-            registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRoster(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}/ships?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var roster = await result.ReadAsJsonAsync<PagedResponse<RosterShipResponse>>();
-        Assert.NotNull(roster);
-        return roster;
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
-        Assert.NotNull(planet);
-        return planet;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"FleetRT_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Pagination/SolarSystemPaginationTests.cs
+++ b/src/Voidforge.Tests/Pagination/SolarSystemPaginationTests.cs
@@ -2,6 +2,7 @@ using Alba;
 using Voidforge.Api.Auth;
 using Voidforge.Api.Endpoints;
 using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Pagination;
@@ -19,7 +20,7 @@ public sealed class SolarSystemPaginationTests
     [Fact]
     public async Task ReturnsPagedEnvelopeOrderedByName()
     {
-        var apiKey = await RegisterAndGetKey();
+        var apiKey = (await _host.RegisterPlayer("Pg_Test_")).ApiKey;
 
         var page = await GetPage(apiKey, "?page=1&pageSize=5");
 
@@ -37,7 +38,7 @@ public sealed class SolarSystemPaginationTests
     [Fact]
     public async Task SecondPageHasPreviousAndDiffersFromFirst()
     {
-        var apiKey = await RegisterAndGetKey();
+        var apiKey = (await _host.RegisterPlayer("Pg_Test_")).ApiKey;
 
         var first = await GetPage(apiKey, "?page=1&pageSize=5");
         var second = await GetPage(apiKey, "?page=2&pageSize=5");
@@ -50,7 +51,7 @@ public sealed class SolarSystemPaginationTests
     [Fact]
     public async Task ClampsPageSizeToMaximum()
     {
-        var apiKey = await RegisterAndGetKey();
+        var apiKey = (await _host.RegisterPlayer("Pg_Test_")).ApiKey;
 
         var page = await GetPage(apiKey, "?pageSize=500");
 
@@ -63,7 +64,7 @@ public sealed class SolarSystemPaginationTests
     [InlineData("?page=-1")]
     public async Task RejectsInvalidParameters(string query)
     {
-        var apiKey = await RegisterAndGetKey();
+        var apiKey = (await _host.RegisterPlayer("Pg_Test_")).ApiKey;
 
         await _host.Scenario(s =>
         {
@@ -85,19 +86,5 @@ public sealed class SolarSystemPaginationTests
         var page = await result.ReadAsJsonAsync<PagedResponse<SolarSystemResponse>>();
         Assert.NotNull(page);
         return page;
-    }
-
-    private async Task<string> RegisterAndGetKey()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Pg_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response.ApiKey;
     }
 }

--- a/src/Voidforge.Tests/Planets/PlanetEndpointTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetEndpointTests.cs
@@ -3,6 +3,7 @@ using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
 using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Planets;
@@ -20,7 +21,7 @@ public sealed class PlanetEndpointTests
     [Fact]
     public async Task GetSolarSystemsReturnsSeededSystems()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Planet_Test_");
 
         var result = await _host.Scenario(s =>
         {
@@ -47,7 +48,7 @@ public sealed class PlanetEndpointTests
     [Fact]
     public async Task GetPlanetByIdReturnsSeededPlanet()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Planet_Test_");
 
         var planetResult = await _host.Scenario(s =>
         {
@@ -72,7 +73,7 @@ public sealed class PlanetEndpointTests
     [Fact]
     public async Task GetPlanetByIdReturnsComputedValuesNotRawCheckpoint()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Planet_Test_");
 
         var planetResult = await _host.Scenario(s =>
         {
@@ -93,7 +94,7 @@ public sealed class PlanetEndpointTests
     [Fact]
     public async Task GetPlanetByIdReturnsStartingBuildings()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Planet_Test_");
 
         var planetResult = await _host.Scenario(s =>
         {
@@ -115,7 +116,7 @@ public sealed class PlanetEndpointTests
     [Fact]
     public async Task GetPlanetByNonExistentIdReturns404()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Planet_Test_");
 
         await _host.Scenario(s =>
         {
@@ -133,19 +134,5 @@ public sealed class PlanetEndpointTests
             s.Get.Url($"/api/planets/{Guid.NewGuid()}");
             s.StatusCodeShouldBe(401);
         });
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Planet_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Ships/ShipConstructionCompletionTests.cs
+++ b/src/Voidforge.Tests/Ships/ShipConstructionCompletionTests.cs
@@ -2,7 +2,7 @@ using Alba;
 using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
-using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Ships;
@@ -20,40 +20,40 @@ public sealed class ShipConstructionCompletionTests
     [Fact]
     public async Task QueuedShipsBuildInParallelAndCompleteOntoRoster()
     {
-        var registration = await RegisterPlayer();
-        await BuildOperationalShipyard(registration);
+        var registration = await _host.RegisterPlayer("ShipE2E_");
+        await _host.EnsureOperationalShipyard(registration);
 
         // Queue 4 ships: 3 start (capacity 3 for one shipyard), 1 waits.
         for (var i = 0; i < 4; i++)
         {
-            await QueueShip(registration, ShipType.CargoVessel);
+            await _host.QueueShip(registration, ShipType.CargoVessel);
         }
 
-        var afterQueue = await GetPlanet(registration);
+        var afterQueue = await _host.GetPlanet(registration);
         Assert.Equal(3, afterQueue.ActiveBuilds);
         Assert.Equal(1, afterQueue.QueueLength);
 
         // Wait for all four to complete (2s builds + scheduler poll; the 4th starts after one frees).
-        var done = await PollUntil(registration, p => p.ShipCount == 4, TimeSpan.FromSeconds(40));
+        var done = await _host.PollUntil(registration, p => p.ShipCount == 4, TestTimeouts.QueueDrain);
         Assert.Equal(4, done.ShipCount);
         Assert.Equal(0, done.ActiveBuilds);
         Assert.Equal(0, done.QueueLength);
 
         // Roster is readable and paginated.
-        var roster = await GetRoster(registration);
+        var roster = await _host.GetRoster(registration);
         Assert.Equal(4, roster.TotalItems);
     }
 
     [Fact]
     public async Task CancellingAnActiveBuildAutoStartsTheQueuedOneAndStaleCompletionNoOps()
     {
-        var registration = await RegisterPlayer();
-        await BuildOperationalShipyard(registration);
+        var registration = await _host.RegisterPlayer("ShipE2E_");
+        await _host.EnsureOperationalShipyard(registration);
 
         var builds = new List<ShipBuildResponse>();
         for (var i = 0; i < 4; i++)
         {
-            builds.Add(await QueueShip(registration, ShipType.CargoVessel));
+            builds.Add(await _host.QueueShip(registration, ShipType.CargoVessel));
         }
 
         // Cancel one active build immediately (before it completes). The 4th (queued) auto-starts;
@@ -62,43 +62,12 @@ public sealed class ShipConstructionCompletionTests
         var active = builds.First(b => b.Status == ShipBuildStatus.Active);
         await CancelBuild(registration, active.Id);
 
-        var done = await PollUntil(registration, p => p.ShipCount == 3 && p.ActiveBuilds == 0, TimeSpan.FromSeconds(40));
+        var done = await _host.PollUntil(registration, p => p.ShipCount == 3 && p.ActiveBuilds == 0, TestTimeouts.QueueDrain);
         Assert.Equal(3, done.ShipCount);        // 4 queued − 1 cancelled = 3 completed
         Assert.Equal(0, done.QueueLength);
 
-        var roster = await GetRoster(registration);
+        var roster = await _host.GetRoster(registration);
         Assert.DoesNotContain(roster.Items, r => r.Id == active.Id);   // stale completion did not resurrect it
-    }
-
-    private async Task BuildOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        await _host.Scenario(s =>
-        {
-            s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        await PollUntil(
-            registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
     }
 
     private async Task CancelBuild(RegisterPlayerResponse registration, Guid buildId)
@@ -109,67 +78,5 @@ public sealed class ShipConstructionCompletionTests
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
             s.StatusCodeShouldBe(200);
         });
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRoster(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}/ships?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var roster = await result.ReadAsJsonAsync<PagedResponse<RosterShipResponse>>();
-        Assert.NotNull(roster);
-        return roster;
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
-        Assert.NotNull(planet);
-        return planet;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"ShipE2E_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Ships/ShipEndpointTests.cs
+++ b/src/Voidforge.Tests/Ships/ShipEndpointTests.cs
@@ -3,6 +3,7 @@ using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
 using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Ships;
@@ -20,7 +21,7 @@ public sealed class ShipEndpointTests
     [Fact]
     public async Task QueueShipIsAcceptedEvenWithNoShipyard()
     {
-        var registration = await RegisterPlayer();   // homeworld has no shipyard
+        var registration = await _host.RegisterPlayer("Ship_Test_");   // homeworld has no shipyard
 
         var result = await _host.Scenario(s =>
         {
@@ -39,10 +40,10 @@ public sealed class ShipEndpointTests
     [Fact]
     public async Task PlanetResponseReportsBoundedShipCounts()
     {
-        var registration = await RegisterPlayer();
-        await QueueShip(registration, ShipType.CargoVessel);
+        var registration = await _host.RegisterPlayer("Ship_Test_");
+        await _host.QueueShip(registration, ShipType.CargoVessel);
 
-        var planet = await GetPlanet(registration);
+        var planet = await _host.GetPlanet(registration);
         Assert.Equal(0, planet.ShipCount);
         Assert.Equal(1, planet.QueueLength);
         Assert.Equal(0, planet.ActiveBuilds);   // no shipyard yet
@@ -51,10 +52,10 @@ public sealed class ShipEndpointTests
     [Fact]
     public async Task ShipQueueEndpointIsPaginated()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Ship_Test_");
         for (var i = 0; i < 3; i++)
         {
-            await QueueShip(registration, ShipType.ColonyShip);
+            await _host.QueueShip(registration, ShipType.ColonyShip);
         }
 
         var result = await _host.Scenario(s =>
@@ -74,7 +75,7 @@ public sealed class ShipEndpointTests
     [Fact]
     public async Task ShipRosterEndpointIsPaginatedAndInitiallyEmpty()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Ship_Test_");
 
         var result = await _host.Scenario(s =>
         {
@@ -92,8 +93,8 @@ public sealed class ShipEndpointTests
     [Fact]
     public async Task CancelQueuedShipRemovesIt()
     {
-        var registration = await RegisterPlayer();
-        var build = await QueueShip(registration, ShipType.ColonyShip);
+        var registration = await _host.RegisterPlayer("Ship_Test_");
+        var build = await _host.QueueShip(registration, ShipType.ColonyShip);
 
         await _host.Scenario(s =>
         {
@@ -102,14 +103,14 @@ public sealed class ShipEndpointTests
             s.StatusCodeShouldBe(200);
         });
 
-        var planet = await GetPlanet(registration);
+        var planet = await _host.GetPlanet(registration);
         Assert.Equal(0, planet.QueueLength);
     }
 
     [Fact]
     public async Task CancelUnknownBuildReturns404()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Ship_Test_");
 
         await _host.Scenario(s =>
         {
@@ -122,8 +123,8 @@ public sealed class ShipEndpointTests
     [Fact]
     public async Task QueueShipOnUnownedPlanetReturns403()
     {
-        var registration = await RegisterPlayer();
-        var foreign = await FindPlanetOtherThan(registration);
+        var registration = await _host.RegisterPlayer("Ship_Test_");
+        var foreign = await _host.FindPlanetOtherThan(registration);
 
         await _host.Scenario(s =>
         {
@@ -132,62 +133,5 @@ public sealed class ShipEndpointTests
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
             s.StatusCodeShouldBe(403);
         });
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
-        Assert.NotNull(planet);
-        return planet;
-    }
-
-    private async Task<Guid> FindPlanetOtherThan(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url("/api/solar-systems?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var systems = await result.ReadAsJsonAsync<PagedResponse<SolarSystemResponse>>();
-        Assert.NotNull(systems);
-        return systems.Items.SelectMany(sys => sys.PlanetIds).First(id => id != registration.HomeworldId);
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Ship_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Support/IntegrationApiExtensions.cs
+++ b/src/Voidforge.Tests/Support/IntegrationApiExtensions.cs
@@ -1,87 +1,3 @@
-# #62 — Shared Integration-Test Helpers Implementation Plan
-
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
-
-**Goal:** Extract the helper methods duplicated across 21 integration-test files into shared test support, and centralize the suite's poll intervals/timeouts as named constants.
-
-**Architecture:** Extension methods on `IAlbaHost` in `Voidforge.Tests/Support/` — not a base class. Test classes keep their `[Collection]` attribute, constructor, and `_host` field untouched; each file's diff is "delete the private-helper region, prefix helper calls with `_host.`". All helpers take the `RegisterPlayerResponse` explicitly (no hidden state), so extensions compose exactly like the private methods did.
-
-**Tech Stack:** .NET 9, xUnit 2.9, Alba 8.4, Marten. Analyzers: Roslynator + Meziantou, `TreatWarningsAsErrors`, MA0048 (one public type per file).
-
-**Spec:** Issue #62; `plans/phase-5-hardening-design.md` §8 wave 0. Test-only churn — no production code changes.
-
-## Global Constraints
-
-- `TreatWarningsAsErrors` — new files must be analyzer-clean.
-- MA0048 — one public type per file (`IntegrationApiExtensions.cs`, `TestTimeouts.cs`).
-- **No behavior change to what tests assert.** Two deliberate, safe unifications (documented in decisions 2-3 below); everything else byte-equivalent.
-- Never run `dotnet test` concurrently with anything (shared test DB; quality-gate Stop hook also runs the suite).
-- Commits: conventional, suffixed `(#62)`.
-
-## Plan-level decisions
-
-1. **Extensions over inheritance.** A base class would force ctor chaining in 21 files, an `_host` → `Host` sweep through hundreds of inline scenarios, and reliance on xUnit inheriting `[Collection]`. Extensions touch none of that.
-2. **`BuildRosterShip` unifies on ensure + roster-diff** (the ClaimRace/Colonize variant): call idempotent `EnsureOperationalShipyard`, snapshot roster ids, queue, return the first *new* id. This subsumes: variant A (no shipyard yet → ensure builds it; empty roster → diff returns the only ship), variant D in `FleetRoundTripTests` (shipyard already built → ensure is a no-op, no second shipyard), and typed variant B directly. `BuildRosterShips(count)` covers the batch case (30 s deadline, as today).
-3. **`FindPlanetOtherThan` unifies on `?pageSize=200`** (`ShipEndpointTests` form). `BuildingEndpointTests`' copy omitted the page size and relied on the default page containing a non-home planet — strictly less reliable; unifying is a safe behavior change.
-4. **Stays local (race- or file-specific):** `ClaimRaceTests.ArriveWithRetry` + `BuildAndLaunchColonizeFleet`; `ColonizeMissionTests.UncolonizedPlanetId` (raw-Marten single-file variant); `MoveMissionEndToEndTests.PickPlanetInAnotherSolarSystem` (ignores ownership — different semantics); `PlayerRegistrationTests` (asserts raw registration responses — untouched); the `Try*`/`*Status` wrappers in `Concurrency/*` (semantic names stay, bodies delegate to the shared `PostForStatus` primitive); `ColonizeSecondPlanetForOwner` (2 files, raw-Marten world mutation with a do-not-parallelize warning — the pair collapses when #67's fixtures land, not worth a `Store`-reaching shared helper now).
-5. **Poll cadence unchanged** (500 ms), but named. Tightening intervals to speed the suite is deliberately out of scope — it changes DB load during polls and belongs with evidence, not inside a mechanical refactor.
-6. **`RegisterPlayer` keeps per-file name prefixes** as an explicit argument — they make test-DB forensics readable; deriving from the class name risks tripping any name-length validation.
-
-## File Structure
-
-```text
-src/Voidforge.Tests/Support/
-  TestTimeouts.cs                (new — named poll interval + timeout constants)
-  IntegrationApiExtensions.cs    (new — all shared helpers as IAlbaHost extensions)
-plans/phase-5/62-test-helpers.md (this plan)
-technical-design/testing.md      (modify — document the Support layer)
-21 test files                    (modify — delete private helpers, prefix calls with _host.)
-```
-
----
-
-### Task 1: Support files
-
-**Files:**
-- Create: `src/Voidforge.Tests/Support/TestTimeouts.cs`
-- Create: `src/Voidforge.Tests/Support/IntegrationApiExtensions.cs`
-
-**Interfaces produced:** every signature below — later tasks rely on them verbatim.
-
-- [ ] **Step 1: Write `TestTimeouts.cs`**
-
-```csharp
-namespace Voidforge.Tests.Support;
-
-/// <summary>
-/// Canonical wall-clock poll cadence and deadlines for the integration suite.
-/// These time out real HTTP polling — unrelated to the app's injected TimeProvider.
-/// </summary>
-public static class TestTimeouts
-{
-    /// <summary>Delay between successive polls.</summary>
-    public static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
-
-    /// <summary>Building/ship construction completing onto the planet.</summary>
-    public static readonly TimeSpan Completion = TimeSpan.FromSeconds(20);
-
-    /// <summary>Resource stock recovering after a spend, and multi-ship queue settling.</summary>
-    public static readonly TimeSpan StockRecovery = TimeSpan.FromSeconds(30);
-
-    /// <summary>Draining a multi-ship build queue.</summary>
-    public static readonly TimeSpan QueueDrain = TimeSpan.FromSeconds(40);
-
-    /// <summary>Real-scheduler fleet arrival (short hops).</summary>
-    public static readonly TimeSpan Arrival = TimeSpan.FromSeconds(30);
-
-    /// <summary>Full-loop end-to-end arrival (longest travel in the suite).</summary>
-    public static readonly TimeSpan FullLoopArrival = TimeSpan.FromSeconds(60);
-}
-```
-
-- [ ] **Step 2: Write `IntegrationApiExtensions.cs`**
-
-```csharp
 using Alba;
 using Marten;
 using Microsoft.Extensions.DependencyInjection;
@@ -132,7 +48,8 @@ public static class IntegrationApiExtensions
     public static Task<PlanetResponse> GetPlanet(this IAlbaHost host, RegisterPlayerResponse registration)
         => host.GetPlanetById(registration, registration.HomeworldId);
 
-    public static Task<PlanetResponse> GetPlanetById(this IAlbaHost host, RegisterPlayerResponse asWhom, Guid planetId)
+    public static Task<PlanetResponse> GetPlanetById(
+        this IAlbaHost host, RegisterPlayerResponse asWhom, Guid planetId)
         => host.GetJson<PlanetResponse>(asWhom, $"/api/planets/{planetId}");
 
     public static Task<PagedResponse<RosterShipResponse>> GetRoster(
@@ -327,6 +244,7 @@ public static class IntegrationApiExtensions
     /// <summary>
     /// Polls the planet (homeworld unless <paramref name="planetId"/> is given) until the
     /// predicate holds. Returns the last-seen state on timeout — callers assert and report.
+    /// Test wall-clock timeout — unrelated to the app's injected TimeProvider.
     /// </summary>
     public static async Task<PlanetResponse> PollUntil(
         this IAlbaHost host,
@@ -452,90 +370,3 @@ public static class IntegrationApiExtensions
         throw new InvalidOperationException("No uncolonized planet found in the universe.");
     }
 }
-```
-
-> Compile-check note: exact DTO namespaces (`RegisterPlayerRequest`, `SolarSystemResponse`, `CompleteFleetArrival`, `CompleteFleetArrivalHandler`, `CargoRequest`) must match the API project — fix usings on first build, do not fully-qualify inline. The `Unload`/`Disband` POST-without-body shape must match the existing local helpers (verify one before deleting).
-
-- [ ] **Step 3: Build**
-
-Run: `dotnet build src/Voidforge.slnx`
-Expected: clean (analyzers on). Nothing consumes the new files yet.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add src/Voidforge.Tests/Support plans/phase-5/62-test-helpers.md
-git commit -m "test: shared integration-test helper extensions + named timeouts (#62)"
-```
-
----
-
-### Task 2: Migrate Fleets/ + Concurrency/ (4 files)
-
-**Files:** `Fleets/FleetEndpointTests.cs`, `Fleets/FleetRoundTripTests.cs`, `Concurrency/FleetConcurrencyTests.cs`, `Concurrency/SameStreamConcurrencyTests.cs`
-
-- [ ] **Step 1:** In each file: add `using Voidforge.Tests.Support;`, delete the private copies of `RegisterPlayer`/`GetJson`/`GetPlanet`/`GetRoster`/`QueueShip`/`BuildOperationalShipyard`/`BuildRosterShip`/`AssembleFleet`/`Disband`/`PollUntil`, prefix every call with `_host.` and pass each file's existing name-prefix literal to `RegisterPlayer("…")`. Replace hardcoded `TimeSpan.FromSeconds(20/30)` poll args at call sites with `TestTimeouts.Completion` / `TestTimeouts.StockRecovery`.
-- [ ] **Step 2:** File-specific: `FleetRoundTripTests` — its local `BuildRosterShip` (variant D) is deleted; the body's one explicit `BuildOperationalShipyard` call becomes `_host.EnsureOperationalShipyard`; the shared diff-based helper preserves its semantics. `FleetConcurrencyTests`/`SameStreamConcurrencyTests` — keep `TryAssemble`/`TryDisband`/`TryLaunch`/`QueueShipStatus` as local one-liners delegating to `_host.PostForStatus(...)`.
-- [ ] **Step 3:** `dotnet build src/Voidforge.slnx` → clean.
-- [ ] **Step 4:** Commit: `test: migrate Fleets + Concurrency suites to shared helpers (#62)`
-
----
-
-### Task 3: Migrate Cargo/ (3 files)
-
-**Files:** `Cargo/CargoEndpointTests.cs`, `Cargo/TransportMissionEndToEndTests.cs`, `Cargo/TransportMissionEndpointTests.cs`
-
-- [ ] **Step 1:** Same mechanical sweep as Task 2 (including `Launch`, `Unload`, `WaitForStock`, `PollFleetUntil`, `GetPlanetById`, `LaunchAndArriveInstantly`).
-- [ ] **Step 2:** File-specific: `CargoEndpointTests` — `BuildRosterShips(count)` maps to the shared batch helper; `MoveAndArriveInstantly` becomes a local one-liner over `_host.LaunchAndArriveInstantly(reg, fleetId, MissionType.Move, dest)` (ignore the return); its `WaitForStock` callers keep using the returned planet. `TransportMissionEndpointTests` keeps `ColonizeSecondPlanetForOwner` local (decision 4). `_arrivalTimeout` fields switch to `TestTimeouts.Arrival`.
-- [ ] **Step 3:** `dotnet build src/Voidforge.slnx` → clean.
-- [ ] **Step 4:** Commit: `test: migrate Cargo suites to shared helpers (#62)`
-
----
-
-### Task 4: Migrate Colonize/ (3 files)
-
-**Files:** `Colonize/ClaimRaceTests.cs`, `Colonize/ColonizeMissionTests.cs`, `Colonize/FullLoopEndToEndTests.cs`
-
-- [ ] **Step 1:** Same mechanical sweep. `EnsureOperationalShipyard` copies delete cleanly (shared one is the same shape). Typed `BuildRosterShip(reg, type)` calls map 1:1.
-- [ ] **Step 2:** File-specific: `ClaimRaceTests` keeps `ArriveWithRetry` + `BuildAndLaunchColonizeFleet` local; its `UncolonizedPlanetId(asWhom)` becomes `_host.FindUncolonizedPlanet(asWhom)`. `ColonizeMissionTests` keeps its raw-Marten `UncolonizedPlanetId()` local (decision 4) and keeps `ColonizeSecondPlanetForOwner` local. `FullLoopEndToEndTests` — `UncolonizedPlanetInAnotherSystem(asWhom, homeSystemId)` becomes `_host.FindUncolonizedPlanet(asWhom, excludeSystemId: homeSystemId)`; `_arrivalTimeout` → `TestTimeouts.FullLoopArrival`.
-- [ ] **Step 3:** `dotnet build src/Voidforge.slnx` → clean.
-- [ ] **Step 4:** Commit: `test: migrate Colonize suites to shared helpers (#62)`
-
----
-
-### Task 5: Migrate Travel/ (3 files)
-
-**Files:** `Travel/FleetMissionEndpointTests.cs`, `Travel/MoveMissionEndToEndTests.cs`, `Travel/PlanetCoordinateApiTests.cs`
-
-- [ ] **Step 1:** Same mechanical sweep.
-- [ ] **Step 2:** File-specific: `MoveMissionEndToEndTests` — `GetRosterAt(reg, planetId)` → `_host.GetRoster(reg, planetId)`; its `PollUntil` variant maps to the shared one (homeworld default); `Task Disband` callers call the shared `Disband` and discard the result with `_ =`; keeps `PickPlanetInAnotherSolarSystem` local; `_arrivalTimeout` → `TestTimeouts.Arrival`. `PlanetCoordinateApiTests` — only `RegisterPlayer` migrates; the `_planetSpread` ctor stays.
-- [ ] **Step 3:** `dotnet build src/Voidforge.slnx` → clean.
-- [ ] **Step 4:** Commit: `test: migrate Travel suites to shared helpers (#62)`
-
----
-
-### Task 6: Migrate remaining suites (7 files)
-
-**Files:** `Buildings/BuildingEndpointTests.cs`, `Construction/BuildingConstructionCompletionTests.cs`, `Energy/EnergyGridTests.cs`, `Ships/ShipConstructionCompletionTests.cs`, `Ships/ShipEndpointTests.cs`, `Planets/PlanetEndpointTests.cs`, `Pagination/SolarSystemPaginationTests.cs`
-
-- [ ] **Step 1:** Same mechanical sweep (`RegisterPlayer`, `GetPlanet`, `PollUntil`, `QueueShip`, `GetRoster`, `BuildOperationalShipyard` → `EnsureOperationalShipyard`, `CancelBuild` stays local in `ShipConstructionCompletionTests`).
-- [ ] **Step 2:** File-specific: both `FindPlanetOtherThan` copies → shared (Buildings' gains `pageSize=200`, decision 3). `ShipConstructionCompletionTests` 40 s timeouts → `TestTimeouts.QueueDrain`. `SolarSystemPaginationTests` — `RegisterAndGetKey()` becomes `(await _host.RegisterPlayer("Pg_Test_")).ApiKey`; `GetPage(string apiKey, …)` stays local. `PlayerRegistrationTests` is deliberately untouched.
-- [ ] **Step 3:** `dotnet build src/Voidforge.slnx` → clean. Then grep for leftovers: `grep -rn "private async Task<RegisterPlayerResponse> RegisterPlayer\|private async Task<PlanetResponse> PollUntil" src/Voidforge.Tests` → no hits.
-- [ ] **Step 4:** Commit: `test: migrate remaining suites to shared helpers; drop last duplicates (#62)`
-
----
-
-### Task 7: Full suite, format, docs
-
-- [ ] **Step 1:** `timeout 900 dotnet test src/Voidforge.slnx` → all green (no concurrent runs; Wolverine teardown hang is cosmetic per `testing.md`).
-- [ ] **Step 2:** `dotnet format src/Voidforge.slnx` → commit any churn.
-- [ ] **Step 3:** Update `technical-design/testing.md`: add a "Shared helpers (`Support/`)" section — `IntegrationApiExtensions` (all API-driving helpers, assert-200, poll-return-last), `TestTimeouts` (named cadences), and the rule: *new integration tests must use the shared helpers; add to them rather than re-declaring privately*.
-- [ ] **Step 4:** Commit: `test+docs: shared-helper conventions in testing.md (#62)`
-
----
-
-### Task 8: PR and merge
-
-- [ ] **Step 1:** Push `chore/62-test-helpers`; open PR → base `phase-5`, title `test: extract shared integration-test helpers (#62)`, body: summary + decisions 1-6 + "Closes #62".
-- [ ] **Step 2:** `gh pr checks --watch` → green.
-- [ ] **Step 3:** `gh pr merge --merge`.

--- a/src/Voidforge.Tests/Support/TestTimeouts.cs
+++ b/src/Voidforge.Tests/Support/TestTimeouts.cs
@@ -1,0 +1,26 @@
+namespace Voidforge.Tests.Support;
+
+/// <summary>
+/// Canonical wall-clock poll cadence and deadlines for the integration suite.
+/// These time out real HTTP polling — unrelated to the app's injected TimeProvider.
+/// </summary>
+public static class TestTimeouts
+{
+    /// <summary>Delay between successive polls.</summary>
+    public static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>Building/ship construction completing onto the planet.</summary>
+    public static readonly TimeSpan Completion = TimeSpan.FromSeconds(20);
+
+    /// <summary>Resource stock recovering after a spend, and multi-ship batches settling.</summary>
+    public static readonly TimeSpan StockRecovery = TimeSpan.FromSeconds(30);
+
+    /// <summary>Draining a multi-ship build queue.</summary>
+    public static readonly TimeSpan QueueDrain = TimeSpan.FromSeconds(40);
+
+    /// <summary>Real-scheduler fleet arrival (short hops).</summary>
+    public static readonly TimeSpan Arrival = TimeSpan.FromSeconds(30);
+
+    /// <summary>Full-loop end-to-end arrival (longest travel in the suite).</summary>
+    public static readonly TimeSpan FullLoopArrival = TimeSpan.FromSeconds(60);
+}

--- a/src/Voidforge.Tests/Travel/FleetMissionEndpointTests.cs
+++ b/src/Voidforge.Tests/Travel/FleetMissionEndpointTests.cs
@@ -5,7 +5,7 @@ using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Domain.Events;
 using Voidforge.Api.Endpoints;
-using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Travel;
@@ -23,7 +23,7 @@ public sealed class FleetMissionEndpointTests
     [Fact]
     public async Task LaunchUnknownFleetReturns404()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("FleetMission_Test_");
 
         await _host.Scenario(s =>
         {
@@ -37,10 +37,10 @@ public sealed class FleetMissionEndpointTests
     [Fact]
     public async Task LaunchForeignFleetReturns403()
     {
-        var owner = await RegisterPlayer();
-        var intruder = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("FleetMission_Test_");
+        var intruder = await _host.RegisterPlayer("FleetMission_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
         await _host.Scenario(s =>
         {
@@ -54,7 +54,7 @@ public sealed class FleetMissionEndpointTests
     [Fact]
     public async Task LaunchUnknownMissionTypeReturns400()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("FleetMission_Test_");
 
         var result = await _host.Scenario(s =>
         {
@@ -71,9 +71,9 @@ public sealed class FleetMissionEndpointTests
     [Fact]
     public async Task LaunchToCurrentLocationReturns400()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("FleetMission_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
         await _host.Scenario(s =>
         {
@@ -87,9 +87,9 @@ public sealed class FleetMissionEndpointTests
     [Fact]
     public async Task LaunchToUnknownDestinationReturns404()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("FleetMission_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
         await _host.Scenario(s =>
         {
@@ -103,12 +103,12 @@ public sealed class FleetMissionEndpointTests
     [Fact]
     public async Task LaunchMoveTransitionsFleetToInTransitAndRoundTripsThroughTheApi()
     {
-        var owner = await RegisterPlayer();
-        var beta = await RegisterPlayer();   // another colonized planet to travel to
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("FleetMission_Test_");
+        var beta = await _host.RegisterPlayer("FleetMission_Test_");   // another colonized planet to travel to
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
-        var launched = await Launch(owner, fleet.Id, MissionType.Move, beta.HomeworldId);
+        var launched = await _host.Launch(owner, fleet.Id, MissionType.Move, beta.HomeworldId);
 
         Assert.Equal(FleetStatus.InTransit, launched.Status);
         Assert.Null(launched.LocationPlanetId);
@@ -120,7 +120,7 @@ public sealed class FleetMissionEndpointTests
 
         // Round-trip through Postgres (not just the launch response): a fresh GET must
         // deserialize the same mid-transit snapshot, including its nested TravelPlan.
-        var fetched = await GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
+        var fetched = await _host.GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
         Assert.Equal(FleetStatus.InTransit, fetched.Status);
         Assert.Null(fetched.LocationPlanetId);
         Assert.Equal(owner.HomeworldId, fetched.OriginPlanetId);
@@ -133,11 +133,11 @@ public sealed class FleetMissionEndpointTests
     [Fact]
     public async Task LaunchWhileInTransitReturns409()
     {
-        var owner = await RegisterPlayer();
-        var beta = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
-        await Launch(owner, fleet.Id, MissionType.Move, beta.HomeworldId);
+        var owner = await _host.RegisterPlayer("FleetMission_Test_");
+        var beta = await _host.RegisterPlayer("FleetMission_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
+        await _host.Launch(owner, fleet.Id, MissionType.Move, beta.HomeworldId);
 
         await _host.Scenario(s =>
         {
@@ -151,11 +151,11 @@ public sealed class FleetMissionEndpointTests
     [Fact]
     public async Task HandlerInvokedArrivalStationsTheFleetAndIsIdempotent()
     {
-        var owner = await RegisterPlayer();
-        var beta = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
-        var launched = await Launch(owner, fleet.Id, MissionType.Move, beta.HomeworldId);
+        var owner = await _host.RegisterPlayer("FleetMission_Test_");
+        var beta = await _host.RegisterPlayer("FleetMission_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
+        var launched = await _host.Launch(owner, fleet.Id, MissionType.Move, beta.HomeworldId);
         Assert.NotNull(launched.ArrivesAt);
         var arrivesAt = launched.ArrivesAt.Value;
 
@@ -168,7 +168,7 @@ public sealed class FleetMissionEndpointTests
             await CompleteFleetArrivalHandler.Handle(new CompleteFleetArrival(fleet.Id, arrivesAt), session);
         }
 
-        var arrived = await GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
+        var arrived = await _host.GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
         Assert.Equal(FleetStatus.Stationed, arrived.Status);
         Assert.Equal(beta.HomeworldId, arrived.LocationPlanetId);
         Assert.Null(arrived.OriginPlanetId);
@@ -183,7 +183,7 @@ public sealed class FleetMissionEndpointTests
             await CompleteFleetArrivalHandler.Handle(new CompleteFleetArrival(fleet.Id, arrivesAt), session);
         }
 
-        var afterDuplicate = await GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
+        var afterDuplicate = await _host.GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
         Assert.Equal(FleetStatus.Stationed, afterDuplicate.Status);
         Assert.Equal(beta.HomeworldId, afterDuplicate.LocationPlanetId);
 
@@ -194,167 +194,8 @@ public sealed class FleetMissionEndpointTests
                 new CompleteFleetArrival(fleet.Id, arrivesAt.AddSeconds(1)), session);
         }
 
-        var afterStale = await GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
+        var afterStale = await _host.GetJson<FleetResponse>(owner, $"/api/fleets/{fleet.Id}");
         Assert.Equal(FleetStatus.Stationed, afterStale.Status);
         Assert.Equal(beta.HomeworldId, afterStale.LocationPlanetId);
-    }
-
-    private async Task<FleetResponse> Launch(
-        RegisterPlayerResponse registration, Guid fleetId, MissionType mission, Guid destinationPlanetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new LaunchMissionRequest(mission, destinationPlanetId)).ToUrl($"/api/fleets/{fleetId}/missions");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    // Builds an operational shipyard, queues one CargoVessel (~2s build), and polls the
-    // roster until it appears. Returns the completed ship's id.
-    private async Task<Guid> BuildRosterShip(RegisterPlayerResponse registration)
-    {
-        await BuildOperationalShipyard(registration);
-        await QueueShip(registration, ShipType.CargoVessel);
-
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
-        do
-        {
-            var roster = await GetRoster(registration);
-            if (roster.Items.Count > 0)
-            {
-                return roster.Items[0].Id;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        throw new InvalidOperationException("Ship did not complete onto the roster in time.");
-    }
-
-    private async Task<FleetResponse> AssembleFleet(RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds)).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    private async Task<T> GetJson<T>(RegisterPlayerResponse registration, string url)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url(url);
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<T>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task BuildOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        await _host.Scenario(s =>
-        {
-            s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        await PollUntil(
-            registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRoster(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}/ships?pageSize=200");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var roster = await result.ReadAsJsonAsync<PagedResponse<RosterShipResponse>>();
-        Assert.NotNull(roster);
-        return roster;
-    }
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanet(registration);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<PlanetResponse> GetPlanet(RegisterPlayerResponse registration)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url($"/api/planets/{registration.HomeworldId}");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
-        Assert.NotNull(planet);
-        return planet;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"FleetMission_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Travel/MoveMissionEndToEndTests.cs
+++ b/src/Voidforge.Tests/Travel/MoveMissionEndToEndTests.cs
@@ -1,8 +1,8 @@
 using Alba;
-using Voidforge.Api.Auth;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Endpoints;
 using Voidforge.Api.Pagination;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Travel;
@@ -16,8 +16,6 @@ namespace Voidforge.Tests.Travel;
 [Collection(IntegrationCollection.Name)]
 public sealed class MoveMissionEndToEndTests
 {
-    private static readonly TimeSpan _arrivalTimeout = TimeSpan.FromSeconds(30);
-
     private readonly IAlbaHost _host;
 
     public MoveMissionEndToEndTests(AppFixture fixture)
@@ -28,25 +26,25 @@ public sealed class MoveMissionEndToEndTests
     [Fact]
     public async Task LaunchedFleetTravelsViaTheRealSchedulerAndArrivesStationedWithItsShipOnTheDestinationRoster()
     {
-        var owner = await RegisterPlayer();
-        var shipId = await BuildRosterShip(owner);
-        var fleet = await AssembleFleet(owner, [shipId]);
+        var owner = await _host.RegisterPlayer("MoveE2E_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);
 
-        var homeworld = await GetPlanetById(owner, owner.HomeworldId);
+        var homeworld = await _host.GetPlanetById(owner, owner.HomeworldId);
         var destinationPlanetId = await PickPlanetInAnotherSolarSystem(owner, homeworld.SolarSystemId);
 
-        var launched = await Launch(owner, fleet.Id, MissionType.Move, destinationPlanetId);
+        var launched = await _host.Launch(owner, fleet.Id, MissionType.Move, destinationPlanetId);
 
         // Trivially observable mid-flight: nothing has had time to arrive yet.
         Assert.Equal(FleetStatus.InTransit, launched.Status);
         Assert.Null(launched.LocationPlanetId);
         Assert.Equal(destinationPlanetId, launched.DestinationPlanetId);
 
-        var arrived = await PollFleetUntil(
+        var arrived = await _host.PollFleetUntil(
             owner,
             fleet.Id,
             f => f.Status == FleetStatus.Stationed && f.LocationPlanetId == destinationPlanetId,
-            _arrivalTimeout);
+            TestTimeouts.Arrival);
 
         Assert.Equal(FleetStatus.Stationed, arrived.Status);
         Assert.Equal(destinationPlanetId, arrived.LocationPlanetId);
@@ -56,55 +54,10 @@ public sealed class MoveMissionEndToEndTests
         Assert.Null(arrived.DepartedAt);
         Assert.Null(arrived.ArrivesAt);
 
-        await Disband(owner, fleet.Id);
+        await _host.Disband(owner, fleet.Id);
 
-        var destinationRoster = await GetRosterAt(owner, destinationPlanetId);
+        var destinationRoster = await _host.GetRoster(owner, destinationPlanetId);
         Assert.Contains(destinationRoster.Items, s => s.Id == shipId);
-    }
-
-    private async Task<FleetResponse> Launch(
-        RegisterPlayerResponse registration, Guid fleetId, MissionType mission, Guid destinationPlanetId)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new LaunchMissionRequest(mission, destinationPlanetId)).ToUrl($"/api/fleets/{fleetId}/missions");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task Disband(RegisterPlayerResponse registration, Guid fleetId)
-    {
-        await _host.Scenario(s =>
-        {
-            s.Post.Url($"/api/fleets/{fleetId}/disband");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-    }
-
-    private async Task<FleetResponse> PollFleetUntil(
-        RegisterPlayerResponse registration, Guid fleetId, Func<FleetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        FleetResponse fleet;
-        do
-        {
-            fleet = await GetJson<FleetResponse>(registration, $"/api/fleets/{fleetId}");
-            if (predicate(fleet))
-            {
-                return fleet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return fleet;
     }
 
     // Picks the first planet belonging to a solar system other than the homeworld's — this
@@ -112,7 +65,8 @@ public sealed class MoveMissionEndToEndTests
     // exercises the coordinate-driven planner across systems, not just within one.
     private async Task<Guid> PickPlanetInAnotherSolarSystem(RegisterPlayerResponse registration, Guid homeSolarSystemId)
     {
-        var systems = await GetJson<PagedResponse<SolarSystemResponse>>(registration, "/api/solar-systems?pageSize=200");
+        var systems = await _host.GetJson<PagedResponse<SolarSystemResponse>>(
+            registration, "/api/solar-systems?pageSize=200");
         var other = systems.Items.FirstOrDefault(s => s.Id != homeSolarSystemId && s.PlanetIds.Count > 0);
         if (other is null)
         {
@@ -120,127 +74,5 @@ public sealed class MoveMissionEndToEndTests
         }
 
         return other.PlanetIds[0];
-    }
-
-    private async Task<PlanetResponse> GetPlanetById(RegisterPlayerResponse registration, Guid planetId)
-        => await GetJson<PlanetResponse>(registration, $"/api/planets/{planetId}");
-
-    // Builds an operational shipyard, queues one CargoVessel (~2s build), and polls the
-    // roster until it appears. Returns the completed ship's id.
-    private async Task<Guid> BuildRosterShip(RegisterPlayerResponse registration)
-    {
-        await BuildOperationalShipyard(registration);
-        await QueueShip(registration, ShipType.CargoVessel);
-
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
-        do
-        {
-            var roster = await GetRosterAt(registration, registration.HomeworldId);
-            if (roster.Items.Count > 0)
-            {
-                return roster.Items[0].Id;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        throw new InvalidOperationException("Ship did not complete onto the roster in time.");
-    }
-
-    private async Task<FleetResponse> AssembleFleet(RegisterPlayerResponse registration, IReadOnlyList<Guid> shipIds)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new AssembleFleetRequest(shipIds)).ToUrl($"/api/planets/{registration.HomeworldId}/fleets");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var fleet = await result.ReadAsJsonAsync<FleetResponse>();
-        Assert.NotNull(fleet);
-        return fleet;
-    }
-
-    private async Task<T> GetJson<T>(RegisterPlayerResponse registration, string url)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Get.Url(url);
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<T>();
-        Assert.NotNull(response);
-        return response;
-    }
-
-    private async Task BuildOperationalShipyard(RegisterPlayerResponse registration)
-    {
-        await _host.Scenario(s =>
-        {
-            s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        await PollUntil(
-            registration,
-            p => p.Buildings.Any(b => b.Type == BuildingType.Shipyard && b.Status == BuildingStatus.Operational),
-            TimeSpan.FromSeconds(20));
-    }
-
-    private async Task<ShipBuildResponse> QueueShip(RegisterPlayerResponse registration, ShipType type)
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new QueueShipRequest(type))
-                .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
-            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
-        });
-
-        var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
-        Assert.NotNull(build);
-        return build;
-    }
-
-    private async Task<PagedResponse<RosterShipResponse>> GetRosterAt(RegisterPlayerResponse registration, Guid planetId)
-        => await GetJson<PagedResponse<RosterShipResponse>>(registration, $"/api/planets/{planetId}/ships?pageSize=200");
-
-    private async Task<PlanetResponse> PollUntil(
-        RegisterPlayerResponse registration, Func<PlanetResponse, bool> predicate, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        PlanetResponse planet;
-        do
-        {
-            planet = await GetPlanetById(registration, registration.HomeworldId);
-            if (predicate(planet))
-            {
-                return planet;
-            }
-
-            await Task.Delay(500);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        return planet;
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"MoveE2E_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/src/Voidforge.Tests/Travel/PlanetCoordinateApiTests.cs
+++ b/src/Voidforge.Tests/Travel/PlanetCoordinateApiTests.cs
@@ -5,6 +5,7 @@ using Voidforge.Api.Auth;
 using Voidforge.Api.Endpoints;
 using Voidforge.Api.Pagination;
 using Voidforge.Api.WorldGeneration;
+using Voidforge.Tests.Support;
 using Xunit;
 
 namespace Voidforge.Tests.Travel;
@@ -24,7 +25,7 @@ public sealed class PlanetCoordinateApiTests
     [Fact]
     public async Task PlanetCoordinatesAreWithinSpreadOfItsSolarSystem()
     {
-        var registration = await RegisterPlayer();
+        var registration = await _host.RegisterPlayer("Coord_Test_");
 
         var planetResult = await _host.Scenario(s =>
         {
@@ -49,19 +50,5 @@ public sealed class PlanetCoordinateApiTests
         Assert.InRange(planet.X, system.X - _planetSpread, system.X + _planetSpread);
         Assert.InRange(planet.Y, system.Y - _planetSpread, system.Y + _planetSpread);
         Assert.InRange(planet.Z, system.Z - _planetSpread, system.Z + _planetSpread);
-    }
-
-    private async Task<RegisterPlayerResponse> RegisterPlayer()
-    {
-        var result = await _host.Scenario(s =>
-        {
-            s.Post.Json(new RegisterPlayerRequest($"Coord_Test_{Guid.NewGuid():N}"))
-                .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
-        });
-
-        var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
-        Assert.NotNull(response);
-        return response;
     }
 }

--- a/technical-design/testing.md
+++ b/technical-design/testing.md
@@ -33,6 +33,23 @@ public sealed class MyTests(AppFixture fixture)
 
 This avoids booting the app per test class (Marten schema migration is slow).
 
+## Shared Helpers (`Support/`)
+
+Since #62, API-driving helpers are shared extension methods on `IAlbaHost` — do not re-declare them privately in test classes. Add missing helpers to the shared layer instead.
+
+- `Support/IntegrationApiExtensions.cs` — register/get/build/assemble/launch/poll helpers. All assert success (200) unless the name says otherwise (`PostForStatus`); polling helpers return the last-seen state on timeout so the caller's assertion reports the failure.
+- `Support/TestTimeouts.cs` — the suite's named poll cadence and deadlines (`PollInterval`, `Completion`, `StockRecovery`, `QueueDrain`, `Arrival`, `FullLoopArrival`). Use these instead of inline `TimeSpan` literals; they time out real HTTP polling and are unrelated to the app's injected `TimeProvider`.
+
+Usage shape (the class keeps its `[Collection]` + `AppFixture` wiring):
+
+```csharp
+var owner = await _host.RegisterPlayer("MySuite_");
+var shipId = await _host.BuildRosterShip(owner);
+var planet = await _host.PollUntil(owner, p => p.Buildings.Count > 0, TestTimeouts.Completion);
+```
+
+Deliberately local (not shared): race-specific arrival retries (`ClaimRaceTests`), raw-Marten world mutations (`ColonizeSecondPlanetForOwner`, `UncolonizedPlanetId`), and `PlayerRegistrationTests`' inline scenarios that assert raw registration responses.
+
 ## Known Pitfalls
 
 ### Do Not Dispose DI-Owned IDocumentStore


### PR DESCRIPTION
Extracts the helper methods duplicated across 21 integration-test files into shared extension methods on `IAlbaHost`, and centralizes poll intervals/timeouts as named constants. Closes #62.

## What changed
- New `src/Voidforge.Tests/Support/IntegrationApiExtensions.cs` — all API-driving helpers (register, get, build, assemble, launch, poll, …) as `IAlbaHost` extensions. Assert success (200) unless named otherwise; polling helpers return the last-seen state on timeout so the caller's assertion reports the failure.
- New `src/Voidforge.Tests/Support/TestTimeouts.cs` — named cadence/deadlines (`PollInterval`, `Completion`, `StockRecovery`, `QueueDrain`, `Arrival`, `FullLoopArrival`).
- 20 integration-test files migrated: private helper regions deleted, calls prefixed with `_host.`. Net ~2,700 lines of duplication removed.
- `technical-design/testing.md` documents the `Support/` layer and the rule: new integration tests use the shared helpers rather than re-declaring them.

## Design decisions
1. **Extensions over a base class** — test classes keep their `[Collection]` + `AppFixture` wiring untouched; each file's diff is just "delete helpers, prefix calls".
2. **`BuildRosterShip` unified on ensure-shipyard + roster-diff** — subsumes the four prior variants (single-ship builds now use the 20s `Completion` deadline rather than the 30s batch path).
3. **`FindPlanetOtherThan` unified on `?pageSize=200`** — the `BuildingEndpointTests` copy previously omitted it and relied on the default page; the shared form is strictly more reliable.
4. **Kept local (race/file-specific):** `ClaimRaceTests.ArriveWithRetry` + `BuildAndLaunchColonizeFleet`; the raw-Marten `UncolonizedPlanetId`/`ColonizeSecondPlanetForOwner`; `MoveMissionEndToEndTests.PickPlanetInAnotherSolarSystem`; `Concurrency` `Try*` status wrappers; `PlayerRegistrationTests` inline scenarios.

## Verification
- `dotnet build src/Voidforge.slnx -warnaserror` — clean (0/0).
- `dotnet format` — no churn.
- Full suite: **246 passed, 0 failed, 0 skipped** (~9 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
