### PR TITLE
fix: WorldSeeder double-seed race — atomic single-seed marker (#46)

### DIFF
--- a/plans/phase-5/46-worldseeder-double-seed.md
+++ b/plans/phase-5/46-worldseeder-double-seed.md
@@ -1,0 +1,70 @@
+# #46 — WorldSeeder Double-Seed Race Implementation Plan
+
+**Goal:** Concurrent `WorldSeeder.StartAsync` runs (multi-instance startup, or a restart racing itself) seed the world **exactly once**, instead of both passing the count check and each seeding a full world.
+
+**Root cause (from survey):** `WorldSeeder.StartAsync` (`WorldSeeder.cs:14-67`) does a non-atomic read-then-act — `Query<SolarSystem>().CountAsync()`, skip if `> 0`, else build the world and `SaveChangesAsync`. Two seeders both read count 0 (TOCTOU) and both commit. No advisory lock, no marker, no unique constraint.
+
+**Tech Stack:** .NET 9, Marten, `IHostedService`, xUnit.
+
+## Global Constraints
+- `TreatWarningsAsErrors`; MA0048 one-public-type-per-file.
+- Commits conventional, suffixed `(#46)`. Branch off updated `phase-5` (after #62 and ideally #45 merge — reuses #45's `MartenExceptions.IsUniqueViolation`).
+- Verification via CI; locally only `dotnet build -warnaserror`.
+
+## File Structure
+```text
+src/Voidforge.Api/WorldGeneration/WorldSeedMarker.cs (new — single-row seed marker)
+src/Voidforge.Api/WorldGeneration/WorldSeeder.cs      (modify — commit marker atomically, catch dup)
+src/Voidforge.Api/Program.cs                          (modify — register marker schema if needed)
+src/Voidforge.Tests/WorldGeneration/WorldSeederIdempotencyTests.cs (new)
+```
+
+## Plan-level decisions
+1. **Marker-document + atomic commit, not an advisory lock.** Define `WorldSeedMarker` with a well-known constant `Id`; insert it in the **same** `session` as the world data so Marten commits both in one transaction. A second seeder's insert hits the primary-key `23505` and the whole batch (including its duplicate world) rolls back atomically. This reuses #45's `MartenExceptions.IsUniqueViolation` and needs no raw-SQL lock plumbing through Marten's session/transaction model.
+2. **Keep the fast-path count check.** The common case (restart against an already-seeded DB) still short-circuits cheaply without attempting a doomed insert; the marker only arbitrates the genuine race.
+3. **Loser logs "already seeded" and returns** — a duplicate is success, not an error. A hosted service throwing from `StartAsync` aborts host startup, so the catch must swallow the unique-violation specifically (rethrow anything else).
+
+### Task 1: Marker document
+**Files:** Create `src/Voidforge.Api/WorldGeneration/WorldSeedMarker.cs`
+- [ ] **Step 1:** Minimal document; the fixed `Id` is the PK that enforces single-seed.
+```csharp
+namespace Voidforge.Api.WorldGeneration;
+
+/// <summary>Single-row marker committed atomically with the seeded world so a second
+/// concurrent seeder collides on the primary key (23505) instead of double-seeding.</summary>
+public sealed class WorldSeedMarker
+{
+    // Well-known constant id — there is only ever one of these.
+    public static readonly Guid WellKnownId = new("5eed0000-0000-0000-0000-000000000001");
+
+    public Guid Id { get; set; }
+}
+```
+- [ ] **Step 2:** If the codebase registers document schemas explicitly (Program.cs ~27-40 registers `Player`/`ApiKey`), add `opts.Schema.For<WorldSeedMarker>();` for parity. Build `-warnaserror` → clean.
+
+### Task 2: Atomic seed
+**Files:** Modify `src/Voidforge.Api/WorldGeneration/WorldSeeder.cs`
+- [ ] **Step 1:** Keep the `existingCount > 0` fast-path. Before `SaveChangesAsync`, `session.Insert(new WorldSeedMarker { Id = WorldSeedMarker.WellKnownId });`. Wrap the save:
+```csharp
+try
+{
+    session.Insert(new WorldSeedMarker { Id = WorldSeedMarker.WellKnownId });
+    await session.SaveChangesAsync(cancellationToken);
+    LogWorldSeeded(logger, opts.SolarSystemCount, opts.PlanetsPerSystem);
+}
+catch (Exception ex) when (MartenExceptions.IsUniqueViolation(ex))
+{
+    // Another instance won the seed race; its world is authoritative. Not an error.
+    LogWorldAlreadySeeded(logger, opts.SolarSystemCount);
+}
+```
+(Reuse the existing log delegates; add `using Voidforge.Api.Http;` for `MartenExceptions`.)
+- [ ] **Step 2:** Build `-warnaserror` → clean.
+
+### Task 3: Idempotency test
+**Files:** Create `src/Voidforge.Tests/WorldGeneration/WorldSeederIdempotencyTests.cs`
+- [ ] **Step 1:** In the shared `[Collection(IntegrationCollection.Name)]`, resolve `IDocumentStore` from `fixture.Host.Services`, count `SolarSystem` (world already seeded once by the fixture boot). Construct a second `WorldSeeder` against the same store/options/logger and call `StartAsync` again; assert the `SolarSystem` count is unchanged (no second world). Optionally run two fresh `StartAsync` calls concurrently against a store and assert a single world's worth. Use `Microsoft.Extensions.Options.Options.Create(...)` and `NullLogger<WorldSeeder>.Instance`.
+- [ ] **Step 2:** Build `-warnaserror` → clean. (CI runs the suite.)
+
+### Task 4: PR
+- [ ] Commit each task suffixed `(#46)`, push, PR base `phase-5`, "Closes #46". Self-merge on green CI.

--- a/src/Voidforge.Api/Program.cs
+++ b/src/Voidforge.Api/Program.cs
@@ -35,6 +35,7 @@ builder.Services.AddMarten(opts =>
     opts.Projections.Snapshot<Planet>(SnapshotLifecycle.Inline);
     opts.Projections.Snapshot<Fleet>(SnapshotLifecycle.Inline);
     opts.Schema.For<Player>().UniqueIndex(x => x.Name);
+    opts.Schema.For<WorldSeedMarker>();
 })
 .UseLightweightSessions()
 .IntegrateWithWolverine();

--- a/src/Voidforge.Api/WorldGeneration/WorldSeedMarker.cs
+++ b/src/Voidforge.Api/WorldGeneration/WorldSeedMarker.cs
@@ -1,0 +1,11 @@
+namespace Voidforge.Api.WorldGeneration;
+
+/// <summary>Single-row marker committed atomically with the seeded world so a second
+/// concurrent seeder collides on the primary key (23505) instead of double-seeding.</summary>
+public sealed class WorldSeedMarker
+{
+    // Well-known constant id — there is only ever one of these.
+    public static readonly Guid WellKnownId = new("5eed0000-0000-0000-0000-000000000001");
+
+    public Guid Id { get; set; }
+}

--- a/src/Voidforge.Api/WorldGeneration/WorldSeeder.cs
+++ b/src/Voidforge.Api/WorldGeneration/WorldSeeder.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Voidforge.Api.Documents;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Domain.Events;
+using Voidforge.Api.Http;
 
 namespace Voidforge.Api.WorldGeneration;
 
@@ -23,6 +24,36 @@ public sealed partial class WorldSeeder(
         }
 
         var opts = options.Value;
+        StageWorld(session, opts);
+
+        try
+        {
+            // Insert (not Store): Store upserts and would silently overwrite; Insert issues a
+            // plain INSERT that trips the primary-key unique violation (23505) on a duplicate.
+            // Committing the marker in the SAME session as the world data makes both land in one
+            // transaction, so a losing concurrent seeder's marker AND its duplicate world roll
+            // back together — the count check above only short-circuits the common already-seeded
+            // restart; this marker is what actually arbitrates the genuine TOCTOU race.
+            session.Insert(new WorldSeedMarker { Id = WorldSeedMarker.WellKnownId });
+            await session.SaveChangesAsync(cancellationToken);
+            LogWorldSeeded(logger, opts.SolarSystemCount, opts.PlanetsPerSystem);
+        }
+        catch (Exception ex) when (MartenExceptions.IsUniqueViolation(ex))
+        {
+            // Another instance won the seed race; its world is authoritative and this seeder's
+            // whole batch rolled back. A duplicate is success, not an error — swallow ONLY the
+            // unique violation (a hosted service throwing from StartAsync aborts host startup;
+            // anything else must propagate).
+            LogWorldAlreadySeeded(logger, opts.SolarSystemCount);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    // Stages every solar system and planet stream into the session's pending unit of work
+    // without saving — the caller commits them together with the seed marker in one transaction.
+    private static void StageWorld(IDocumentSession session, WorldGenOptions opts)
+    {
         var random = new Random();
 
         for (var s = 0; s < opts.SolarSystemCount; s++)
@@ -60,13 +91,7 @@ public sealed partial class WorldSeeder(
                 PlanetIds = planetIds,
             });
         }
-
-        await session.SaveChangesAsync(cancellationToken);
-
-        LogWorldSeeded(logger, opts.SolarSystemCount, opts.PlanetsPerSystem);
     }
