### PR TITLE
fix: event-ordering invariant made structural (#44)

### DIFF
--- a/plans/phase-5/44-event-ordering-invariant.md
+++ b/plans/phase-5/44-event-ordering-invariant.md
@@ -1,0 +1,66 @@
+# #44 — Event-Ordering Invariant Made Structural Implementation Plan
+
+**Goal:** Close the *structural* half of #44/D14 — encode the non-decreasing-checkpoint invariant in the type system where cheaply possible, and move the residual analysis from a GitHub comment into durable design docs. Full exact-correctness (rewind-and-reapply) stays **post-MVP** per D14.
+
+## Critical framing (from the #44 survey — read before planning any code)
+
+The #47 partial fix already ships the load-bearing protection: `ResourcePool.GetCurrentValue` floors `elapsed` at 0 and `ResourcePool.Checkpoint` never moves `CheckpointTime` backwards. An out-of-order event is therefore already **inert and conservative** (under-credit only, never corruption). The survey establishes three facts that bound what #44 can add in MVP:
+
+1. **Wall-clock player-command appends provably cannot invert.** Every event's `at` is ≤ wall-clock at application time (the scheduler never fires before its scheduled instant), so a planet's `CheckpointTime` is never ahead of wall-clock; a new command at `now` always has `now ≥ CheckpointTime`. A `max(head, now)` clamp on these 8 sites is a **no-op** — building it adds a snapshot field and 8 call-site changes for zero behavior change. **Rejected.**
+2. **Scheduled-completion timestamps double as validate-on-arrival match tokens** (`Fleet.Arrive` checks `ArrivesAt == at`; `Planet.CompleteBuilding` checks `slot.CompletesAt == at`; `CompleteShipBuild` likewise). Clamping the token breaks the guard → the completion never fires → permanent stuck state. PR #47 analyzed the `matchAt`/`effectiveAt` split needed to clamp safely and found it **numerically identical** to the shipped floor. **Rejected — re-litigating #47.**
+3. **The only genuine inversions are scheduled fleet arrivals** (`CargoDeliveredToStorage`, `PlanetColonized`-via-`Claim`), stamped with `message.ArrivesAt` which can be far in the past after a host-down / dead-letter replay. The planet-side stamp is *separable* from the fleet match token, so a deterministic `max(planetHead, at)` clamp there is feasible — **but** it changes `AcceptCargoDelivery` headroom timing (headroom computed at the clamped-later instant), a subtle behavior change for marginal MVP benefit. **Deferred** to the post-MVP rewind work, documented as a known refinement.
+
+**Net:** #44's MVP-value deliverables are **WS2 (guard the one convention-bypassing Apply)** and **WS3 (durable docs of the bound + conservative guarantee)**, plus regression-tripwire tests. This is consistent with D14's "rewind-and-reapply stays post-MVP."
+
+## Global Constraints
+- `TreatWarningsAsErrors`; MA0048/MA0051. Branch `fix/44-event-ordering` off `phase-5` (after #69 merges — #69 touched `Planet.cs`/`Planet.Energy.cs` but not the colonization path; low conflict risk). Commits suffixed `(#44)`. Build-only locally; CI runs the suite.
+
+## File Structure
+```text
+src/Voidforge.Api/Domain/Planet.cs        (modify: Apply(PlanetColonized) → guarded checkpoint-then-set-value)
+technical-design/architecture.md OR a new technical-design/adr/000X-event-ordering.md  (WS3 docs)
+src/Voidforge.Tests/Planets/PlanetEventOrderingTests.cs  (add WS2 + arrival-inversion tripwire tests)
+```
+
+### Task 1: WS2 — guard `Apply(PlanetColonized)` (pure domain, unit-tested)
+
+**Files:** modify `Planet.cs` `Apply(PlanetColonized)` (~lines 42-53); test `PlanetEventOrderingTests.cs`.
+
+Current code uses raw `with` to inject seeded stores, bypassing the non-regressing `Checkpoint` — flagged by the issue as "guarded by convention, not by the type." Route it through the guarded path while preserving the seeded-store injection:
+```csharp
+public void Apply(PlanetColonized @event)
+{
+    OwnerId = @event.OwnerId;
+    // Guarded (#44): checkpoint at the colonization instant (non-regressing), then set the seeded
+    // stores. Numerically identical to the prior raw `with` on the zero-rate/zero-value claim-time
+    // pool this event always lands on (fleet Claim → 0/0; homeworld → first event after PlanetCreated),
+    // but the invariant is now type-enforced rather than convention-enforced.
+    IronOre = IronOre.Checkpoint(@event.ColonizedAt) with { CheckpointValue = @event.IronOreStored };
+    IronIngot = IronIngot.Checkpoint(@event.ColonizedAt) with { CheckpointValue = @event.IronIngotStored };
+}
+```
+- [ ] **Step 1:** Write a unit test first: colonize at `t`, assert both pools' `CheckpointValue == seeded stores` and `CheckpointTime == t`; and a second test that colonizing (via `Claim`, zero stores) after a hypothetical later `CheckpointTime` does not regress `CheckpointTime` (documents the guard). Use the `Homeworld(at)` fixture idiom.
+- [ ] **Step 2:** Apply the change. Confirm the "claim-time pools are zero-rate/zero-value" invariant still holds post-#69 (survey confirmed: #69 changed only owned-planet halting, not colonization). Keep the code comment.
+- [ ] **Step 3:** `dotnet build -warnaserror` clean. Commit: `fix: route Apply(PlanetColonized) through the guarded non-regressing checkpoint (#44)`.
+
+### Task 2: WS3 — durable docs of the inversion bound + conservative guarantee
+
+**Files:** add a short ADR `technical-design/adr/0002-event-ordering-invariant.md` (follow `adr/0001`'s format) OR a section in `architecture.md` — check which the repo prefers.
+
+- [ ] **Step 1:** Document, moving the analysis out of the #44 GitHub comment into the repo: (a) the shipped `ResourcePool` floor + non-regressing `Checkpoint` and why an inversion is inert/conservative (under-credit only); (b) the inversion-window bound — ~7s for command/completion races (ADR-0001 poll + #39 backoff), but **unbounded by outage/travel duration for scheduled fleet arrivals** (`CargoDeliveredToStorage`/`PlanetColonized` stamped with `message.ArrivesAt`); (c) why clamping scheduled-completion timestamps is rejected (match-token landmine, #47); (d) the residual under-credit and that exact correctness needs **rewind-and-reapply, tracked post-MVP** (link the follow-up issue from Task 4).
+- [ ] **Step 2:** Commit: `docs: ADR — event-ordering invariant, inversion bound, conservative guarantee (#44)`.
+
+### Task 3: Arrival-inversion tripwire test
+
+**Files:** `PlanetEventOrderingTests.cs`.
+
+- [ ] **Step 1:** Add a test simulating a far-past fleet arrival: build up a destination planet's `CheckpointTime` via intervening commands, then apply a `CargoDeliveredToStorage` stamped with an `At` well before the current head. Assert the outcome is **conservative** — checkpoint does not regress, stored value stays non-negative and ≤ capacity, and delivery under-accepts rather than corrupts (mirror `ReverseOrderShortfallIsTheInvertedWindowAtThePreCompletionRate`'s "constant offset, not widening drift" style: assert the shortfall is stable across two read times). This pins the conservative guarantee as a regression tripwire.
+- [ ] **Step 2:** `dotnet build -warnaserror`. Commit: `test: arrival-inversion stays conservative — non-regressing, non-negative tripwire (#44)`.
+
+### Task 4: Post-MVP follow-up + close-out
+
+- [ ] **Step 1:** File a post-MVP issue: "Exact event-ordering correctness via rewind-and-reapply" (`domain:core`, no phase label) — the only path to eliminating the under-credit residual; capture the survey's WS3-arrival-clamp refinement (deterministic `max(planetHead, at)` on planet-side arrival stamps, which subtly changes delivery headroom timing) as a candidate.
+- [ ] **Step 2:** PR `fix/44-event-ordering` → `phase-5`, "Closes #44" with a clear body: MVP-resolves #44 (conservative + structurally guarded + documented); full correctness → the new post-MVP issue. Self-merge on green CI.
+
+## Sequencing note
+D14 put #44 before #70 because "depletion's pool-drain math sits on this invariant." The survey shows that invariant is the **already-shipped #47 floor**, not new #44 work — so #70 does not functionally block on #44. #44 stays first (it's small and closes a wave-1 item), but if it proves contentious it can run in parallel with #70 without risk.

--- a/src/Voidforge.Api/Domain/Planet.cs
+++ b/src/Voidforge.Api/Domain/Planet.cs
@@ -39,17 +39,15 @@ public sealed partial class Planet
     // same rationale as the energy getters.
     public Coordinates GetCoordinates() => new(X, Y, Z);
 
-    // Raw `with` (not the non-regressing Checkpoint) is safe here specifically: a claimable
-    // planet's pools are zero-rate/zero-value (nothing has ever accrued, so there is nothing
-    // to lose by overwriting CheckpointTime outright), and homeworld seeding passes its
-    // starting stores explicitly via this same event rather than deriving them from an
-    // in-flight accrual. Fleet colonization always claims through Claim (zero stores, §2.4);
-    // registration's richer seeded colonization is the other caller of this event/Apply.
     public void Apply(PlanetColonized @event)
     {
         OwnerId = @event.OwnerId;
-        IronOre = IronOre with { CheckpointValue = @event.IronOreStored, CheckpointTime = @event.ColonizedAt };
-        IronIngot = IronIngot with { CheckpointValue = @event.IronIngotStored, CheckpointTime = @event.ColonizedAt };
+        // Guarded (#44): checkpoint at the colonization instant (non-regressing), then set the seeded
+        // stores. Numerically identical to the prior raw `with` on the zero-rate/zero-value claim-time
+        // pool this event always lands on (fleet Claim → 0/0; homeworld → first event after PlanetCreated),
+        // but the invariant is now type-enforced rather than convention-enforced.
+        IronOre = IronOre.Checkpoint(@event.ColonizedAt) with { CheckpointValue = @event.IronOreStored };
+        IronIngot = IronIngot.Checkpoint(@event.ColonizedAt) with { CheckpointValue = @event.IronIngotStored };
     }
 
     // The D10 null-owner assertion (spec §2.4): guards the claim itself. A genuine race

--- a/src/Voidforge.Tests/Planets/PlanetEventOrderingTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetEventOrderingTests.cs
@@ -166,4 +166,70 @@ public sealed class PlanetEventOrderingTests
         var later = now.AddSeconds(600);
         Assert.Equal(300m, BalancesAt(inOrder, later).Ore - BalancesAt(reversed, later).Ore);
     }
+
+    // Task 3 (#44): scheduled FLEET ARRIVALS are the one genuine inversion (ADR 0002). A dead-lettered
+    // or host-down-replayed CargoDeliveredToStorage is stamped with its original ArrivesAt — which can
+    // be far behind a destination checkpoint that intervening traffic has since advanced. Unlike the
+    // ~7s command/completion race, that window is bounded only by outage/travel duration. Applying such
+    // a far-past delivery must stay CONSERVATIVE: the checkpoint must not regress, the pool must stay in
+    // [0, capacity], and the buffer may under-accept (cargo rides along) but must never be corrupted.
+    [Fact]
+    public void FarPastArrivalDeliveryStaysConservativeAndNonRegressing()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        // The destination, and a control that receives the same intervening traffic but NOT the
+        // far-past delivery — so the delta between them isolates exactly what the delivery contributed.
+        var planet = Homeworld(now);
+        var control = Homeworld(now);
+
+        // Intervening in-order traffic advances the destination checkpoint 300s into the future. The
+        // ingot leg lands the buffer near capacity (5000 cap; 3100 accrued + 1800 = 4900) on purpose.
+        var head = now.AddSeconds(300);
+        var forwardOre = 100m;
+        var forwardIngot = 1800m;
+        planet.Apply(planet.AcceptCargoDelivery(Guid.NewGuid(), forwardOre, forwardIngot, head));
+        control.Apply(control.AcceptCargoDelivery(Guid.NewGuid(), forwardOre, forwardIngot, head));
+        Assert.Equal(head, planet.IronOre.CheckpointTime);
+
+        var oreBefore = planet.IronOre.GetCurrentValue(head);
+        var ingotBefore = planet.IronIngot.GetCurrentValue(head);
+
+        // A fleet that departed before `head` is replayed; its arrival is stamped with the original
+        // ArrivesAt == now, far behind the current head (the match token is deliberately left exact).
+        var delivered = planet.AcceptCargoDelivery(Guid.NewGuid(), ironOre: 1000m, ironIngot: 500m, at: now);
+        Assert.Equal(now, delivered.At);
+
+        // The ingot leg under-accepts: only ~100 of the 500 offered fits the near-full buffer, computed
+        // against the floored (not rewound) headroom. Conservative, never a corrupting over-accept.
+        Assert.True(delivered.IronIngot < 500m, $"ingot delivery did not under-accept: {delivered.IronIngot}");
+        Assert.True(delivered.IronOre <= 1000m);
+        planet.Apply(delivered);
+
+        // Guarantee 1: the rewound delivery does not drag either checkpoint backwards.
+        Assert.Equal(head, planet.IronOre.CheckpointTime);
+        Assert.Equal(head, planet.IronIngot.CheckpointTime);
+
+        // Guarantee 2: a positive delivery never REDUCES a pool (the floor absorbs the negative
+        // elapsed — without it the buffer would silently drain) and never exceeds capacity.
+        var oreAfter = planet.IronOre.GetCurrentValue(head);
+        var ingotAfter = planet.IronIngot.GetCurrentValue(head);
+        Assert.True(oreAfter >= oreBefore, $"delivery reduced ore: {oreAfter} < {oreBefore}");
+        Assert.True(ingotAfter >= ingotBefore, $"delivery reduced ingots: {ingotAfter} < {ingotBefore}");
+        Assert.InRange(oreAfter, 0m, planet.IronOre.StorageCapacity);
+        Assert.InRange(ingotAfter, 0m, planet.IronIngot.StorageCapacity);
+
+        // Guarantee 3: what the buffer actually gained is at most what the fleet carried — a far-past
+        // stamp cannot fabricate resources.
+        Assert.True(oreAfter - oreBefore <= 1000m);
+        Assert.True(ingotAfter - ingotBefore <= 500m);
+
+        // Mirror ReverseOrderShortfall's "constant offset, not widening drift": the delivery bumped
+        // CheckpointValue, not Rate, so its contribution over the control is a fixed additive step —
+        // identical whether read 120s or 600s past the head, never a widening drift.
+        var deltaOre120 = BalancesAt(planet, head.AddSeconds(120)).Ore - BalancesAt(control, head.AddSeconds(120)).Ore;
+        var deltaOre600 = BalancesAt(planet, head.AddSeconds(600)).Ore - BalancesAt(control, head.AddSeconds(600)).Ore;
+        Assert.Equal(delivered.IronOre, deltaOre120);
+        Assert.Equal(deltaOre120, deltaOre600);
+    }
 }

