### PR TITLE
test: cascade scenarios, edge cases & even-split proofs (#71)

### DIFF
--- a/plans/phase-5/71-cascade-scenarios.md
+++ b/plans/phase-5/71-cascade-scenarios.md
@@ -1,0 +1,47 @@
+# #71 — Cascading Scenarios & Even-Split Proof Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Prove the four `engine.md` cascade scenarios resolve **within a single checkpoint**, cover the edge cases (simultaneous checks; all-buildings-halted), and prove even-split distribution — all as tests. **No new machinery** (design D5); the halting/depletion/demolition/ingot machinery already exists (#69/#70/#72/#83).
+
+**Architecture:** integration tests via the `DepletionCascadeTests`/`IngotStarvationCascadeTests` deterministic pattern (direct handler invocation through `InvokeHandler`, pool pinning via oversized cargo events, live-aggregate deadline math — no wall-clock waits), plus a few pure-domain unit slices where cheaper. Assert the `engine.md` L52 invariant explicitly (one `SaveChangesAsync` / one `RebaseRates` re-derivation).
+
+**Tech Stack:** .NET 9, Marten, Wolverine, xUnit + Alba, the #62 shared helpers.
+
+**Spec:** `plans/phase-5-hardening-design.md` §4, D5; `game-design/engine.md` §"Cascading Events" (L48-52 — mirror the wording in test names/comments).
+
+## Global Constraints
+- `TreatWarningsAsErrors`; MA0048/MA0051. Branch `feat/71-cascade-scenarios` off `phase-5` (after #83 merges — the scenario-2 tail needs #83). Commits suffixed `(#71)`.
+- BOTH `dotnet build -warnaserror` AND `dotnet format --verify-no-changes`. No local `dotnet test`.
+- Place in `src/Voidforge.Tests/Cascade/` (new folder, namespace `Voidforge.Tests.Cascade`) — signals the "prove the four scenarios" mandate distinctly from the incremental `Halting/*CascadeTests`.
+
+## Coverage baseline (from survey — do NOT duplicate)
+- **Scenario 1 head** (`DepletionCascadeTests`) + **energy tail as a unit slice** (`PlanetHaltingTests.ApplyBuildingHaltedLiftsProductivityMultiplierInOneRederivation`) — exist SPLIT; the full-chain-on-an-overloaded-planet integration is the gap.
+- **Scenario 2** — covered SPLIT across `DepletionCascadeTests` (ore→refinery InputStarved→ingots stop) + `IngotStarvationCascadeTests` (→ construction + ship halt). Optional single-flow stitch.
+- **Scenario 3** — unit-only (`PlanetEnergyTests.OverloadScalesProductivityProportionally`, via immediate `BuildingPlaced`); the completion-drives-overload integration is the gap.
+- **Scenario 4** — unit-only (`PlanetDemolitionTests.DemolishingAConsumerFreesEnergyAndResolvesOverloadInTheSameCommit`); the demolish-endpoint-on-overloaded-planet integration is the gap.
+- **Edge cases 5, 6 and even-split proofs 7, 8** — MISSING.
+
+## Task 1 — The four scenarios as cohesive integration tests (`Cascade/CascadeScenarioTests.cs`)
+Fill gaps 1 and 3; add the single-flow stitches for 2 and 4 (mirroring engine.md's unbroken-chain wording). Use the `InvokeHandler` + pool-pinning + `PredictX` deadline techniques; assert single-checkpoint resolution.
+- **Scenario 1 (full, on an overloaded planet):** register; build extra Drills so the planet is energy-**overloaded** (e.g. enough drills that Σ draw > 100 MW generation, m < 1 — build & complete them via `EnsureOperational...`/`BuildingConstructionCompletionHandler` or seed operational drills). Deplete the ore deposit (`PredictDepletionDeadline` → `CheckPoolDepletedHandler`). Assert: all drills `ResourceDepleted`, **energy consumption drops, `GetProductivityMultiplier`/`Energy.ProductivityMultiplier` recovers toward 1** (energy freed → overload resolves → productivity recovers), all in the depletion commit.
+- **Scenario 2 (single flow):** register; start a construction + queue a ship (ingot consumers). Empty the ore buffer + halt/deplete drills so the refinery starves → ingot production stops → the ingot buffer empties → construction + ship build halt. Assert the chain: refinery `InputStarved`, `IronIngot.Rate <= 0`, then (`CheckIngotStarvedHandler`) construction `ConstructionHalted` + ship `Halted`. (May reuse the seed helpers from the existing cascade tests.)
+- **Scenario 3 (completion drives overload):** register; queue construction of a building that, on **completion** (`CompleteBuildingConstructionHandler`), tips the planet into overload. Assert the productivity multiplier drops and dependent pool rates scale down — in the completion commit. (This is the real post-#26 path, vs. the retired immediate-place integration.)
+- **Scenario 4 (demolish resolves overload, integration):** register; reach an overloaded state; demolish a consumer via `POST .../demolish` + (deterministic) `CompleteBuildingDemolitionHandler`, OR assert the immediate-shutdown at `BuildingDemolitionStarted` already lifts the multiplier. Assert overload resolves in the commit.
+- Each test asserts the L52 "within a single checkpoint" invariant (one commit / one re-derivation).
+- Build + format. Commit: `test: engine.md cascade scenarios 1-4 as cohesive integration tests (#71)`.
+
+## Task 2 — Edge cases + even-split proofs (`Cascade/CascadeEdgeCaseTests.cs`, `Cascade/EvenSplitContentionTests.cs`)
+- **Edge 5 — simultaneous depletion + storage-full at one instant:** compose a planet where a depletion deadline and a storage-full (or buffer-empty) deadline fall at the SAME instant; invoke both handlers at that instant; assert one consistent checkpoint (correct halts, non-negative/≤cap pools, no double-apply, no throw).
+- **Edge 6 — all buildings halted (blackout):** halt every operational building (drills + refinery via `ResourceDepleted`/`InputStarved`/`OutputStorageFull`); assert the planet is stable — energy consumption == only the 5% idle floors, all production rates 0 (or buffer-drain only), and reads/queries don't throw.
+- **Even-split 7 — two refineries share insufficient ore:** planet with 2 Refineries (demand 10) and 1 Drill (inflow 10) and an empty ore buffer → aggregate refined ore clamps to inflow 10, `IronIngot.Rate = factor × 10` (each refinery implicitly gets inflow/2). Explicitly named as the scalar-pool even-split proof; assert the aggregate throughput, and (from `EvaluateInputStarvation`) that neither refinery halts (both at reduced throughput, not starved). Note in a comment there is no per-refinery tracking — even-split IS the scalar-pool clamp.
+- **Even-split 8 — shipyard build vs construction share ingots:** an ingot buffer of N with a construction drain + a ship-build drain; both reach their halt at the SAME predicted `PredictIngotBufferEmpty` instant → the shared buffer was drained evenly (both halt together in the one `CheckIngotStarved`). Assert both consumers halt at that instant.
+- Build + format. Commit: `test: cascade edge cases (simultaneous, blackout) + even-split proofs (#71)`.
+
+## Task 3 — docs note + PR
+- `technical-design/testing.md`: a short "Cascade scenario coverage (#71)" note mapping the four engine.md scenarios + edge cases + even-split to their tests, and the single-checkpoint invariant they assert.
+- PR `feat/71-cascade-scenarios` → `phase-5`, "Closes #71". Self-merge on green CI.
+
+## Notes
+- Prefer integration (they prove the real handler/commit path) but a pure-domain unit slice is fine where an integration arrangement would be disproportionate (e.g. even-split 7 can be unit if composing 2 refineries + 1 drill in-memory is cleaner).
+- If any "gap" turns out already covered once you read the code, say so and skip it — don't add a redundant test.

--- a/src/Voidforge.Tests/Cascade/CascadeEdgeCaseTests.cs
+++ b/src/Voidforge.Tests/Cascade/CascadeEdgeCaseTests.cs
@@ -1,0 +1,150 @@
+using Voidforge.Api.Domain;
+using Voidforge.Api.Domain.Events;
+using Xunit;
+
+namespace Voidforge.Tests.Cascade;
+
+// engine.md "Cascading Events" EDGE cases (#71, Task 2): (5) two independent scheduled checks falling
+// due at the SAME instant, and (6) the all-producers-halted "blackout". engine.md L52 requires each
+// cascade to resolve "within a single checkpoint" leaving a consistent state.
+//
+// Implemented as PURE-DOMAIN UNIT tests (no host). The check handlers (CheckPoolDepletedHandler,
+// CheckStorageFullHandler, …) are thin, idempotent wrappers — FetchForWriting → Evaluate* →
+// AppendMany → SaveChangesAsync — whose validate-on-arrival guard IS the Evaluate* method returning
+// []. Each handler's commit path is already exercised individually by Halting/DepletionCascadeTests
+// and the storage-halt integration tests, so the NOVEL content of both edge cases is a pure-aggregate
+// property: (5) two independent evaluators at one instant compose into one consistent, bounded,
+// idempotent (no-double-apply) state, and (6) a fully halted planet's derived energy/rates/queries are
+// stable and throw-free. Composing the aggregate in-memory expresses both directly and avoids adding
+// runtime-marginal integration tests.
+public sealed class CascadeEdgeCaseTests
+{
+    // Fixed base time so checkpoint/deadline math is deterministic (no DateTimeOffset.UtcNow).
+    private static readonly DateTimeOffset _at = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    // Colonized planet (deposit 50000, IronOre cap 10000, IronIngot cap 5000, empty buffers) with the
+    // caller-supplied operational composition — each BuildingPlaced lands Operational at _at.
+    private static Planet Colonized(params BuildingType[] operational)
+    {
+        var planet = new Planet();
+        planet.Apply(new PlanetCreated("P", Guid.NewGuid(), 50000, 6, 10000, 5000, 0m, 0m, 0m));
+        planet.Apply(new PlanetColonized(Guid.NewGuid(), 0, 0, _at));
+        foreach (var type in operational)
+        {
+            planet.Apply(new BuildingPlaced(type, _at));
+        }
+
+        return planet;
+    }
+
+    // Edge 5: a depletion deadline (deposit empty → Drill halts) and an output-storage-full deadline
+    // (ingot buffer at cap → Refinery halts) fall at the SAME instant. Firing both checks there yields
+    // ONE consistent checkpoint: correct halts on DISJOINT slots, pools clamped non-negative and ≤ cap,
+    // no throw, and re-firing either check is a validate-on-arrival no-op (no double-apply).
+    [Fact]
+    public void SimultaneousDepletionAndStorageFullResolveToOneConsistentCheckpoint()
+    {
+        // Homeworld layout: slot 0 Drill, 1 Refinery, 2 Generator.
+        var planet = Colonized(BuildingType.Drill, BuildingType.Refinery, BuildingType.Generator);
+        var t = _at.AddSeconds(5000); // the single shared instant both checks fire at.
+
+        // Pin the coincident triggers at t: the finite deposit empty (→ depletion halts the Drill), the
+        // ore buffer empty (so the Drill's OUTPUT pool is below cap and is NEVER a storage-full target —
+        // the two checks act on DISJOINT slots, making the outcome independent of which commits first),
+        // and the ingot buffer full (→ the Refinery halts OutputStorageFull). Rates are left intact so
+        // the first Apply's RebaseRates re-derives them honestly.
+        planet.IronOreDeposit = planet.IronOreDeposit with { CheckpointValue = 0m, CheckpointTime = t };
+        planet.IronOre = planet.IronOre with { CheckpointValue = 0m, CheckpointTime = t };
+        planet.IronIngot = planet.IronIngot with { CheckpointValue = planet.IronIngot.StorageCapacity, CheckpointTime = t };
+
+        // Check 1 (depletion): the deposit is empty → the operational Drill (slot 0) halts ResourceDepleted.
+        var depletionEvents = planet.EvaluateDepletion(t);
+        Assert.Equal(2, depletionEvents.Count);
+        Assert.IsType<PlanetResourceDepleted>(depletionEvents[0]);
+        var drillHalt = Assert.IsType<BuildingHalted>(depletionEvents[1]);
+        Assert.Equal(0, drillHalt.SlotIndex);
+        Assert.Equal(HaltReason.ResourceDepleted, drillHalt.Reason);
+        planet.Apply((PlanetResourceDepleted)depletionEvents[0]);
+        planet.Apply(drillHalt);
+
+        // Check 2 (storage-full) on the post-depletion state: the ingot buffer is at cap → the Refinery
+        // (slot 1) halts OutputStorageFull. The already-halted Drill is skipped (not in the Operational set).
+        var storageEvents = planet.EvaluateStorageHalts(t);
+        var refineryHalt = Assert.IsType<BuildingHalted>(Assert.Single(storageEvents));
+        Assert.Equal(1, refineryHalt.SlotIndex);
+        Assert.Equal(HaltReason.OutputStorageFull, refineryHalt.Reason);
+        planet.Apply(refineryHalt);
+
+        // One consistent checkpoint — correct halts, Generator still Operational.
+        Assert.Equal(BuildingStatus.Halted, planet.Buildings[0].Status);
+        Assert.Equal(HaltReason.ResourceDepleted, planet.Buildings[0].HaltReason);
+        Assert.Equal(BuildingStatus.Halted, planet.Buildings[1].Status);
+        Assert.Equal(HaltReason.OutputStorageFull, planet.Buildings[1].HaltReason);
+        Assert.Equal(BuildingStatus.Operational, planet.Buildings[2].Status);
+
+        // Pools non-negative and ≤ cap; all production rates settle to 0 (no operational producer left).
+        Assert.Equal(0m, planet.IronOreDeposit.GetCurrentValue(t));
+        Assert.InRange(planet.IronOre.GetCurrentValue(t), 0m, planet.IronOre.StorageCapacity);
+        Assert.InRange(planet.IronIngot.GetCurrentValue(t), 0m, planet.IronIngot.StorageCapacity);
+        Assert.Equal(planet.IronIngot.StorageCapacity, planet.IronIngot.GetCurrentValue(t));
+        Assert.Equal(0m, planet.IronOre.Rate);
+        Assert.Equal(0m, planet.IronIngot.Rate);
+        Assert.Equal(0m, planet.IronOreDeposit.Rate);
+
+        // Stable + no throw: generation covers only the 5% idle floors (0.05 × (20 + 30) = 2.5 MW), m = 1.
+        Assert.Equal(2.5m, planet.GetEnergyConsumptionMw());
+        Assert.Equal(1m, planet.GetProductivityMultiplier());
+
+        // No double-apply: re-firing either check at the same instant re-derives to [] (validate-on-arrival)
+        // — no operational Drill left to deplete, the Refinery is already halted.
+        Assert.Empty(planet.EvaluateDepletion(t));
+        Assert.Empty(planet.EvaluateStorageHalts(t));
+    }
+
+    // Edge 6: the all-producers-halted "blackout" — every Drill halts ResourceDepleted and the Refinery
+    // halts InputStarved, leaving only the Generator (a pure source, never a halt target) Operational.
+    // The planet must be stable: energy consumption is ONLY the 5% idle floors, all production rates 0,
+    // and every read/query is throw-free.
+    [Fact]
+    public void AllProducersHaltedLeavesPlanetStableOnIdleFloors()
+    {
+        // Slots: 0 Generator, 1 Drill, 2 Drill, 3 Refinery.
+        var planet = Colonized(
+            BuildingType.Generator, BuildingType.Drill, BuildingType.Drill, BuildingType.Refinery);
+
+        planet.Apply(new BuildingHalted(1, HaltReason.ResourceDepleted, _at));
+        planet.Apply(new BuildingHalted(2, HaltReason.ResourceDepleted, _at));
+        planet.Apply(new BuildingHalted(3, HaltReason.InputStarved, _at));
+
+        // Every producer halted; only the Generator stays Operational.
+        Assert.Equal(BuildingStatus.Operational, planet.Buildings[0].Status);
+        Assert.Equal(BuildingStatus.Halted, planet.Buildings[1].Status);
+        Assert.Equal(HaltReason.ResourceDepleted, planet.Buildings[1].HaltReason);
+        Assert.Equal(BuildingStatus.Halted, planet.Buildings[2].Status);
+        Assert.Equal(HaltReason.ResourceDepleted, planet.Buildings[2].HaltReason);
+        Assert.Equal(BuildingStatus.Halted, planet.Buildings[3].Status);
+        Assert.Equal(HaltReason.InputStarved, planet.Buildings[3].HaltReason);
+
+        // Energy consumption is ONLY the 5% idle floors of the three halted buildings:
+        // 0.05 × (20 + 20 + 30) = 3.5 MW. Generation (100) trivially covers it, so the planet is stable.
+        Assert.Equal(3.5m, planet.GetEnergyConsumptionMw());
+        Assert.Equal(100m, planet.GetEnergyGenerationMw());
+        Assert.Equal(1m, planet.GetProductivityMultiplier());
+
+        // All production rates are 0 — no operational producer feeds or drains anything.
+        Assert.Equal(0m, planet.IronOre.Rate);
+        Assert.Equal(0m, planet.IronIngot.Rate);
+        Assert.Equal(0m, planet.IronOreDeposit.Rate);
+
+        // Reads/queries on the blacked-out planet are stable: no throw, and every predictor/evaluator
+        // reports "nothing pending" rather than faulting on the all-zero rates.
+        Assert.Null(planet.PredictDepletionDeadline(_at));
+        Assert.Null(planet.PredictBufferEmpty(_at));
+        Assert.Null(planet.PredictIngotBufferEmpty(_at));
+        Assert.Empty(planet.PredictStorageDeadlines(_at));
+        Assert.Empty(planet.EvaluateStorageHalts(_at));
+        Assert.Empty(planet.EvaluateDepletion(_at));
+        Assert.Empty(planet.EvaluateInputStarvation(_at));
+        Assert.Empty(planet.EvaluateIngotStarvation(_at));
+    }
+}

--- a/src/Voidforge.Tests/Cascade/CascadeScenarioTests.cs
+++ b/src/Voidforge.Tests/Cascade/CascadeScenarioTests.cs
@@ -1,0 +1,326 @@
+using Alba;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Voidforge.Api.Auth;
+using Voidforge.Api.Domain;
+using Voidforge.Api.Domain.Events;
+using Voidforge.Api.Endpoints;
+using Voidforge.Tests.Support;
+using Wolverine;
+using Xunit;
+
+namespace Voidforge.Tests.Cascade;
+
+// The four engine.md "Cascading Events" scenarios (§"Cascading Events", L48-52) proven as cohesive
+// integration tests. engine.md L52: the engine must resolve each dependency chain "within a single
+// checkpoint" to maintain a consistent state. Energy is never an event — it is re-derived by RebaseRates
+// inside every composition-changing Apply — so a scenario resolves "within a single checkpoint" exactly
+// when ONE handler/endpoint commit (one SaveChangesAsync) turns the trigger AND all of its downstream
+// consequences (halts/resumes AND the energy re-derivation) into one consistent post-commit state.
+//
+// Driven deterministically via the DepletionCascadeTests/IngotStarvationCascadeTests pattern: direct
+// handler invocation through InvokeHandler, live-aggregate deadline math (PredictDepletionDeadline), and
+// pool pinning via oversized CargoLoadedFromStorage events — no wall-clock waits, no fixed sleeps.
+//
+// Coverage note (#71): the ore→refinery head (DepletionCascadeTests), the ingot-consumer tail
+// (IngotStarvationCascadeTests), and the energy/demolition slices (PlanetHaltingTests / PlanetEnergyTests
+// / PlanetDemolitionTests) already exist SPLIT. These tests fill the surveyed integration gaps —
+// full-chain-on-an-overloaded-planet (1), the completion-drives-overload path (3), the demolish-endpoint
+// path (4) — and stitch the split ore→ingot chain into one unbroken flow (2).
+[Collection(IntegrationCollection.Name)]
+public sealed class CascadeScenarioTests
+{
+    private readonly IAlbaHost _host;
+
+    public CascadeScenarioTests(AppFixture fixture)
+    {
+        _host = fixture.Host;
+    }
+
+    // Scenario 1 (engine.md: "Ore pool depletes → Drill halts (5% energy) → energy balance changes →
+    // other buildings' productivity may shift"), on an OVERLOADED planet. The freed Drill energy must
+    // resolve the overload in the SAME depletion commit.
+    [Fact]
+    public async Task DepletionOnOverloadedPlanetHaltsAllDrillsAndRecoversProductivityInOneCheckpoint()
+    {
+        var registration = await _host.RegisterPlayer("Cascade_S1_");
+        var planetId = registration.HomeworldId;
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        var at = DateTimeOffset.UtcNow;
+
+        // The homeworld seeds Drill (20 MW) + Refinery (30 MW) + Generator (100 MW gen). Add 3 more
+        // operational Drills so demand = 4 Drills (80) + Refinery (30) = 110 MW > 100 gen → m = 100/110.
+        await SeedOperationalDrills(store, planetId, count: 3, at);
+
+        var overloaded = await FetchPlanet(store, planetId);
+        Assert.Equal(110m, overloaded.GetEnergyConsumptionMw());
+        Assert.Equal(100m / 110m, overloaded.GetProductivityMultiplier());
+        Assert.True(overloaded.IronOreDeposit.Rate < 0m, "the four Drills must be draining the finite deposit.");
+
+        // Compute the deposit-empty instant from the aggregate's OWN drain math. Fire the check a hair past
+        // it (as the real poll-lagged scheduler would, ADR 0001) so the ResourcePool clamp guarantees an
+        // empty deposit regardless of decimal rounding on the fractional-m extraction rate — no wall-clock wait.
+        var depletion = overloaded.PredictDepletionDeadline(overloaded.IronOreDeposit.CheckpointTime);
+        Assert.NotNull(depletion);
+        var depletedAt = depletion.At.AddSeconds(1);
+
+        // ONE checkpoint: CheckPoolDepletedHandler does a single SaveChangesAsync. EvaluateDepletion halts
+        // every operational Drill (ResourceDepleted) and each BuildingHalted.Apply re-derives energy via
+        // RebaseRates in that same commit, so the freed Drill energy resolves the overload (engine.md L52)
+        // with NO separate energy event.
+        await InvokeHandler(store, (session, bus) =>
+            CheckPoolDepletedHandler.Handle(new CheckPoolDepleted(planetId, depletedAt), session, bus));
+
+        var after = await FetchPlanet(store, planetId);
+        var drills = after.Buildings.Where(b => b.Type == BuildingType.Drill).ToList();
+        Assert.Equal(4, drills.Count);
+        Assert.All(drills, d =>
+        {
+            Assert.Equal(BuildingStatus.Halted, d.Status);
+            Assert.Equal(HaltReason.ResourceDepleted, d.HaltReason);
+        });
+        Assert.Equal(0m, after.IronOreDeposit.GetCurrentValue(depletedAt)); // the drained deposit reads empty.
+
+        // Energy freed → overload resolved IN the depletion commit: the 4 halted Drills now draw only their
+        // 5% idle floor (4 × 1 MW) + the still-Operational Refinery (30) = 34 MW < 100 gen → m recovers to 1.
+        Assert.Equal(BuildingStatus.Operational, after.Buildings.Single(b => b.Type == BuildingType.Refinery).Status);
+        Assert.Equal(34m, after.GetEnergyConsumptionMw());
+        Assert.Equal(1m, after.GetProductivityMultiplier());
+    }
+
+    // Scenario 2 (engine.md: "Ore storage empties → Refinery halts (5% energy) → ingot production stops →
+    // Shipyard halts → construction halts") as ONE unbroken flow: deposit depleted (Drill halted) → ore
+    // buffer empty → Refinery InputStarved → ingot production stops → ingot buffer empty → the in-flight
+    // building AND ship build both pause. The tail's single-checkpoint claim is that ONE CheckIngotStarved
+    // commit pauses EVERY ingot consumer together (the shared planet-level ingot scalar drives both).
+    [Fact]
+    public async Task OreDepletionStarvesRefineryThenHaltsBothIngotConsumersAlongTheChain()
+    {
+        var registration = await _host.RegisterPlayer("Cascade_S2_");
+        var planetId = registration.HomeworldId;
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        var at = DateTimeOffset.UtcNow;
+
+        // Head of the chain: the homeworld Drill is halted ResourceDepleted (deposit depleted → ore inflow 0),
+        // with the ingot consumers (an UnderConstruction building + an Active, bay-backed ship build) in
+        // flight. The Refinery is left Operational — the chain halts it below.
+        var (constructionIdx, shipId) = await SeedChainConsumers(store, planetId, at);
+
+        // Link 1→2: pin the ore buffer empty, then the ore-starvation check halts the Refinery InputStarved.
+        await PinPoolToZero(store, planetId, ResourceType.IronOre, at);
+        await InvokeHandler(store, (session, bus) =>
+            CheckInputStarvedHandler.Handle(new CheckInputStarved(planetId, at), session, bus));
+
+        var afterRefinery = await FetchPlanet(store, planetId);
+        var refinery = afterRefinery.Buildings.Single(b => b.Type == BuildingType.Refinery);
+        Assert.Equal(BuildingStatus.Halted, refinery.Status);
+        Assert.Equal(HaltReason.InputStarved, refinery.HaltReason);
+        // Ingot production stopped: with no Refinery output the two consumers only DRAIN the ingot buffer.
+        Assert.True(
+            afterRefinery.IronIngot.Rate <= 0m,
+            $"ingot production must stop once the Refinery is starved: rate={afterRefinery.IronIngot.Rate}.");
+
+        // Tail (engine.md L52): pin the ingot buffer empty, then a SINGLE CheckIngotStarved commit pauses
+        // BOTH ingot consumers together — the building (ConstructionHalted) and the ship build (Halted).
+        await PinPoolToZero(store, planetId, ResourceType.IronIngot, at);
+        await InvokeHandler(store, (session, bus) =>
+            CheckIngotStarvedHandler.Handle(new CheckIngotStarved(planetId, at), session, bus));
+
+        var after = await FetchPlanet(store, planetId);
+        Assert.Equal(BuildingStatus.ConstructionHalted, after.Buildings[constructionIdx].Status);
+        Assert.Equal(at, after.Buildings[constructionIdx].HaltedAt);
+        var shipBuild = after.ShipQueue.Single(b => b.Id == shipId);
+        Assert.Equal(ShipBuildStatus.Halted, shipBuild.Status);
+        Assert.Equal(at, shipBuild.HaltedAt);
+    }
+
+    // Scenario 3 (engine.md: "New building comes online → energy consumption increases → planet may become
+    // overloaded → all building productivity drops"). The real post-#26 path: overload is tipped by a
+    // building COMPLETING (CompleteBuildingConstructionHandler), not by an immediate placement.
+    [Fact]
+    public async Task BuildingCompletionTipsPlanetIntoOverloadInTheCompletionCommit()
+    {
+        var registration = await _host.RegisterPlayer("Cascade_S3_");
+        var planetId = registration.HomeworldId;
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        var at = DateTimeOffset.UtcNow;
+
+        // Homeworld demand is 50 MW (Drill 20 + Refinery 30) vs 100 MW gen. Add 2 operational Drills →
+        // demand 90 MW, still under generation (m = 1). Then queue a Drill construction: while
+        // UnderConstruction it draws NOTHING (construction consumes no energy), so demand stays 90, m = 1.
+        // Its ingot drain is seeded to 0 so the pre/post ingot rate reflects only the energy throttle.
+        await SeedOperationalDrills(store, planetId, count: 2, at);
+        var completesAt = at.AddSeconds(50);
+        var constructionIdx = await SeedZeroDrainDrillConstruction(store, planetId, at, completesAt);
+
+        var beforeCompletion = await FetchPlanet(store, planetId);
+        Assert.Equal(90m, beforeCompletion.GetEnergyConsumptionMw());
+        Assert.Equal(1m, beforeCompletion.GetProductivityMultiplier());
+        Assert.Equal(10m, beforeCompletion.IronIngot.Rate); // full-throttle Refinery output: 2 × 5 ore/s.
+
+        // ONE checkpoint: CompleteBuildingConstructionHandler does a single SaveChangesAsync. The completing
+        // Drill flips Operational (demand → 110 MW), and BuildingCompleted.Apply re-derives energy via
+        // RebaseRates in that same commit, so the overload (m = 100/110) and the throttled dependent rates
+        // appear together (engine.md L52).
+        await InvokeHandler(store, (session, bus) =>
+            CompleteBuildingConstructionHandler.Handle(
+                new CompleteBuildingConstruction(planetId, constructionIdx, completesAt), session, bus));
+
+        var after = await FetchPlanet(store, planetId);
+        Assert.Equal(BuildingStatus.Operational, after.Buildings[constructionIdx].Status);
+        Assert.Equal(110m, after.GetEnergyConsumptionMw());
+        Assert.Equal(100m / 110m, after.GetProductivityMultiplier());
+        // Dependent pool rate scaled DOWN by the same m in the completion commit: the Refinery's ingot
+        // output drops from 10 to 2 × (5 × m) as its throughput is energy-throttled.
+        Assert.True(after.IronIngot.Rate < beforeCompletion.IronIngot.Rate, "the Refinery output must scale down.");
+        Assert.Equal(
+            BuildingSpecs.RefineryIngotOutputFactor
+                * (BuildingSpecs.RefineryOreConsumptionPerSecond(BuildingType.Refinery) * after.GetProductivityMultiplier()),
+            after.IronIngot.Rate);
+    }
+
+    // Scenario 4 (engine.md: "Building demolished → energy consumption decreases → planet may exit overload
+    // → productivity recovers"), through the real demolish ENDPOINT. Step 1 of the teardown
+    // (BuildingDemolitionStarted) is the immediate shutdown, so the overload lifts in that one endpoint commit.
+    [Fact]
+    public async Task DemolishingAConsumerResolvesOverloadInTheDemolitionCommit()
+    {
+        var registration = await _host.RegisterPlayer("Cascade_S4_");
+        var planetId = registration.HomeworldId;
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        var at = DateTimeOffset.UtcNow;
+
+        // Overload: homeworld Drill (20) + Refinery (30) + 3 seeded Drills (60) = 110 MW > 100 gen → m = 100/110.
+        await SeedOperationalDrills(store, planetId, count: 3, at);
+        var overloaded = await FetchPlanet(store, planetId);
+        Assert.Equal(110m, overloaded.GetEnergyConsumptionMw());
+        Assert.Equal(100m / 110m, overloaded.GetProductivityMultiplier());
+
+        // Demolish one seeded Drill (slot 3) via the endpoint. Step 1 (BuildingDemolitionStarted) leaves the
+        // Operational set (a Demolishing building draws nothing), and its Apply re-derives energy via
+        // RebaseRates in that SINGLE endpoint commit — freed energy resolves the overload (engine.md L52).
+        const int demolishedSlot = 3;
+        await _host.Scenario(s =>
+        {
+            s.Post.Url($"/api/planets/{planetId}/buildings/{demolishedSlot}/demolish");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(202);
+        });
+
+        var after = await FetchPlanet(store, planetId);
+        Assert.Equal(BuildingStatus.Demolishing, after.Buildings[demolishedSlot].Status);
+        // Demand dropped to 3 Drills (60) + Refinery (30) = 90 MW < 100 gen → productivity fully recovered.
+        Assert.Equal(90m, after.GetEnergyConsumptionMw());
+        Assert.Equal(1m, after.GetProductivityMultiplier());
+    }
+
+    // Seeds `count` additional Operational Drills onto the homeworld stream (BuildingPlaced lands
+    // Operational immediately, like registration's homeworld seeding). Each adds 20 MW of draw and 10 ore/s
+    // of inflow — the lever used to push demand past the 100 MW generation so the planet is overloaded.
+    private static async Task SeedOperationalDrills(IDocumentStore store, Guid planetId, int count, DateTimeOffset at)
+    {
+        await using var session = store.LightweightSession();
+        var stream = await session.Events.FetchForWriting<Planet>(planetId);
+        var events = new List<object>();
+        for (var i = 0; i < count; i++)
+        {
+            events.Add(new BuildingPlaced(BuildingType.Drill, at));
+        }
+
+        stream.AppendMany([.. events]);
+        await session.SaveChangesAsync();
+    }
+
+    // Seeds one UnderConstruction Drill at the next slot (Apply lands at Buildings.Count) completing at
+    // `completesAt`, with ZERO ingot drain so the pre/post-completion ingot rate isolates the energy
+    // throttle from construction draw. Returns its slot index.
+    private static async Task<int> SeedZeroDrainDrillConstruction(
+        IDocumentStore store, Guid planetId, DateTimeOffset startedAt, DateTimeOffset completesAt)
+    {
+        await using var session = store.LightweightSession();
+        var stream = await session.Events.FetchForWriting<Planet>(planetId);
+        var planet = stream.Aggregate;
+        Assert.NotNull(planet);
+        var slotIndex = planet.Buildings.Count;
+        stream.AppendMany([
+            new BuildingConstructionStarted(slotIndex, BuildingType.Drill, startedAt, completesAt, DrainPerSecond: 0m),
+        ]);
+        await session.SaveChangesAsync();
+        return slotIndex;
+    }
+
+    // Seeds scenario 2's chain state onto the homeworld stream: the homeworld Drill halted ResourceDepleted
+    // (the post-depletion head — ore inflow 0), an Operational Shipyard (so the ship build is bay-backed),
+    // an UnderConstruction building and an Active ship build (the two ingot consumers). The Refinery is left
+    // Operational so the chain halts it via CheckInputStarvedHandler. Mirrors IngotStarvationCascadeTests.
+    private static async Task<(int ConstructionIdx, Guid ShipId)> SeedChainConsumers(
+        IDocumentStore store, Guid planetId, DateTimeOffset at)
+    {
+        await using var session = store.LightweightSession();
+        var stream = await session.Events.FetchForWriting<Planet>(planetId);
+        var planet = stream.Aggregate;
+        Assert.NotNull(planet);
+
+        var drillIdx = IndexOfBuilding(planet, BuildingType.Drill);
+        var constructionIdx = planet.Buildings.Count + 1; // BuildingConstructionStarted lands right after the Shipyard.
+        var shipId = Guid.NewGuid();
+
+        stream.AppendMany([
+            new BuildingHalted(drillIdx, HaltReason.ResourceDepleted, at),
+            new BuildingPlaced(BuildingType.Shipyard, at),
+            new BuildingConstructionStarted(constructionIdx, BuildingType.Drill, at, at.AddSeconds(100), DrainPerSecond: 1m),
+            new ShipConstructionQueued(shipId, ShipType.ColonyShip, at, DrainPerSecond: 1m, BuildDurationSeconds: 30m),
+            new ShipConstructionStarted(shipId, at, at.AddSeconds(30)),
+        ]);
+        await session.SaveChangesAsync();
+        return (constructionIdx, shipId);
+    }
+
+    // Pins a stored pool to 0 at `at` via an oversized CargoLoadedFromStorage — Apply clamps
+    // (CheckpointValue − amount) into [0, cap], so loading the whole capacity zeroes the pool while leaving
+    // the other pool untouched. The documented deterministic buffer-empty technique (mirrors
+    // StorageHaltingTests / IngotStarvationCascadeTests) — no wall-clock drain wait.
+    private static async Task PinPoolToZero(
+        IDocumentStore store, Guid planetId, ResourceType resource, DateTimeOffset at)
+    {
+        await using var session = store.LightweightSession();
+        var stream = await session.Events.FetchForWriting<Planet>(planetId);
+        var planet = stream.Aggregate;
+        Assert.NotNull(planet);
+        var ore = resource == ResourceType.IronOre ? planet.IronOre.StorageCapacity : 0m;
+        var ingot = resource == ResourceType.IronIngot ? planet.IronIngot.StorageCapacity : 0m;
+        stream.AppendMany([new CargoLoadedFromStorage(Guid.NewGuid(), ore, ingot, at)]);
+        await session.SaveChangesAsync();
+    }
+
+    private static int IndexOfBuilding(Planet planet, BuildingType type)
+    {
+        for (var i = 0; i < planet.Buildings.Count; i++)
+        {
+            if (planet.Buildings[i].Type == type)
+            {
+                return i;
+            }
+        }
+
+        throw new InvalidOperationException($"Homeworld is expected to seed a {type}.");
+    }
+
+    private static async Task<Planet> FetchPlanet(IDocumentStore store, Guid planetId)
+    {
+        await using var session = store.LightweightSession();
+        var planet = await session.Events.FetchLatest<Planet>(planetId);
+        Assert.NotNull(planet);
+        return planet;
+    }
+
+    // Invokes a check handler in a fresh scope/session, mirroring DepletionCascadeTests.InvokeHandler
+    // (a real IMessageBus so the handler's self-reschedule runs through the outbox harmlessly).
+    private async Task InvokeHandler(IDocumentStore store, Func<IDocumentSession, IMessageBus, Task> handle)
+    {
+        using var scope = _host.Services.CreateScope();
+        var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+        await using var session = store.LightweightSession();
+        await handle(session, bus);
+    }
+}

--- a/src/Voidforge.Tests/Cascade/EvenSplitContentionTests.cs
+++ b/src/Voidforge.Tests/Cascade/EvenSplitContentionTests.cs
@@ -1,0 +1,129 @@
+using Voidforge.Api.Domain;
+using Voidforge.Api.Domain.Events;
+using Xunit;
+
+namespace Voidforge.Tests.Cascade;
+
+// Even-split distribution proofs (#71, Task 2). The MVP resolves competition for a scarce resource
+// among several consumers by EVEN SPLIT (game-design/resources.md) — and the engine gets that for free
+// because ore and ingots are planet-level SCALAR pools: aggregate consumption is clamped against the
+// single shared inflow / buffer scalar, so there is no per-consumer accounting to get wrong. These two
+// slices prove that emergent behaviour directly on the aggregate.
+//
+// Implemented as PURE-DOMAIN UNIT tests (no host): both properties are functions of the aggregate's own
+// rate engine (RebaseRates → EffectiveOreConsumption) and its pure predictors/evaluators
+// (PredictIngotBufferEmpty, EvaluateInputStarvation, EvaluateIngotStarvation), so an in-memory
+// composition asserts them fully and an integration arrangement would be disproportionate (the plan
+// flags even-split 7 as unit-friendly; the commit path for the ingot-consumer halts is already covered
+// by Halting/IngotStarvationCascadeTests, so proving it again here would be redundant).
+public sealed class EvenSplitContentionTests
+{
+    // Fixed base time so checkpoint/deadline math is deterministic (no DateTimeOffset.UtcNow).
+    private static readonly DateTimeOffset _at = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    // Storage caps come from PlanetCreated: deposit 50000, IronOre cap 10000, IronIngot cap 5000. Each
+    // BuildingPlaced lands Operational at _at (like registration's homeworld seeding), so the caller
+    // supplies the operational composition; the starting stores seed the buffers.
+    private static Planet Colonized(long oreStored, long ingotStored, params BuildingType[] operational)
+    {
+        var planet = new Planet();
+        planet.Apply(new PlanetCreated("P", Guid.NewGuid(), 50000, 6, 10000, 5000, 0m, 0m, 0m));
+        planet.Apply(new PlanetColonized(Guid.NewGuid(), oreStored, ingotStored, _at));
+        foreach (var type in operational)
+        {
+            planet.Apply(new BuildingPlaced(type, _at));
+        }
+
+        return planet;
+    }
+
+    // Even-split 7: several Refineries competing for one Drill's ore. EffectiveOreConsumption clamps the
+    // AGGREGATE refined ore to min(Σ refinery demand, drill inflow) against the single shared IronOre
+    // scalar — there is no per-Refinery tracking; the even split IS that scalar clamp, so each Refinery
+    // implicitly draws inflow/N.
+    //
+    // NB on composition: 2 Refineries + 1 Drill (the plan's headline numbers) has demand (10) == inflow
+    // (10) at ANY productivity multiplier — both scale by m together — so the min-clamp sits exactly on
+    // its boundary and cannot distinguish "clamped to inflow" from "unclamped at demand". To give the
+    // proof teeth (and to make "reduced throughput" literally true), this uses 3 Refineries (demand 15)
+    // against 1 Drill (inflow 10): the clamp genuinely bites. Two Generators (200 MW gen vs 110 MW draw)
+    // keep m == 1 so the energy throttle does not muddy the ore arithmetic; IronIngot.Rate is then still
+    // exactly factor × 10 == 20 (the plan's headline number), provably NOT factor × 15 == 30.
+    [Fact]
+    public void EvenSplitClampsAggregateRefiningToTheSingleSharedDrillInflow()
+    {
+        var planet = Colonized(
+            oreStored: 0,
+            ingotStored: 0,
+            BuildingType.Drill,
+            BuildingType.Refinery,
+            BuildingType.Refinery,
+            BuildingType.Refinery,
+            BuildingType.Generator,
+            BuildingType.Generator);
+
+        // Preconditions: full productivity (Generators cover the 110 MW draw) and an empty ore buffer,
+        // so EffectiveOreConsumption takes its supply-limited min(demand, inflow) branch.
+        Assert.Equal(1m, planet.GetProductivityMultiplier());
+        Assert.Equal(0m, planet.IronOre.GetCurrentValue(_at));
+
+        // Aggregate refining clamps to the single 10 ore/s inflow shared across all three Refineries:
+        // ingot output = factor × 10 == 20, NOT factor × 15 == 30 (the even-split scalar clamp bites).
+        Assert.Equal(BuildingSpecs.RefineryIngotOutputFactor * 10m, planet.IronIngot.Rate);
+        Assert.NotEqual(BuildingSpecs.RefineryIngotOutputFactor * 15m, planet.IronIngot.Rate);
+
+        // Net ore rate 0: the shared inflow exactly covers aggregate consumption, so the empty buffer is
+        // neither filled nor driven negative — there is no per-Refinery over-draw of the one scalar pool.
+        Assert.Equal(0m, planet.IronOre.Rate);
+
+        // From EvaluateInputStarvation: NONE of the Refineries halt. Starvation needs zero inflow AND an
+        // empty buffer; here inflow is 10, so every Refinery is supply-LIMITED (reduced throughput), not
+        // starved. Even-split means shared scarcity, never a halt while any ore flows.
+        Assert.Empty(planet.EvaluateInputStarvation(_at));
+    }
+
+    // Even-split 8: a construction drain and a ship-build drain competing for the shared IronIngot buffer.
+    // Because both draw from the ONE planet-level ingot scalar, the buffer empties for BOTH at a single
+    // PredictIngotBufferEmpty instant, and a single EvaluateIngotStarvation at that instant halts BOTH
+    // together (feeding one CheckIngotStarved commit — the commit path itself is covered by
+    // Halting/IngotStarvationCascadeTests). Equal drains make the shared drain-down explicit.
+    [Fact]
+    public void SharedIngotBufferEmptiesForBothConsumersAtTheSameInstant()
+    {
+        // Generator + Shipyard keep the state a valid, powered game state (m == 1, the ship build is
+        // bay-backed). No Refinery, so ingot production is 0 and the buffer only drains.
+        var planet = Colonized(oreStored: 0, ingotStored: 100, BuildingType.Generator, BuildingType.Shipyard);
+
+        // An UnderConstruction building (slot 2) draining 1 ingot/s and an Active ship build draining
+        // 1 ingot/s — both in flight past the buffer-empty instant (they complete at _at + 100s).
+        planet.Apply(new BuildingConstructionStarted(2, BuildingType.Drill, _at, _at.AddSeconds(100), DrainPerSecond: 1m));
+        var shipId = Guid.NewGuid();
+        planet.Apply(new ShipConstructionQueued(shipId, ShipType.ColonyShip, _at, DrainPerSecond: 1m, BuildDurationSeconds: 100m));
+        planet.Apply(new ShipConstructionStarted(shipId, _at, _at.AddSeconds(100)));
+
+        // The two drains share the one buffer: net ingot rate is −(1 + 1) = −2/s, productivity full.
+        Assert.Equal(1m, planet.GetProductivityMultiplier());
+        Assert.Equal(-2m, planet.IronIngot.Rate);
+
+        // One empty instant for the shared scalar buffer: 100 ingots ÷ 2/s = 50s.
+        var deadline = planet.PredictIngotBufferEmpty(_at);
+        Assert.NotNull(deadline);
+        Assert.Equal(ResourceType.IronIngot, deadline.Resource);
+        Assert.Equal(_at.AddSeconds(50), deadline.At);
+        var emptyAt = deadline.At;
+
+        // Just before that instant the shared buffer still has ingots, so NEITHER consumer halts.
+        Assert.Empty(planet.EvaluateIngotStarvation(emptyAt.AddSeconds(-1)));
+
+        // At the empty instant a single EvaluateIngotStarvation halts BOTH consumers together — one
+        // ConstructionHalted and one ShipBuildHalted, each stamped at the SAME emptyAt.
+        var halts = planet.EvaluateIngotStarvation(emptyAt);
+        Assert.Equal(2, halts.Count);
+        var constructionHalt = Assert.IsType<ConstructionHalted>(halts.Single(e => e is ConstructionHalted));
+        Assert.Equal(2, constructionHalt.SlotIndex);
+        Assert.Equal(emptyAt, constructionHalt.At);
+        var shipHalt = Assert.IsType<ShipBuildHalted>(halts.Single(e => e is ShipBuildHalted));
+        Assert.Equal(shipId, shipHalt.BuildId);
+        Assert.Equal(emptyAt, shipHalt.At);
+    }
+}

--- a/technical-design/testing.md
+++ b/technical-design/testing.md
@@ -50,6 +50,23 @@ var planet = await _host.PollUntil(owner, p => p.Buildings.Count > 0, TestTimeou
 
 Deliberately local (not shared): race-specific arrival retries (`ClaimRaceTests`), raw-Marten world mutations (`ColonizeSecondPlanetForOwner`, `UncolonizedPlanetId`), and `PlayerRegistrationTests`' inline scenarios that assert raw registration responses.
 
+## Cascade Scenario Coverage (#71)
+
+`game-design/engine.md` §"Cascading Events" (L48–52) requires each dependency chain to resolve **within a single checkpoint** — one commit / one `RebaseRates` re-derivation — so state stays consistent. Energy is never an event; it is re-derived inside every composition-changing `Apply`, so "within a single checkpoint" means the trigger AND its downstream halts/resumes AND the energy re-derivation land in one post-commit read. The `Cascade/` suite proves the four scenarios, the edge cases, and even-split distribution; the head/tail slices they build on live in `Halting/DepletionCascadeTests`, `Halting/IngotStarvationCascadeTests`, `Planets/PlanetHaltingTests`, `Planets/PlanetEnergyTests`, and `Planets/PlanetDemolitionTests`.
+
+| engine.md item | Test | Kind |
+| --- | --- | --- |
+| Scenario 1 — ore depletes → all Drills halt → freed energy resolves overload | `Cascade/CascadeScenarioTests.DepletionOnOverloadedPlanetHaltsAllDrillsAndRecoversProductivityInOneCheckpoint` | integration |
+| Scenario 2 — ore starvation → Refinery halts → ingot buffer empties → construction + ship build halt (single flow) | `Cascade/CascadeScenarioTests.OreDepletionStarvesRefineryThenHaltsBothIngotConsumersAlongTheChain` | integration |
+| Scenario 3 — building **completes** → overload → dependent rates throttle | `Cascade/CascadeScenarioTests.BuildingCompletionTipsPlanetIntoOverloadInTheCompletionCommit` | integration |
+| Scenario 4 — demolish (endpoint) frees energy → overload resolves in the start-demolition commit | `Cascade/CascadeScenarioTests.DemolishingAConsumerResolvesOverloadInTheDemolitionCommit` | integration |
+| Edge 5 — simultaneous depletion + storage-full at one instant → one consistent, bounded, idempotent state | `Cascade/CascadeEdgeCaseTests.SimultaneousDepletionAndStorageFullResolveToOneConsistentCheckpoint` | unit |
+| Edge 6 — all producers halted (blackout) → stable on 5% idle floors, all rates 0, queries throw-free | `Cascade/CascadeEdgeCaseTests.AllProducersHaltedLeavesPlanetStableOnIdleFloors` | unit |
+| Even-split 7 — refineries share one Drill's ore (aggregate clamps to inflow; no per-consumer tracking) | `Cascade/EvenSplitContentionTests.EvenSplitClampsAggregateRefiningToTheSingleSharedDrillInflow` | unit |
+| Even-split 8 — construction + ship build share the ingot buffer → empty together, halt together | `Cascade/EvenSplitContentionTests.SharedIngotBufferEmptiesForBothConsumersAtTheSameInstant` | unit |
+
+No new machinery (design D5): all halting/depletion/demolition/ingot behaviour already exists (#69/#70/#72/#83); #71 is test-only. Integration tests use the deterministic direct-handler-invocation pattern (`InvokeHandler` + `PredictX` deadline math + pool-pinning via oversized `CargoLoadedFromStorage`) — **no wall-clock waits**. Scenario 2's full chain is intentionally multi-checkpoint (three scheduled checks); its single-checkpoint claim is scoped to the ingot-consumer tail (one `CheckIngotStarved` pauses every consumer together). Edge cases and even-split proofs are pure-domain unit slices — the individual handler commit paths are already covered, and the novel content (two evaluators at one instant; the scalar-pool clamp; a shared buffer emptying for both consumers) is an aggregate property expressed directly without the runtime-marginal integration host. Even-split 7 uses 3 refineries vs 1 drill so the `min(demand, inflow)` clamp genuinely bites (2-vs-1 is tautological — demand equals inflow at every multiplier).
+
 ## Known Pitfalls
 
 ### Do Not Dispose DI-Owned IDocumentStore


### PR DESCRIPTION
Closes #71.

**Test-only (design D5) — no production code changed.** Proves the four `engine.md` "Cascading Events" scenarios resolve within a single checkpoint, covers the two edge cases, and proves even-split distribution. All halting/depletion/demolition/ingot machinery already exists (#69/#70/#72/#83).

## Coverage (see the mapping table in `technical-design/testing.md`)
- **`Cascade/CascadeScenarioTests.cs`** — the four scenarios as cohesive **integration** tests (deterministic `InvokeHandler` + `PredictX` deadline math + pool-pinning; no wall-clock waits): (1) depletion on an overloaded planet halts all Drills and recovers productivity in the depletion commit; (2) ore-depletion → refinery `InputStarved` → both ingot consumers halt, as one unbroken flow; (3) a building **completing** tips the planet into overload and throttles dependent rates in the completion commit; (4) demolishing a consumer resolves overload in the start-demolition commit.
- **`Cascade/CascadeEdgeCaseTests.cs`** — Edge 5 (simultaneous depletion + storage-full at one instant → one consistent, bounded, idempotent state, order-independent, no double-apply) and Edge 6 (all-producers blackout → stable on 5% idle floors, all rates 0, every predictor/evaluator throw-free).
- **`Cascade/EvenSplitContentionTests.cs`** — Even-split 7 (refineries share one Drill's ore; aggregate refining clamps to inflow — the scalar pool *is* the even split, no per-consumer tracking) and Even-split 8 (construction + ship build share the ingot buffer → empty together at one `PredictIngotBufferEmpty` instant, halt together in one `EvaluateIngotStarvation`).

## Notes
- Edge cases and even-split proofs are **pure-domain unit** slices: the handler commit paths are already covered by `Halting/DepletionCascadeTests`/`IngotStarvationCascadeTests`, so the novel content (coincident evaluators; the scalar clamp; a shared buffer emptying for both consumers) is an aggregate property expressed directly — keeping the runtime-marginal integration suite lean.
- Even-split 7 uses 3 refineries vs 1 drill so the `min(demand, inflow)` clamp genuinely bites; 2-vs-1 is tautological (demand == inflow at every productivity multiplier).
- Scenario 2's full chain is intentionally multi-checkpoint (three scheduled checks); its single-checkpoint claim is scoped to the ingot-consumer tail.
- CI note: the `test` job runs a ~11.5-min integration suite that has been flakily killed under load; if it fails with no xUnit summary + a `pk_mt_events_stream_and_version` duplicate-key flood, re-run before diagnosing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)