-
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     private static decimal NextCoordinate(Random random, decimal range)
     {

--- a/src/Voidforge.Tests/WorldGeneration/WorldSeederIdempotencyTests.cs
+++ b/src/Voidforge.Tests/WorldGeneration/WorldSeederIdempotencyTests.cs
@@ -1,0 +1,78 @@
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Voidforge.Api.Documents;
+using Voidforge.Api.Http;
+using Voidforge.Api.WorldGeneration;
+using Xunit;
+
+namespace Voidforge.Tests.WorldGeneration;
+
+// #46: WorldSeeder.StartAsync used to do a non-atomic read-then-act (count SolarSystems, seed if
+// zero), so two concurrent seeders both read zero and each seeded a full world. The fix commits a
+// single-row WorldSeedMarker (fixed primary key) in the SAME transaction as the world data, so the
+// loser collides on the primary key (23505) and its whole batch rolls back atomically. These tests
+// pin both halves of the guard against the shared, already-seeded fixture host.
+[Collection(IntegrationCollection.Name)]
+public sealed class WorldSeederIdempotencyTests
+{
+    private readonly IServiceProvider _services;
+
+    public WorldSeederIdempotencyTests(AppFixture fixture)
+    {
+        _services = fixture.Host.Services;
+    }
+
+    [Fact]
+    public async Task ReSeedingAnAlreadySeededWorldAddsNoNewSolarSystems()
+    {
+        // DI owns the store's lifetime — resolve it, never dispose it (testing.md pitfall).
+        var store = _services.GetRequiredService<IDocumentStore>();
+        var options = _services.GetRequiredService<IOptions<WorldGenOptions>>();
+
+        var countBefore = await CountSolarSystemsAsync(store);
+        Assert.True(countBefore > 0, "Fixture boot should have seeded a world exactly once.");
+
+        // A second seeder against the already-seeded store must take the count fast-path and return
+        // without staging or committing a second world.
+        var secondSeeder = new WorldSeeder(store, options, NullLogger<WorldSeeder>.Instance);
+        await secondSeeder.StartAsync(CancellationToken.None);
+        await secondSeeder.StopAsync(CancellationToken.None);
+
+        var countAfter = await CountSolarSystemsAsync(store);
+        Assert.Equal(countBefore, countAfter);
+    }
+
+    [Fact]
+    public async Task DuplicateSeedMarkerInsertTripsTheUniqueViolationThatArbitratesConcurrentSeeders()
+    {
+        // The fixture-boot seeder already committed the one WorldSeedMarker. Inserting the same
+        // well-known primary key again — exactly what a losing concurrent seeder does inside its own
+        // transaction — must fail SaveChanges with a Postgres unique violation (23505). That
+        // collision is what rolls the loser's whole batch (marker + duplicate world) back instead of
+        // double-seeding, so proving it deterministically proves the race arbitration.
+        //
+        // A live two-seeder concurrent run is deliberately NOT exercised here: the shared fixture DB
+        // is already seeded, so both seeders would take the count fast-path and never contend. Forcing
+        // the primary-key collision by hand proves the same mechanism without a separate empty store
+        // and without probabilistic timing — matching how the codebase pins its other race guards.
+        var store = _services.GetRequiredService<IDocumentStore>();
+
+        await using var session = store.LightweightSession();
+        // Insert (not Store): an insert-only statement that trips the PK constraint on a duplicate,
+        // whereas Store would upsert and silently succeed.
+        session.Insert(new WorldSeedMarker { Id = WorldSeedMarker.WellKnownId });
+
+        var exception = await Assert.ThrowsAnyAsync<Exception>(() => session.SaveChangesAsync());
+        Assert.True(
+            MartenExceptions.IsUniqueViolation(exception),
+            "A duplicate WorldSeedMarker insert must surface as a Postgres 23505 unique violation.");
+    }
+
+    private static async Task<int> CountSolarSystemsAsync(IDocumentStore store)
+    {
+        await using var session = store.LightweightSession();
+        return await session.Query<SolarSystem>().CountAsync();
+    }
+}

--- a/technical-design/domain-model.md
+++ b/technical-design/domain-model.md
@@ -122,6 +122,13 @@ Stores SHA-256 hashed API keys. The raw key is returned once at registration and
 
 Groups planets into a named system at a 3D position. Created during world seeding.
 
+### WorldSeedMarker
+
+- **File**: `WorldGeneration/WorldSeedMarker.cs`
+- **Fields**: `Id` (fixed `WellKnownId` constant, the primary key)
+
+Single-row marker committed atomically with the seeded world (#46). Its fixed primary key is what makes a second concurrent `WorldSeeder` collide on `23505` instead of double-seeding — see the World Seeding transaction below.
+
 ## Relationships
 
 ```
@@ -145,9 +152,16 @@ World Seeding (atomic transaction via IHostedService):
 │    For each planet:                             │
 │      StartStream<Planet>(planetId, PlanetCreated)│
 │    Store(new SolarSystem { PlanetIds = [...] }) │
+│  Insert(new WorldSeedMarker { WellKnownId })    │  → mt_doc_worldseedmarker
 │  SaveChangesAsync()  → single DB transaction    │
 └─────────────────────────────────────────────────┘
-  Idempotent: skips if SolarSystem count > 0
+  Fast-path: skips if SolarSystem count > 0 (cheap already-seeded restart).
+  Race guard (#46): the marker and the world commit in ONE transaction, so two
+  seeders that both pass the count check can't both win — the loser's Insert trips
+  the marker's primary-key unique violation (23505, detected via
+  MartenExceptions.IsUniqueViolation) and its whole batch (marker + duplicate
+  world) rolls back atomically. The loser logs "already seeded" and returns;
+  a duplicate is success, not an error (throwing from StartAsync aborts host startup).
 ```
 
 ## Adding New Aggregates


### PR DESCRIPTION
Concurrent `WorldSeeder.StartAsync` runs (multi-instance startup, or a restart racing itself) now seed the world **exactly once**. Closes #46.

## Root cause
`StartAsync` did a non-atomic read-then-act: `Query<SolarSystem>().CountAsync()`, skip if `> 0`, else build the world and `SaveChangesAsync`. Two seeders both read count 0 (TOCTOU) and each committed a full world. No lock, no marker.

## Fix
- New `WorldSeedMarker` (`src/Voidforge.Api/WorldGeneration/`) — a single-row document with a fixed well-known `Id` (its primary key).
- `StartAsync` keeps the `existingCount > 0` fast-path (cheap short-circuit for the common already-seeded restart), then `session.Insert(marker)` and commits it **in the same transaction** as the staged world. A losing concurrent seeder's marker `Insert` trips the PK unique violation (`23505`), rolling back its *entire* batch — marker and duplicate world together.
- The `23505` is caught via the `MartenExceptions.IsUniqueViolation` helper introduced in #45 and swallowed as "already seeded" (a hosted service throwing from `StartAsync` would abort host startup; only the unique violation is swallowed, anything else propagates).
- `Insert` (not `Store`): `Store` upserts and would silently overwrite the marker, never arbitrating the race — confirmed against Marten 8.37's API docs.
- World-building loop extracted to a private `StageWorld` (staging only; caller commits) — behavior-identical, keeps `StartAsync` under the method-length limit.

## Verification
- `dotnet build -warnaserror` clean; full suite in CI.
- Two tests (`WorldSeederIdempotencyTests`): the sequential re-seed fast-path adds no world; and a **deterministic** proof that re-inserting the well-known marker id — exactly what a losing seeder does — fails `SaveChanges` with a `23505` that `IsUniqueViolation` recognizes. A live two-seeder run is deliberately avoided (the shared fixture DB is already seeded, so both would take the fast-path and never contend); the hand-forced PK collision proves the same mechanism deterministically, matching the repo's existing race-guard test pattern.
- `technical-design/domain-model.md` updated (new document + seeding transaction note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)