--- a/src/Voidforge.Tests/Planets/PlanetEventOrderingTests.cs
+++ b/src/Voidforge.Tests/Planets/PlanetEventOrderingTests.cs
@@ -39,6 +39,54 @@ public sealed class PlanetEventOrderingTests
         planet.Apply((BuildingCompleted)events[0]);
     }
 
+    private static Planet Created()
+    {
+        var planet = new Planet();
+        planet.Apply(new PlanetCreated("P", Guid.NewGuid(), 50000, 6, 10000, 5000, 0m, 0m, 0m));
+        return planet;
+    }
+
+    // WS2 (#44): the seeded-store injection still lands exactly at the colonization instant after
+    // routing Apply(PlanetColonized) through the guarded Checkpoint — numerically identical to the
+    // old raw `with` on the zero-rate/zero-value claim-time pool this event always lands on.
+    [Fact]
+    public void ColonizationSeedsStoresAtTheColonizationInstant()
+    {
+        var t = DateTimeOffset.UtcNow;
+        var planet = Created();
+
+        planet.Apply(new PlanetColonized(Guid.NewGuid(), 500, 100, t));
+
+        Assert.Equal(500m, planet.IronOre.CheckpointValue);
+        Assert.Equal(100m, planet.IronIngot.CheckpointValue);
+        Assert.Equal(t, planet.IronOre.CheckpointTime);
+        Assert.Equal(t, planet.IronIngot.CheckpointTime);
+    }
+
+    // WS2 guard (#44): with the raw `with` gone, a colonization stamped BEHIND an already-advanced
+    // pool checkpoint no longer rewinds CheckpointTime — the non-regressing Checkpoint freezes it.
+    // The claim-time pool is zero-rate/zero-value in production so this can't happen there; the test
+    // documents that the invariant is now enforced by the type, not by that convention.
+    [Fact]
+    public void ColonizingBehindAnAdvancedCheckpointDoesNotRegressIt()
+    {
+        var t = DateTimeOffset.UtcNow;
+        var planet = Created();
+
+        // Hypothetically advance the claim-time pools' checkpoint ahead of the colonization stamp.
+        var head = t.AddSeconds(120);
+        planet.IronOre = planet.IronOre with { CheckpointTime = head };
+        planet.IronIngot = planet.IronIngot with { CheckpointTime = head };
+
+        // A fleet claim seeds zero stores at the (earlier) arrival instant.
+        planet.Apply(planet.Claim(Guid.NewGuid(), t));
+
+        Assert.Equal(head, planet.IronOre.CheckpointTime);
+        Assert.Equal(head, planet.IronIngot.CheckpointTime);
+        Assert.Equal(0m, planet.IronOre.CheckpointValue);
+        Assert.Equal(0m, planet.IronIngot.CheckpointValue);
+    }
+
     [Fact]
     public void OutOfOrderCompletionNeverProducesNegativeElapsedOrBackwardsCheckpoint()
     {

--- a/technical-design/adr/0002-event-ordering-invariant.md
+++ b/technical-design/adr/0002-event-ordering-invariant.md
@@ -47,7 +47,7 @@ Clamping the token breaks the equality guard, the completion never fires, and th
 
 ## Residual under-credit and the post-MVP path
 
-The conservative guarantee leaves an **under-credit residual**: the inverted window accrues at the older rate. `ReverseOrderShortfallIsTheInvertedWindowAtThePreCompletionRate` pins this exactly — a 30 s inversion of a `5/s → 15/s` rate change leaves 300 units uncredited, a constant offset that does not widen. Eliminating the residual requires **rewind-and-reapply** — retroactively re-deriving the pool from the rewound timestamp under the post-transition rates — which is explicitly out of MVP scope (D14) and tracked as **the post-MVP rewind-and-reapply issue**.
+The conservative guarantee leaves an **under-credit residual**: the inverted window accrues at the older rate. `ReverseOrderShortfallIsTheInvertedWindowAtThePreCompletionRate` pins this exactly — a 30 s inversion of a `5/s → 15/s` rate change leaves 300 units uncredited, a constant offset that does not widen. Eliminating the residual requires **rewind-and-reapply** — retroactively re-deriving the pool from the rewound timestamp under the post-transition rates — which is explicitly out of MVP scope (D14) and tracked as **the post-MVP rewind-and-reapply issue (#81)**.
 
 That issue also carries a candidate refinement surfaced by the survey: a deterministic `max(planetHead, at)` clamp on the **planet-side arrival stamps only** (the `CargoDeliveredToStorage` / `PlanetColonized` effective instant — never the fleet `ArrivesAt` match token, which must stay exact). It is deferred because it subtly changes `AcceptCargoDelivery` headroom timing: headroom would be computed at the clamped-later instant rather than the true arrival instant, a behaviour change for marginal MVP benefit.
 
@@ -59,5 +59,5 @@ Accept the shipped `ResourcePool` floor + non-regressing `Checkpoint` as the MVP
 
 - The event-ordering invariant is now enforced by `ResourcePool` (type) plus this record, not by per-call-site convention. New pool-mutating `Apply` methods must checkpoint through `ResourcePool.Checkpoint`, never a raw `with` on `CheckpointTime`.
 - Scheduled-completion / arrival `at` timestamps remain **exact** (unclamped) because they are match tokens; the floor in `ResourcePool` absorbs any inversion they cause.
-- A known under-credit residual persists on inverted windows; it is bounded, conservative, and pinned by regression tests. Full correctness is deferred to the post-MVP rewind-and-reapply issue.
+- A known under-credit residual persists on inverted windows; it is bounded, conservative, and pinned by regression tests. Full correctness is deferred to the post-MVP rewind-and-reapply issue (#81).
 - No change to ADR 0001 — this ADR builds on its durable-scheduling model.

--- a/technical-design/adr/0002-event-ordering-invariant.md
+++ b/technical-design/adr/0002-event-ordering-invariant.md
@@ -1,0 +1,63 @@
+# ADR 0002 — Event-ordering invariant: inversion bound and the conservative guarantee
+
+- **Status:** Accepted — 2026-08-15 (**MVP-resolves #44 — structural guard + this record; exact correctness stays post-MVP**)
+- **Date:** 2026-08-15
+- **Deciders:** Tomas Grbalik
+- **Related:** issues [#44](https://github.com/VoidForgeOrg/VoidForge/issues/44), [#47](https://github.com/VoidForgeOrg/VoidForge/issues/47), [#39](https://github.com/VoidForgeOrg/VoidForge/issues/39); `technical-design/adr/0001-completion-event-resolution.md`; `src/Voidforge.Api/Domain/ResourcePool.cs`; `src/Voidforge.Tests/Planets/PlanetEventOrderingTests.cs`
+
+## Context
+
+`ResourcePool` uses lazy calculation (ADR 0001): a pool's current value is `checkpoint + rate × elapsed`, and each state-changing event checkpoints the pool at its own `at` timestamp before mutating rates or stored value. This is only sound if the `at` timestamps applied to a single Planet stream are **non-decreasing**. They are not guaranteed to be.
+
+This ADR is the durable record of the #44 survey: it states *what protects us today*, *how far a timestamp can invert*, *why the obvious clamp is rejected*, and *what residual remains for post-MVP*. It moves that analysis out of the #44 GitHub comment and into the repo.
+
+## The shipped protection (#47)
+
+Two lines in `ResourcePool` already make an out-of-order event **inert and conservative** — the load-bearing fix landed in #47:
+
+- **`GetCurrentValue` floors elapsed at zero:** `var elapsed = Math.Max(0m, (decimal)(now - CheckpointTime).TotalSeconds);`. A read stamped *before* the checkpoint yields `elapsed == 0`, not a negative one. Without the floor a negative `elapsed` silently drains an accruing pool, and a negative `elapsed` multiplied by a negative `rate` fabricates resources outright.
+- **`Checkpoint` never moves `CheckpointTime` backwards:** `CheckpointTime = now > CheckpointTime ? now : CheckpointTime`. A backwards checkpoint freezes time and locks in the value accrued up to the current head; it is a no-op on time, not a rewind. Letting it regress would re-accrue the inverted interval on every subsequent read, compounding the error instead of absorbing it once.
+
+**Consequence:** an inverted event can only ever **under-credit** — the inverted window accrues at the older (pre-transition) rate. It can never over-credit, drive a value negative, exceed `StorageCapacity`, or corrupt the stream. `Math.Clamp` in `GetCurrentValue` bounds the stored value into `[0, StorageCapacity]` as a second belt.
+
+## Why timestamps invert along a Planet stream
+
+An event's `at` is not wall-clock-at-append; it is the *intended effective instant*. Two sources produce a backwards `at`:
+
+1. **Command / completion races — bounded ~7 s.** A durable completion (ADR 0001) is stamped with its scheduled `CompletesAt = T` but commits after a poll delay. If a player command already committed at wall-clock `W > T`, the completion lands behind it. The window is bounded by ADR 0001's ~5 s durable-message poll lag plus the #39 `ConcurrencyException` retry backoff (~1.9 s) — on the order of **~7 s**.
+2. **Scheduled fleet arrivals — bounded by outage / travel, NOT 7 s.** `CompleteFleetArrivalHandler` stamps `CargoDeliveredToStorage` (Transport) and `PlanetColonized` (Colonize, via `Planet.Claim`) with `message.ArrivesAt`. After a host-down window or a dead-letter replay, that message is delivered long after `ArrivesAt` — which can therefore be **arbitrarily far in the past**. The inversion window here is bounded by the outage / travel duration, not by the ~7 s race window.
+
+## Why we do not clamp scheduled-completion timestamps
+
+The intuitive fix — clamp each event's `at` up to the current head — is rejected because those `at` values **double as validate-on-arrival match tokens**:
+
+- `Fleet.Arrive` no-ops unless `ArrivesAt == at`.
+- `Planet.CompleteBuilding` no-ops unless `slot.CompletesAt == at`.
+- `Planet.CompleteShipBuild` no-ops unless `build.CompletesAt == at`.
+
+Clamping the token breaks the equality guard, the completion never fires, and the aggregate is stuck permanently in `UnderConstruction` / `InTransit`. PR #47 analysed the `matchAt` / `effectiveAt` split that would be needed to clamp the *effective* instant while preserving the *match* token, and found the result **numerically identical to the shipped floor** for the pools involved — so the split buys nothing over what already ships.
+
+**Wall-clock player-command appends provably cannot invert.** Every event's `at` is ≤ wall-clock at application time (the scheduler never fires before its scheduled instant), so a planet's `CheckpointTime` is never ahead of wall-clock; a new command at `now` always has `now ≥ CheckpointTime`. A `max(head, now)` clamp on those sites is a no-op — no clamp is needed there.
+
+## What #44 delivers
+
+- **`Apply(PlanetColonized)` routed through the guarded checkpoint.** It previously used a raw `with` that overwrote `CheckpointTime` outright — guarded by convention, not by the type. It now calls `IronOre.Checkpoint(@event.ColonizedAt) with { CheckpointValue = @event.IronOreStored }` (likewise ingot), so the non-regressing invariant is **type-enforced**. Numerically identical on the zero-rate/zero-value claim-time pool this event always lands on.
+- **This ADR** — the durable record of the bound and the conservative guarantee.
+- **Regression tripwires** in `PlanetEventOrderingTests` — the reverse-order completion tests plus a far-past-arrival delivery test that pins the conservative outcome (non-regressing checkpoint, values in `[0, capacity]`, under-accept never corrupt).
+
+## Residual under-credit and the post-MVP path
+
+The conservative guarantee leaves an **under-credit residual**: the inverted window accrues at the older rate. `ReverseOrderShortfallIsTheInvertedWindowAtThePreCompletionRate` pins this exactly — a 30 s inversion of a `5/s → 15/s` rate change leaves 300 units uncredited, a constant offset that does not widen. Eliminating the residual requires **rewind-and-reapply** — retroactively re-deriving the pool from the rewound timestamp under the post-transition rates — which is explicitly out of MVP scope (D14) and tracked as **the post-MVP rewind-and-reapply issue**.
+
+That issue also carries a candidate refinement surfaced by the survey: a deterministic `max(planetHead, at)` clamp on the **planet-side arrival stamps only** (the `CargoDeliveredToStorage` / `PlanetColonized` effective instant — never the fleet `ArrivesAt` match token, which must stay exact). It is deferred because it subtly changes `AcceptCargoDelivery` headroom timing: headroom would be computed at the clamped-later instant rather than the true arrival instant, a behaviour change for marginal MVP benefit.
+
+## Decision
+
+Accept the shipped `ResourcePool` floor + non-regressing `Checkpoint` as the MVP invariant, make it type-enforced at the one convention-bypassing site (`Apply(PlanetColonized)`), and record the bound and the conservative guarantee here. Exact ordering correctness (rewind-and-reapply) stays post-MVP.
+
+## Consequences
+
+- The event-ordering invariant is now enforced by `ResourcePool` (type) plus this record, not by per-call-site convention. New pool-mutating `Apply` methods must checkpoint through `ResourcePool.Checkpoint`, never a raw `with` on `CheckpointTime`.
+- Scheduled-completion / arrival `at` timestamps remain **exact** (unclamped) because they are match tokens; the floor in `ResourcePool` absorbs any inversion they cause.
+- A known under-credit residual persists on inverted windows; it is bounded, conservative, and pinned by regression tests. Full correctness is deferred to the post-MVP rewind-and-reapply issue.
+- No change to ADR 0001 — this ADR builds on its durable-scheduling model.


### PR DESCRIPTION
MVP-resolves #44 by making the non-decreasing-checkpoint invariant **type-enforced** where it was convention-enforced, and moving the inversion analysis into a durable ADR. Full exact-correctness (rewind-and-reapply) is split out to **#81** (post-MVP), per design D14. Closes #44.

## Context
The #47 partial fix already ships the load-bearing protection: `ResourcePool.GetCurrentValue` floors `elapsed` at 0 and `Checkpoint` never regresses `CheckpointTime`, so an out-of-order event is **inert and conservative** (under-credit only, never corruption). The survey established that the remaining D14 work is numerically MVP-equivalent:
- Wall-clock player-command appends **provably cannot invert** (a planet's checkpoint is never ahead of wall-clock) — a clamp there is a no-op, not built.
- Scheduled-completion timestamps double as validate-on-arrival **match tokens** (`Fleet.Arrive`, `Planet.CompleteBuilding`); clamping them breaks the guard → permanent stuck state. The `matchAt`/`effectiveAt` split needed to clamp safely is numerically identical to the shipped floor (PR #47).

## What's delivered
- **`Apply(PlanetColonized)` routed through the guarded checkpoint** — `Checkpoint(ColonizedAt) with { CheckpointValue = seeded }` instead of raw `with`. Numerically identical on the zero-rate/zero-value claim-time pool this event always lands on, but the invariant is now type-enforced. Regression test `ColonizingBehindAnAdvancedCheckpointDoesNotRegressIt` fails on the old raw `with`, passes on the guarded form.
- **ADR `technical-design/adr/0002-event-ordering-invariant.md`** — the durable record: shipped protection, the inversion bound (~7 s command/completion races vs outage/travel-bounded scheduled fleet arrivals), why clamping scheduled timestamps is rejected, and the residual → #81.
- **Arrival-inversion tripwire test** — a far-past `CargoDeliveredToStorage` under-accepts, doesn't regress the checkpoint, stays non-negative/≤capacity, and the offset is constant across two read times (not widening drift).

## Verification
- `dotnet build -warnaserror` and `dotnet format --verify-no-changes` both clean.
- Full suite in CI.

## Scope note
This narrows #44 (a "bug") to its MVP-resolvable structural + documentation half; the under-credit residual is only eliminable by rewind-and-reapply (#81), which D14 already parks post-MVP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)