### PR TITLE
feat: API polish (ownership + ProblemDetails) & capstone e2e (#74)

### DIFF
--- a/plans/phase-5/74-api-polish-capstone.md
+++ b/plans/phase-5/74-api-polish-capstone.md
@@ -1,0 +1,67 @@
+# #74 — API Polish & Capstone e2e Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. This is the phase's closing issue and the **only wave-3 issue that touches production code broadly** — review every task's diff like a PR (memory `plan-embedded-code-needs-review-scrutiny`).
+
+**Goal:** One consistent API surface — one ownership check, one error shape (ProblemDetails everywhere) — plus a capstone e2e exercising the phase. Spec: `plans/phase-5-hardening-design.md` §7, decisions **D11, D12, D13**; closes **#74** and folds **#63**.
+
+**Tech stack:** .NET 9, Wolverine.Http endpoints, Marten, Swashbuckle (OpenAPI), xUnit + Alba, the #62 shared helpers.
+
+## Global Constraints
+- `TreatWarningsAsErrors`; MA0048/MA0051. Branch `feat/74-api-polish-capstone` off `phase-5`. Commits suffixed `(#74)`.
+- BOTH `dotnet build src/Voidforge.slnx -warnaserror` AND `dotnet format src/Voidforge.slnx --verify-no-changes` must pass per task. **No local `dotnet test`** (shared Postgres DB corruption + Stop-hook auto-run) — defer to CI. Memory `ci-test-job-flaky-kill`: the `test` job can flakily SIGKILL mid-run (no summary + `pk_mt_events_stream_and_version` flood); re-run before diagnosing.
+- Production code touched → each task committed separately, reviewed between.
+
+## Canonical patterns (PIN THESE — every task follows them identically)
+
+### Ownership (D11)
+- New `src/Voidforge.Api/Auth/ClaimsPrincipalExtensions.cs`: `public static Guid? PlayerId(this ClaimsPrincipal principal)` = `Guid.TryParse(principal.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : null`. Single source of the claim parse.
+- Ownership stays a per-endpoint comparison because the aggregate differs (planet vs fleet). Add small, intention-revealing domain helpers where they read better — `planet.IsOwnedBy(playerId)` / `fleet.IsOwnedBy(playerId)` — but the ONE claim-parse primitive is `PlayerId()`. Delete `ShipEndpoints.IsOwner`, `BuildingEndpoints.IsOwner`, `FleetEndpoints.PlayerId`, and the inline parse in `PlayerEndpoints.Me`.
+- **Behavior must not change:** 401 (no/ër bad key) is auth-layer; a valid key whose id doesn't own the aggregate → **403**; unknown aggregate → **404**. Preserve the existing 403-vs-404 ordering at each call site exactly. `GetOwnFleets` uses `PlayerId()` to SCOPE the query (not a 403 gate) — keep that semantics.
+
+### Error shape (D12)
+- Every deliberate non-2xx becomes a ProblemDetails via **`TypedResults.Problem(detail: "...", statusCode: StatusCodes.Status4xx)`** (returns `ProblemHttpResult`). Collapse each endpoint's `Results<Ok<T>, BadRequest<string>, NotFound, ForbidHttpResult, Conflict<string>>` union to `Results<Ok<T>, ProblemHttpResult>` (keep the 2xx arm(s) as-is: `Ok<T>`/`Accepted`/`Created`).
+- Map current → new, preserving status codes: `TypedResults.NotFound()`→`Problem(statusCode:404)`; `TypedResults.Forbid()`→`Problem(statusCode:403)`; `Conflict<string>(msg)`/`Conflict(msg)`→`Problem(detail:msg,statusCode:409)`; `BadRequest<string>(msg)`→`Problem(detail:msg,statusCode:400)`; `StatusCode(503)`→`Problem(statusCode:503)`. Keep the human-readable `detail` messages that already exist (e.g. "Only a completed building can be demolished.").
+- Concurrency handler `src/Voidforge.Api/Http/ConcurrencyConflictExceptionHandler.cs`: replace the bare `{ detail }` write with a ProblemDetails 409 emitted through the registered **`IProblemDetailsService`** (inject it), so it matches the endpoint shape.
+- `Program.cs` `AddProblemDetails(options => options.CustomizeProblemDetails = ctx => { ... })`: stamp a consistent shape — `Instance = ctx.HttpContext.Request.Path`, a `traceId` extension (`ctx.HttpContext.TraceIdentifier` / `Activity.Current?.Id`). Do NOT hand-set `title`/`type` per call — let the framework default them from status so the shape stays uniform.
+- **Tests:** grep the suite for error-body assertions that read a raw string (`ReadAsText`, `ShouldContain`, `ReadAsJsonAsync<string>`, or asserting the old `{ detail }` object) and update them to the ProblemDetails shape. Status-code assertions (`StatusCodeShouldBe(4xx)`) are unaffected — do not touch those. Wave-0 registration-race 409 (`PlayerEndpoints` Register `Conflict`) shape aligns automatically via this sweep; check `PlayerRegistrationTests`/the 409 race test still pass by shape.
+
+## Task 1 — Shared ownership helper (D11)
+- Add `Auth/ClaimsPrincipalExtensions.PlayerId()` (+ optional `IsOwnedBy` domain helpers). Replace all four ad-hoc copies and every call site (survey: `ShipEndpoints` :37,:76; `BuildingEndpoints` :39,:94,:146; `FleetEndpoints` :48,:129,:189,:243,:291,:310,:346 + internal :433,:462,:493; `PlayerEndpoints.Me` :187). Pure refactor — NO status-code/behavior change, so no test changes expected.
+- Acceptance check: `git grep -n "FindFirstValue(ClaimTypes.NameIdentifier)"` returns ONLY `ClaimsPrincipalExtensions.cs`.
+- Build + format. Commit: `refactor: unify ownership checks into ClaimsPrincipal.PlayerId (#74, D11)`.
+
+## Task 2 — ProblemDetails everywhere + #63 (D12)
+- Apply the D12 pattern across ALL endpoint files (`PlayerEndpoints`, `PlanetEndpoints`, `ShipEndpoints`, `SolarSystemEndpoints`, `FleetEndpoints`, `BuildingEndpoints`) + the concurrency handler + `Program.cs` `CustomizeProblemDetails`.
+- **#63:** `FleetEndpoints.GetOwnFleets` — change `FleetStatus? status` to a `string? status` query param, `Enum.TryParse<FleetStatus>(status, ignoreCase:true, out …)` guarded (reject values not in `Enum.IsDefined`), return **400 ProblemDetails** ("Unknown fleet status '{status}'.") on unparseable input before the query; null/empty keeps the current "exclude Disbanded" default. Add a test asserting `?status=bogus` → 400 ProblemDetails and a valid `?status=Travelling` still filters.
+- Update every affected existing test to the ProblemDetails body shape (grep first; see pattern note).
+- Build + format. Commit: `feat: ProblemDetails on every error response + invalid ?status=->400 (#74, D12, #63)`.
+
+## Task 3 — OpenAPI review + park frontend regen
+- Verify the live `/swagger/v1/swagger.json` includes ALL Phase 2-5 endpoints (ship-queue, buildings place/cancel/demolish, fleets missions/assemble/disband/cancel/unload/list/get/planet-fleets). Add `.ProducesProblem(4xx)` metadata (or Wolverine.Http equivalent) so the doc documents ProblemDetails error responses for the swept endpoints where it is low-effort and improves fidelity.
+- **Recapture** the stale committed snapshot `frontend/app/openapi/voidforge.json` (currently 5 of ~19 paths): run the API and dump swagger to that file (script it: `dotnet run` + `curl localhost:port/swagger/v1/swagger.json`, or a tiny test that writes it). Confirm it now lists the Phase-5 endpoints and ProblemDetails responses.
+- **PARK** the frontend zod-client regen (#64/#41): NOT near-free (14+ endpoints behind) per spec L94 — add a brief comment on those issues (or a note in this plan's PR body) that the snapshot was recaptured but the client regen stays parked. Do NOT run `bun run generate:api` in this issue.
+- Build + format. Commit: `chore: OpenAPI review + recapture openapi snapshot for phase-5 endpoints (#74)`.
+
+## Task 4 — Capstone e2e (D13: NO score assertion)
+- Extend `src/Voidforge.Tests/Colonize/FullLoopEndToEndTests.cs` (or add a sibling capstone `[Fact]` in the same collection) covering: register → build economy → **storage fills and halts a producer** (`HaltReason.OutputStorageFull`) → **transport ore away** → **producer resumes** → **cancel a build** → **recall a fleet** → **colonize** → verify final state via the READ API. NO score assertion (D13).
+- Add missing helpers to `src/Voidforge.Tests/Support/IntegrationApiExtensions.cs`: place-a-building + poll-until-`Halted`; cancel a ship build (`DELETE /api/planets/{id}/ship-queue/{buildId}`) and/or cancel construction (`DELETE …/buildings/{slot}/construction`); a resume assertion (poll `Buildings[..].Status` back to `Operational`). Recall (`Recall`/`CancelForStatus`) and colonize helpers already exist — reuse.
+- **Flaky-suite discipline:** keep it ONE cohesive test; reuse existing polling helpers + `TestTimeouts`; lean on the test host's fast balance durations so halt/resume happen quickly; avoid fixed sleeps.
+- Build + format. Commit: `test: capstone full-loop e2e — halt/resume/cancel/recall/colonize (#74)`.
+
+## Task 5 — docs note + PR (coordinator)
+- Update `technical-design/domain-model.md` / `authentication.md` (ownership helper) and `technical-design/testing.md` (capstone coverage) as touched. Note the parked frontend regen.
+- PR `feat/74-api-polish-capstone` → `phase-5`, "Closes #74. Folds #63." Self-merge on green CI.
+
+## Acceptance (from the issue)
+- [ ] One ownership-check implementation; grep finds no per-file variants (Task 1).
+- [ ] Every non-2xx response is ProblemDetails incl. 409 concurrency + validation 400s (Task 2).
+- [ ] Invalid `?status=` returns 400 — fixes #63 (Task 2).
+- [ ] OpenAPI document reflects all Phase 5 endpoints (Task 3).
+- [ ] Capstone e2e passes (Task 4).
+- [ ] `dotnet test` green (CI).
+
+## Notes / judgment calls (documented, not asked — autonomous per handover)
+- Ownership is a shared **helper**, not a blanket endpoint filter, because planet-owner vs fleet-owner vs both (`Unload`) can't be uniformly filtered — this is the minimal change that satisfies "one implementation."
+- Collapsing error unions to `ProblemHttpResult` slightly reduces per-status OpenAPI fidelity; Task 3's `.ProducesProblem` metadata restores documentation of the distinct codes.
+- Frontend zod regen stays parked (spec L94); only the committed OpenAPI snapshot is recaptured.
+- If any "gap" is already satisfied once read, say so and skip — don't add redundancy.

--- a/plans/phase-5/PHASE-5-HANDOVER.md
+++ b/plans/phase-5/PHASE-5-HANDOVER.md
@@ -1,0 +1,34 @@
+# Phase 5 (Hardening) — Session Handover
+
+**As of:** 2026-08-15, mid-phase. Read this first, then `git -C /home/dev/VoidForge log --oneline -5 phase-5` and `gh pr list` to confirm live state.
+
+## Where things stand right now (VERIFY on resume)
+- **Current branch:** `phase-5` (both #83 and #71 merged; nothing in flight). Untracked: `plans/phase-5/PHASE-5-HANDOVER.md` (this file).
+- **#83 (PR #87) — MERGED** into phase-5 (`0990e2c`). The `test` job flakily SIGKILL'd once mid-run (no xUnit summary + a `pk_mt_events_stream_and_version` dup-key flood + orphaned dotnet); a re-run went green. NOT a code bug (the #83 ingot self-reschedule provably terminates once the buffer clamps to 0). New memory: `ci-test-job-flaky-kill`.
+- **#71 (PR #88) — MERGED** into phase-5 (`2204268`). Test-only cascade/edge/even-split proofs in `src/Voidforge.Tests/Cascade/`; passed CI first try. Even-split 7 uses 3 refineries (2-vs-1 is tautological — demand==inflow at every m).
+- **FIRST ACTION on resume:** `git -C /home/dev/VoidForge checkout phase-5 && git pull --ff-only`, then `gh pr list`. **Wave 3 is next (#74 → #67 → #68).**
+
+## The workflow (established, follow exactly)
+- **One issue → one branch off `phase-5` → one PR into `phase-5` → self-merge on green CI → don't ping between PRs; report at phase end.** (Memory: `phase-integration-branch-workflow`.) The final `phase-5 → main` PR is NEVER self-merged — open it and wait for the user (Tomas).
+- **Per issue:** write a JIT plan to `plans/phase-5/<n>-<name>.md`, commit it, then implement via **subagents** (Tomas wants primarily subagents — memory `prefer-subagents-for-execution`), one subagent per plan task, **review the diff between tasks** (this gate has caught ~8 real defects). Then push, open PR, poll CI with a background bash loop, merge on green.
+- **CI gotchas:** the `lint` job runs `dotnet format --verify-no-changes` (catches IDE1006 naming etc. that `-warnaserror` misses — memory `lint-ci-runs-dotnet-format`). Always have subagents run BOTH `dotnet build src/Voidforge.slnx -warnaserror` AND `dotnet format --verify-no-changes`. NEVER run `dotnet test` locally concurrently (shared Postgres `voidforge_test` + the quality-gate Stop hook auto-runs the suite → corruption; memory `quality-gate-hook-races-test-runs`). Defer test validation to CI. Commit trailers: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` + `Claude-Session: https://claude.ai/code/session_01M7tLYUG4gAfHkgEX6Bacim`.
+- **CI poll pattern:** background `while` loop over `gh pr checks <n> --json name,state`, exit when no PENDING/IN_PROGRESS/QUEUED; it re-invokes on completion.
+
+## Progress
+Epic **#75**. Waves:
+- **Wave 0 — DONE (merged):** #62 (shared test helpers), #45 (registration 409; #61 closed as dup), #46 (WorldSeeder double-seed guard), #40 (closed after class-size audit → spawned **#78** FleetEndpoints split).
+- **Wave 1 — DONE (merged):** #69 (storage caps & halting — the keystone), #44 (event-ordering invariant, MVP-scoped: guarded `Apply(PlanetColonized)` + ADR 0002; full rewind-and-reapply → **#81** post-MVP), #70 (resource depletion + refinery ore-starvation).
+- **Wave 2 — DONE (merged):** #73 (fleet recall + #60 colonize-in-place; #58 KEPT OPEN — residual double-409 assertion fragility), #72 (building cancel/demolition, tombstone slots), #83 (zero-ingot in-flight-build halting).
+- **Wave 1 trailing / capstone — #71 (cascade scenarios & even-split proof): DONE (merged, PR #88).** Test-only (D5), 3 files in `src/Voidforge.Tests/Cascade/` (CascadeScenarioTests = scenarios 1-4 integration; CascadeEdgeCaseTests = edge 5-6 unit; EvenSplitContentionTests = even-split 7-8 unit) + coverage note in `technical-design/testing.md`. Deterministic techniques used: `InvokeHandler`, pool-pinning via oversized cargo events, `PredictX` deadline math, `_base`/`_at` fixed time.
+- **Wave 3 — NOT STARTED (NEXT):** #74 (API polish + capstone e2e — shared ownership filter replacing 3 ad-hoc impls, ProblemDetails everywhere replacing bare `{detail}`/`BadRequest<string>`, folds **#63** invalid `?status=`→400; full register→economy→halt→cancel→recall→colonize e2e, NO score assertion), #67 (lazy `ScoreCalculator` on `GET /api/players/me`), #68 (async `Leaderboard` projection + `GET /api/leaderboard`, first async Marten projection, depends on #67).
+
+## Design spec & conventions
+- Spec: `plans/phase-5-hardening-design.md` (decisions D1–D14). Docs kept current in `technical-design/domain-model.md`, `adr/0002-event-ordering-invariant.md`.
+- **Recurring event-sourcing correctness pattern:** under Marten `UseIdentityMapForAggregates=true`, appended events are re-applied to `stream.Aggregate` at `SaveChanges`. So **idempotent absolute-state events** (BuildingCompleted/Resumed) are safe to also apply in-memory before evaluating downstream resumes; **value-transforming events** (cargo deltas, `ConstructionResumed`/`ShipBuildResumed` which clear `HaltedAt`) must NOT be double-applied — append only, read results post-commit via `FetchLatest`. This has bitten 3x; scrutinize it in any resume/cascade wiring.
+- Halting machinery (reuse for #71): `Planet.Halting.cs` (`EvaluateStorageHalts/Resumes`, `EvaluateDepletion`, `EvaluateInputStarvation(Resumes)`, `EvaluateIngotStarvation(Resumes)`, `PredictStorageDeadlines`/`PredictBufferEmpty`/`PredictDepletionDeadline`/`PredictIngotBufferEmpty`), scheduled checks (`CheckStorageFull`/`CheckPoolDepleted`/`CheckInputStarved`/`CheckIngotStarved` + handlers), `StorageHaltScheduling.ScheduleAllChecksAsync` (arms all 4 checks at mutation sites). Statuses: `BuildingStatus{Operational,UnderConstruction,Halted,Cancelled,Demolishing,Demolished,ConstructionHalted}`, `ShipBuildStatus{Queued,Active,Halted}`.
+
+## Next actions in order
+1. **#74** (API polish + capstone e2e) — the biggest, PROD-code issue (spec §7, D11/D12). Survey the ownership/error-handling surface first, write a JIT plan, implement via subagents with a review gate (prod code — scrutinize hard per `plan-embedded-code-needs-review-scrutiny`). Parts: shared ownership filter replacing `ShipEndpoints.IsOwner`/inline `BuildingEndpoints` claim parsing/`FleetEndpoints.PlayerId`; ProblemDetails on every non-2xx (concurrency handler's bare `{detail}`, all `BadRequest<string>`); folds #63 (invalid `?status=`→400); OpenAPI review; capstone e2e extending `FullLoopEndToEndTests` (NO score assertion, D13).
+2. **#67** (lazy `ScoreCalculator` on `GET /api/players/me`).
+3. **#68** (async `Leaderboard` projection + `GET /api/leaderboard`; depends on #67 — first async Marten projection).
+4. When #74/#67/#68 merged → open the `phase-5 → main` PR, present the phase report, and **STOP for Tomas's approval (NEVER self-merge to main).**

--- a/src/Voidforge.Api/Auth/ClaimsPrincipalExtensions.cs
+++ b/src/Voidforge.Api/Auth/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,12 @@
+using System.Security.Claims;
+
+namespace Voidforge.Api.Auth;
+
+public static class ClaimsPrincipalExtensions
+{
+    // The single source of the player-id claim parse (D11). Every endpoint that needs the
+    // caller's player id goes through here. Returns null when the principal carries no
+    // parseable NameIdentifier claim; ownership call sites treat null as "not the owner".
+    public static Guid? PlayerId(this ClaimsPrincipal principal)
+        => Guid.TryParse(principal.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : null;
+}

--- a/src/Voidforge.Api/Domain/Planet.cs
+++ b/src/Voidforge.Api/Domain/Planet.cs
@@ -49,6 +49,11 @@ public sealed partial class Planet
     // same rationale as the energy getters.
     public Coordinates GetCoordinates() => new(X, Y, Z);
 
+    // Ownership predicate (D11): an uncolonized planet (null OwnerId) is owned by nobody, so
+    // this is false for every playerId. Callers resolve the caller's id via
+    // ClaimsPrincipal.PlayerId() first and forbid when it is null.
+    public bool IsOwnedBy(Guid playerId) => OwnerId == playerId;
+
     public void Apply(PlanetColonized @event)
     {
         OwnerId = @event.OwnerId;

--- a/src/Voidforge.Api/Endpoints/BuildingEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/BuildingEndpoints.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Marten;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
+using Voidforge.Api.Auth;
 using Voidforge.Api.Balance;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Domain.Events;
@@ -36,7 +37,7 @@ public static class BuildingEndpoints
             return TypedResults.NotFound();
         }
 
-        if (!IsOwner(principal, planet))
+        if (principal.PlayerId() is not { } playerId || !planet.IsOwnedBy(playerId))
         {
             return TypedResults.Forbid();
         }
@@ -91,7 +92,7 @@ public static class BuildingEndpoints
             return TypedResults.NotFound();
         }
 
-        if (!IsOwner(principal, planet))
+        if (principal.PlayerId() is not { } playerId || !planet.IsOwnedBy(playerId))
         {
             return TypedResults.Forbid();
         }
@@ -143,7 +144,7 @@ public static class BuildingEndpoints
             return TypedResults.NotFound();
         }
 
-        if (!IsOwner(principal, planet))
+        if (principal.PlayerId() is not { } playerId || !planet.IsOwnedBy(playerId))
         {
             return TypedResults.Forbid();
         }
@@ -175,11 +176,5 @@ public static class BuildingEndpoints
         // checks from the post-commit state (#69/#70).
         await StorageHaltScheduling.ScheduleAllChecksAsync(bus, planetId, updated!, now);
         return TypedResults.Accepted($"/api/planets/{planetId}");
-    }
-
-    private static bool IsOwner(ClaimsPrincipal principal, Planet planet)
-    {
-        var idClaim = principal.FindFirstValue(ClaimTypes.NameIdentifier);
-        return Guid.TryParse(idClaim, out var playerId) && planet.OwnerId == playerId;
     }
 }

--- a/src/Voidforge.Api/Endpoints/BuildingEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/BuildingEndpoints.cs
@@ -17,7 +17,7 @@ public static class BuildingEndpoints
     // and ingots drain over cost/duration; a durable CompleteBuildingConstruction message is
     // scheduled at the completion time (ADR 0001).
     [WolverinePost("/api/planets/{planetId}/buildings")]
-    public static async Task<Results<Ok<PlanetResponse>, NotFound, ForbidHttpResult, Conflict<string>>> Place(
+    public static async Task<Results<Ok<PlanetResponse>, ProblemHttpResult>> Place(
         Guid planetId,
         PlaceBuildingRequest request,
         ClaimsPrincipal principal,
@@ -34,12 +34,12 @@ public static class BuildingEndpoints
         var planet = stream.Aggregate;
         if (planet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         if (principal.PlayerId() is not { } playerId || !planet.IsOwnedBy(playerId))
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         var now = timeProvider.GetUtcNow();
@@ -52,7 +52,7 @@ public static class BuildingEndpoints
         }
         catch (NoFreeSlotsException ex)
         {
-            return TypedResults.Conflict(ex.Message);
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
         }
 
         stream.AppendOne(started);
@@ -76,7 +76,7 @@ public static class BuildingEndpoints
     // 204 with no body — nothing meaningful to return. Per plan decision 4, no resume hook is wired:
     // a cancelled ingot drain has nothing to un-halt in #72's world (deferred to #83).
     [WolverineDelete("/api/planets/{planetId}/buildings/{slotIndex}/construction")]
-    public static async Task<Results<NoContent, NotFound, ForbidHttpResult, Conflict<string>>> CancelConstruction(
+    public static async Task<Results<NoContent, ProblemHttpResult>> CancelConstruction(
         Guid planetId,
         int slotIndex,
         ClaimsPrincipal principal,
@@ -89,24 +89,24 @@ public static class BuildingEndpoints
         var planet = stream.Aggregate;
         if (planet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         if (principal.PlayerId() is not { } playerId || !planet.IsOwnedBy(playerId))
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         // SlotIndex addresses the append-only Buildings list, so range is against the raw count; a
         // tombstoned slot is in range but its status is not UnderConstruction, handled below as 409.
         if (slotIndex < 0 || slotIndex >= planet.Buildings.Count)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         if (planet.Buildings[slotIndex].Status != BuildingStatus.UnderConstruction)
         {
-            return TypedResults.Conflict("Only in-progress construction can be cancelled.");
+            return TypedResults.Problem(detail: "Only in-progress construction can be cancelled.", statusCode: StatusCodes.Status409Conflict);
         }
 
         var now = timeProvider.GetUtcNow();
@@ -128,7 +128,7 @@ public static class BuildingEndpoints
     // list position throughout, so SlotIndex stays stable. 202 Accepted — the teardown is deferred.
     // Per plan decision 4, no resume hook is wired (deferred to #83). No cancel-of-demolition.
     [WolverinePost("/api/planets/{planetId}/buildings/{slotIndex}/demolish")]
-    public static async Task<Results<Accepted, NotFound, ForbidHttpResult, Conflict<string>>> Demolish(
+    public static async Task<Results<Accepted, ProblemHttpResult>> Demolish(
         Guid planetId,
         int slotIndex,
         ClaimsPrincipal principal,
@@ -141,23 +141,23 @@ public static class BuildingEndpoints
         var planet = stream.Aggregate;
         if (planet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         if (principal.PlayerId() is not { } playerId || !planet.IsOwnedBy(playerId))
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         // SlotIndex addresses the append-only Buildings list, so range is against the raw count.
         if (slotIndex < 0 || slotIndex >= planet.Buildings.Count)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         if (planet.Buildings[slotIndex].Status is not (BuildingStatus.Operational or BuildingStatus.Halted))
         {
-            return TypedResults.Conflict("Only a completed building can be demolished.");
+            return TypedResults.Problem(detail: "Only a completed building can be demolished.", statusCode: StatusCodes.Status409Conflict);
         }
 
         var now = timeProvider.GetUtcNow();

--- a/src/Voidforge.Api/Endpoints/FleetEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/FleetEndpoints.cs
@@ -23,7 +23,7 @@ public static class FleetEndpoints
     // CompleteFleetArrivalHandler — which is where Transport's cargo delivery and
     // Colonize's guarded claim happen.
     [WolverinePost("/api/fleets/{fleetId}/missions")]
-    public static async Task<Results<Ok<FleetResponse>, BadRequest<string>, NotFound, ForbidHttpResult, Conflict<string>>> Launch(
+    public static async Task<Results<Ok<FleetResponse>, ProblemHttpResult>> Launch(
         Guid fleetId,
         LaunchMissionRequest request,
         ClaimsPrincipal principal,
@@ -43,31 +43,31 @@ public static class FleetEndpoints
         var fleet = stream.Aggregate;
         if (fleet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         var playerId = principal.PlayerId();
         if (playerId != fleet.OwnerId)
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         if (fleet.Status != FleetStatus.Stationed || fleet.LocationPlanetId is null)
         {
-            return TypedResults.Conflict("Only a stationed fleet can be launched.");
+            return TypedResults.Problem(detail: "Only a stationed fleet can be launched.", statusCode: StatusCodes.Status409Conflict);
         }
 
         // #60: Move/Transport to the current location is a 400 (no journey); colonize-in-place
         // is exempt — a zero-distance plan arrives at once and the guarded claim decides.
         if (request.DestinationPlanetId == fleet.LocationPlanetId && request.Mission != MissionType.Colonize)
         {
-            return TypedResults.BadRequest("Destination must differ from the fleet's current location.");
+            return TypedResults.Problem(detail: "Destination must differ from the fleet's current location.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         var destination = await session.LoadAsync<Planet>(request.DestinationPlanetId);
         if (destination is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         var missionError = ValidateMissionPrecondition(request.Mission, fleet, destination, playerId);
@@ -100,7 +100,7 @@ public static class FleetEndpoints
     // when requested, additionally requires owning the planet (you cannot draw from someone
     // else's storage).
     [WolverinePost("/api/planets/{planetId}/fleets")]
-    public static async Task<Results<Ok<FleetResponse>, BadRequest<string>, NotFound, ForbidHttpResult, Conflict<string>>> Assemble(
+    public static async Task<Results<Ok<FleetResponse>, ProblemHttpResult>> Assemble(
         Guid planetId,
         AssembleFleetRequest request,
         ClaimsPrincipal principal,
@@ -111,12 +111,12 @@ public static class FleetEndpoints
     {
         if (request.ShipIds is null || request.ShipIds.Count == 0)
         {
-            return TypedResults.BadRequest("shipIds must not be empty.");
+            return TypedResults.Problem(detail: "shipIds must not be empty.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         if (request.ShipIds.Distinct().Count() != request.ShipIds.Count)
         {
-            return TypedResults.BadRequest("shipIds must not contain duplicates.");
+            return TypedResults.Problem(detail: "shipIds must not contain duplicates.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         // FetchForWriting arms Marten's optimistic-concurrency guard (#39).
@@ -124,7 +124,7 @@ public static class FleetEndpoints
         var planet = stream.Aggregate;
         if (planet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         var playerId = principal.PlayerId();
@@ -173,7 +173,7 @@ public static class FleetEndpoints
     // Disband (D6 counterpart): ships reach a roster only through this path. Allowed at
     // unowned/foreign planets (fleets.md); refused while cargo remains from #50 on.
     [WolverinePost("/api/fleets/{fleetId}/disband")]
-    public static async Task<Results<Ok<FleetResponse>, NotFound, ForbidHttpResult, Conflict<string>>> Disband(
+    public static async Task<Results<Ok<FleetResponse>, ProblemHttpResult>> Disband(
         Guid fleetId,
         ClaimsPrincipal principal,
         IDocumentSession session,
@@ -184,17 +184,17 @@ public static class FleetEndpoints
         var fleet = fleetStream.Aggregate;
         if (fleet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         if (principal.PlayerId() != fleet.OwnerId)
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         if (fleet.Status != FleetStatus.Stationed || fleet.LocationPlanetId is null)
         {
-            return TypedResults.Conflict("Only a stationed fleet can be disbanded.");
+            return TypedResults.Problem(detail: "Only a stationed fleet can be disbanded.", statusCode: StatusCodes.Status409Conflict);
         }
 
         // D11 (#50): pre-validate here rather than let Fleet.Disband's own guard throw —
@@ -203,7 +203,7 @@ public static class FleetEndpoints
         // InvalidOperationException as a 500 instead of the spec's 409.
         if (fleet.GetCargoLoad() > 0)
         {
-            return TypedResults.Conflict("Cannot disband a fleet with cargo aboard.");
+            return TypedResults.Problem(detail: "Cannot disband a fleet with cargo aboard.", statusCode: StatusCodes.Status409Conflict);
         }
 
         var planetStream = await session.Events.FetchForWriting<Planet>(fleet.LocationPlanetId.Value);
@@ -226,7 +226,7 @@ public static class FleetEndpoints
     // the originally-scheduled CompleteFleetArrival(oldArrivesAt) goes stale and no-ops via
     // Fleet.Arrive's validate-on-arrival guard (ADR 0001 — no outbox cancellation).
     [WolverinePost("/api/fleets/{fleetId}/cancel")]
-    public static async Task<Results<Ok<FleetResponse>, NotFound, ForbidHttpResult, Conflict<string>>> Cancel(
+    public static async Task<Results<Ok<FleetResponse>, ProblemHttpResult>> Cancel(
         Guid fleetId,
         ClaimsPrincipal principal,
         IDocumentSession session,
@@ -238,24 +238,24 @@ public static class FleetEndpoints
         var fleet = stream.Aggregate;
         if (fleet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         if (principal.PlayerId() != fleet.OwnerId)
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         if (fleet.Status != FleetStatus.InTransit)
         {
-            return TypedResults.Conflict("Only an in-transit fleet can be recalled.");
+            return TypedResults.Problem(detail: "Only an in-transit fleet can be recalled.", statusCode: StatusCodes.Status409Conflict);
         }
 
         // Pre-check the "already returning" marker here rather than let Fleet.Recall's guard
         // throw — that guard is a defensive backstop, not the 409 path (mirrors Disband's cargo pre-check).
         if (fleet.RecalledAt is not null)
         {
-            return TypedResults.Conflict("Fleet is already returning.");
+            return TypedResults.Problem(detail: "Fleet is already returning.", statusCode: StatusCodes.Status409Conflict);
         }
 
         var now = timeProvider.GetUtcNow();
@@ -275,7 +275,7 @@ public static class FleetEndpoints
     // after a partial delivery (destination storage was full), and for Move fleets — which
     // never auto-unload — carrying cargo to their new location.
     [WolverinePost("/api/fleets/{fleetId}/unload")]
-    public static async Task<Results<Ok<FleetResponse>, NotFound, ForbidHttpResult, Conflict<string>>> Unload(
+    public static async Task<Results<Ok<FleetResponse>, ProblemHttpResult>> Unload(
         Guid fleetId,
         ClaimsPrincipal principal,
         IDocumentSession session,
@@ -286,22 +286,22 @@ public static class FleetEndpoints
         var fleet = fleetStream.Aggregate;
         if (fleet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         if (principal.PlayerId() != fleet.OwnerId)
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         if (fleet.Status != FleetStatus.Stationed || fleet.LocationPlanetId is null)
         {
-            return TypedResults.Conflict("Only a stationed fleet can unload cargo.");
+            return TypedResults.Problem(detail: "Only a stationed fleet can unload cargo.", statusCode: StatusCodes.Status409Conflict);
         }
 
         if (fleet.GetCargoLoad() == 0)
         {
-            return TypedResults.Conflict("No cargo aboard.");
+            return TypedResults.Problem(detail: "No cargo aboard.", statusCode: StatusCodes.Status409Conflict);
         }
 
         var planetStream = await session.Events.FetchForWriting<Planet>(fleet.LocationPlanetId.Value);
@@ -310,7 +310,7 @@ public static class FleetEndpoints
 
         if (planet.OwnerId != principal.PlayerId())
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         var now = timeProvider.GetUtcNow();
@@ -329,10 +329,10 @@ public static class FleetEndpoints
     // The caller's fleets (mutation-adjacent view — scoped to owner rather than universe,
     // matching "my empire" reads). Disbanded fleets are history: excluded unless asked for.
     [WolverineGet("/api/fleets")]
-    public static async Task<Results<Ok<PagedResponse<FleetSummaryResponse>>, BadRequest<string>>> GetOwnFleets(
+    public static async Task<Results<Ok<PagedResponse<FleetSummaryResponse>>, ProblemHttpResult>> GetOwnFleets(
         ClaimsPrincipal principal,
         IQuerySession session,
-        FleetStatus? status = null,
+        string? status = null,
         int? page = null,
         int? pageSize = null)
     {
@@ -341,14 +341,29 @@ public static class FleetEndpoints
             pageSize ?? PaginationParameters.DefaultPageSize);
         if (parameters is null)
         {
-            return TypedResults.BadRequest("page and pageSize must be >= 1.");
+            return TypedResults.Problem(detail: "page and pageSize must be >= 1.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        // #63: `status` is a free-text query param. Omitted/empty keeps the default (exclude
+        // Disbanded history); any other value must parse to a defined FleetStatus or it is a 400 —
+        // never a silent empty result. Enum.TryParse alone accepts out-of-range numeric strings, so
+        // guard with Enum.IsDefined too.
+        FleetStatus? statusFilter = null;
+        if (!string.IsNullOrEmpty(status))
+        {
+            if (!Enum.TryParse<FleetStatus>(status, ignoreCase: true, out var parsed) || !Enum.IsDefined(parsed))
+            {
+                return TypedResults.Problem(detail: $"Unknown fleet status '{status}'.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            statusFilter = parsed;
         }
 
         var playerId = principal.PlayerId();
         var query = session.Query<Fleet>().Where(f => f.OwnerId == playerId);
-        query = status is null
+        query = statusFilter is null
             ? query.Where(f => f.Status != FleetStatus.Disbanded)
-            : query.Where(f => f.Status == status);
+            : query.Where(f => f.Status == statusFilter);
 
         var response = await query
             .OrderBy(f => f.AssembledAt).ThenBy(f => f.Id)
@@ -359,13 +374,13 @@ public static class FleetEndpoints
 
     // Universe-visible (full visibility, no fog of war in MVP).
     [WolverineGet("/api/fleets/{fleetId}")]
-    public static async Task<Results<Ok<FleetResponse>, NotFound>> GetFleet(
+    public static async Task<Results<Ok<FleetResponse>, ProblemHttpResult>> GetFleet(
         Guid fleetId, IQuerySession session, IOptions<BalanceOptions> balanceOptions)
     {
         var fleet = await session.LoadAsync<Fleet>(fleetId);
         if (fleet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         var balance = balanceOptions.Value;
@@ -374,7 +389,7 @@ public static class FleetEndpoints
 
     // Universe-visible: fleets currently stationed at this planet.
     [WolverineGet("/api/planets/{planetId}/fleets")]
-    public static async Task<Results<Ok<PagedResponse<FleetSummaryResponse>>, NotFound, BadRequest<string>>> GetPlanetFleets(
+    public static async Task<Results<Ok<PagedResponse<FleetSummaryResponse>>, ProblemHttpResult>> GetPlanetFleets(
         Guid planetId,
         IQuerySession session,
         int? page = null,
@@ -383,7 +398,7 @@ public static class FleetEndpoints
         var planet = await session.LoadAsync<Planet>(planetId);
         if (planet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         var parameters = PaginationParameters.Create(
@@ -391,7 +406,7 @@ public static class FleetEndpoints
             pageSize ?? PaginationParameters.DefaultPageSize);
         if (parameters is null)
         {
-            return TypedResults.BadRequest("page and pageSize must be >= 1.");
+            return TypedResults.Problem(detail: "page and pageSize must be >= 1.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         var response = await session.Query<Fleet>()
@@ -405,17 +420,17 @@ public static class FleetEndpoints
     // Mission/destination shape checks that don't need the fleet or DB yet. Returns null
     // when the request is valid; kept as its own method so Launch stays within MA0051's
     // line limit.
-    private static Results<Ok<FleetResponse>, BadRequest<string>, NotFound, ForbidHttpResult, Conflict<string>>? ValidateLaunchRequest(
+    private static Results<Ok<FleetResponse>, ProblemHttpResult>? ValidateLaunchRequest(
         LaunchMissionRequest request)
     {
         if (!Enum.IsDefined(request.Mission))
         {
-            return TypedResults.BadRequest("Unknown mission type.");
+            return TypedResults.Problem(detail: "Unknown mission type.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         if (request.DestinationPlanetId == Guid.Empty)
         {
-            return TypedResults.BadRequest("destinationPlanetId is required.");
+            return TypedResults.Problem(detail: "destinationPlanetId is required.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         return null;
@@ -428,17 +443,17 @@ public static class FleetEndpoints
     // whether the destination is already owned is exactly what arrival decides (guarded
     // claim vs. ColonizationFailed), not something launch can pre-empt. Returns null when
     // the request is valid; kept as its own method so Launch stays within MA0051's line limit.
-    private static Results<Ok<FleetResponse>, BadRequest<string>, NotFound, ForbidHttpResult, Conflict<string>>? ValidateMissionPrecondition(
+    private static Results<Ok<FleetResponse>, ProblemHttpResult>? ValidateMissionPrecondition(
         MissionType mission, Fleet fleet, Planet destination, Guid? playerId)
     {
         if (mission == MissionType.Transport && destination.OwnerId != playerId)
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         if (mission == MissionType.Colonize && !fleet.Ships.Any(s => s.Type == ShipType.ColonyShip))
         {
-            return TypedResults.Conflict("Colonize requires a Colony Ship.");
+            return TypedResults.Problem(detail: "Colonize requires a Colony Ship.", statusCode: StatusCodes.Status409Conflict);
         }
 
         return null;
@@ -448,7 +463,7 @@ public static class FleetEndpoints
     // and checks the caller owns every one of them (403, per D13). Returns null and the
     // resolved ships via `out` when valid; kept as its own method so Assemble stays within
     // MA0051's line limit.
-    private static Results<Ok<FleetResponse>, BadRequest<string>, NotFound, ForbidHttpResult, Conflict<string>>? ResolveOwnedShips(
+    private static Results<Ok<FleetResponse>, ProblemHttpResult>? ResolveOwnedShips(
         Planet planet, IReadOnlyList<Guid> shipIds, Guid? playerId, out List<RosterShip> ships)
     {
         var byId = planet.Ships.ToDictionary(s => s.Id);
@@ -456,13 +471,13 @@ public static class FleetEndpoints
         if (missing.Count > 0)
         {
             ships = [];
-            return TypedResults.Conflict($"Ship(s) not on this planet's roster: {string.Join(", ", missing)}.");
+            return TypedResults.Problem(detail: $"Ship(s) not on this planet's roster: {string.Join(", ", missing)}.", statusCode: StatusCodes.Status409Conflict);
         }
 
         ships = shipIds.Select(id => byId[id]).ToList();
         if (playerId is null || ships.Any(s => s.OwnerId != playerId))
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         return null;
@@ -472,7 +487,7 @@ public static class FleetEndpoints
     // combined capacity → planet not owned by the caller → over what's actually stored).
     // Returns null when the request is valid; kept as its own method so Assemble stays
     // within MA0051's line limit.
-    private static Results<Ok<FleetResponse>, BadRequest<string>, NotFound, ForbidHttpResult, Conflict<string>>? ValidateCargo(
+    private static Results<Ok<FleetResponse>, ProblemHttpResult>? ValidateCargo(
         CargoRequest cargo,
         IReadOnlyList<RosterShip> ships,
         Planet planet,
@@ -482,23 +497,23 @@ public static class FleetEndpoints
     {
         if (cargo.IronOre < 0m || cargo.IronIngot < 0m)
         {
-            return TypedResults.BadRequest("Cargo amounts cannot be negative.");
+            return TypedResults.Problem(detail: "Cargo amounts cannot be negative.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         var capacity = ships.Sum(s => balance.Ships.For(s.Type).CargoCapacity);
         if (cargo.IronOre + cargo.IronIngot > capacity)
         {
-            return TypedResults.BadRequest("Cargo exceeds the selected ships' combined capacity.");
+            return TypedResults.Problem(detail: "Cargo exceeds the selected ships' combined capacity.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         if (planet.OwnerId != playerId)
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         if (cargo.IronOre > planet.IronOre.GetCurrentValue(now) || cargo.IronIngot > planet.IronIngot.GetCurrentValue(now))
         {
-            return TypedResults.Conflict("Insufficient stored resources for the requested cargo.");
+            return TypedResults.Problem(detail: "Insufficient stored resources for the requested cargo.", statusCode: StatusCodes.Status409Conflict);
         }
 
         return null;

--- a/src/Voidforge.Api/Endpoints/FleetEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/FleetEndpoints.cs
@@ -3,6 +3,7 @@ using Marten;
 using Marten.Events;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
+using Voidforge.Api.Auth;
 using Voidforge.Api.Balance;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Domain.Events;
@@ -45,7 +46,7 @@ public static class FleetEndpoints
             return TypedResults.NotFound();
         }
 
-        var playerId = PlayerId(principal);
+        var playerId = principal.PlayerId();
         if (playerId != fleet.OwnerId)
         {
             return TypedResults.Forbid();
@@ -126,7 +127,7 @@ public static class FleetEndpoints
             return TypedResults.NotFound();
         }
 
-        var playerId = PlayerId(principal);
+        var playerId = principal.PlayerId();
         var shipsError = ResolveOwnedShips(planet, request.ShipIds, playerId, out var ships);
         if (shipsError is not null)
         {
@@ -186,7 +187,7 @@ public static class FleetEndpoints
             return TypedResults.NotFound();
         }
 
-        if (PlayerId(principal) != fleet.OwnerId)
+        if (principal.PlayerId() != fleet.OwnerId)
         {
             return TypedResults.Forbid();
         }
@@ -240,7 +241,7 @@ public static class FleetEndpoints
             return TypedResults.NotFound();
         }
 
-        if (PlayerId(principal) != fleet.OwnerId)
+        if (principal.PlayerId() != fleet.OwnerId)
         {
             return TypedResults.Forbid();
         }
@@ -288,7 +289,7 @@ public static class FleetEndpoints
             return TypedResults.NotFound();
         }
 
-        if (PlayerId(principal) != fleet.OwnerId)
+        if (principal.PlayerId() != fleet.OwnerId)
         {
             return TypedResults.Forbid();
         }
@@ -307,7 +308,7 @@ public static class FleetEndpoints
         var planet = planetStream.Aggregate
             ?? throw new InvalidOperationException($"Fleet {fleetId} is stationed at unknown planet {fleet.LocationPlanetId}.");
 
-        if (planet.OwnerId != PlayerId(principal))
+        if (planet.OwnerId != principal.PlayerId())
         {
             return TypedResults.Forbid();
         }
@@ -343,7 +344,7 @@ public static class FleetEndpoints
             return TypedResults.BadRequest("page and pageSize must be >= 1.");
         }
 
-        var playerId = PlayerId(principal);
+        var playerId = principal.PlayerId();
         var query = session.Query<Fleet>().Where(f => f.OwnerId == playerId);
         query = status is null
             ? query.Where(f => f.Status != FleetStatus.Disbanded)
@@ -534,7 +535,4 @@ public static class FleetEndpoints
         var updatedPlanet = await session.Events.FetchLatest<Planet>(planetId);
         await StorageHaltScheduling.ScheduleAllChecksAsync(bus, planetId, updatedPlanet!, now);
     }
-
-    private static Guid? PlayerId(ClaimsPrincipal principal)
-        => Guid.TryParse(principal.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : null;
 }

--- a/src/Voidforge.Api/Endpoints/PlanetEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/PlanetEndpoints.cs
@@ -8,7 +8,7 @@ namespace Voidforge.Api.Endpoints;
 public static class PlanetEndpoints
 {
     [WolverineGet("/api/planets/{id}")]
-    public static async Task<Results<Ok<PlanetResponse>, NotFound>> GetById(
+    public static async Task<Results<Ok<PlanetResponse>, ProblemHttpResult>> GetById(
         Guid id,
         IQuerySession session,
         TimeProvider timeProvider)
@@ -17,7 +17,7 @@ public static class PlanetEndpoints
 
         if (planet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         return TypedResults.Ok(PlanetResponse.From(planet, timeProvider.GetUtcNow()));

--- a/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
@@ -184,8 +184,7 @@ public static class PlayerEndpoints
         ClaimsPrincipal principal,
         IQuerySession session)
     {
-        var idClaim = principal.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!Guid.TryParse(idClaim, out var playerId))
+        if (principal.PlayerId() is not { } playerId)
         {
             return TypedResults.NotFound();
         }

--- a/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/PlayerEndpoints.cs
@@ -26,7 +26,7 @@ public static class PlayerEndpoints
 
     [AllowAnonymous]
     [WolverinePost("/api/players/register")]
-    public static async Task<Results<Ok<RegisterPlayerResponse>, Conflict<string>, StatusCodeHttpResult>> Register(
+    public static async Task<Results<Ok<RegisterPlayerResponse>, ProblemHttpResult>> Register(
         RegisterPlayerRequest request,
         IDocumentStore store,
         IMessageBus bus,
@@ -42,7 +42,7 @@ public static class PlayerEndpoints
 
             if (nameTaken)
             {
-                return TypedResults.Conflict("Player name is already taken.");
+                return TypedResults.Problem(detail: "Player name is already taken.", statusCode: StatusCodes.Status409Conflict);
             }
         }
 
@@ -75,15 +75,15 @@ public static class PlayerEndpoints
                     // and our commit, tripping the Player.Name unique index. Return immediately —
                     // this is NOT the planet re-pick path: retrying would re-hit the same duplicate
                     // name every attempt and exhaust the loop pointlessly.
-                    return TypedResults.Conflict("Player name is already taken.");
+                    return TypedResults.Problem(detail: "Player name is already taken.", statusCode: StatusCodes.Status409Conflict);
                 case ClaimOutcome.NoUncolonizedPlanets:
-                    return TypedResults.StatusCode(503);
+                    return TypedResults.Problem(statusCode: StatusCodes.Status503ServiceUnavailable);
                 case ClaimOutcome.LostRace:
                     continue;   // stale read or a genuine tie lost on commit — re-pick
             }
         }
 
-        return TypedResults.StatusCode(503);
+        return TypedResults.Problem(statusCode: StatusCodes.Status503ServiceUnavailable);
     }
 
     private enum ClaimOutcome
@@ -180,19 +180,19 @@ public static class PlayerEndpoints
     }
 
     [WolverineGet("/api/players/me")]
-    public static async Task<Results<Ok<PlayerInfoResponse>, NotFound>> Me(
+    public static async Task<Results<Ok<PlayerInfoResponse>, ProblemHttpResult>> Me(
         ClaimsPrincipal principal,
         IQuerySession session)
     {
         if (principal.PlayerId() is not { } playerId)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         var player = await session.LoadAsync<Player>(playerId);
         if (player is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         return TypedResults.Ok(new PlayerInfoResponse(player.Id, player.Name, player.RegisteredAt));

--- a/src/Voidforge.Api/Endpoints/ShipEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/ShipEndpoints.cs
@@ -15,7 +15,7 @@ namespace Voidforge.Api.Endpoints;
 public static class ShipEndpoints
 {
     [WolverinePost("/api/planets/{planetId}/ship-queue")]
-    public static async Task<Results<Ok<ShipBuildResponse>, NotFound, ForbidHttpResult>> Queue(
+    public static async Task<Results<Ok<ShipBuildResponse>, ProblemHttpResult>> Queue(
         Guid planetId,
         QueueShipRequest request,
         ClaimsPrincipal principal,
@@ -32,12 +32,12 @@ public static class ShipEndpoints
         var planet = stream.Aggregate;
         if (planet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         if (principal.PlayerId() is not { } playerId || !planet.IsOwnedBy(playerId))
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         var now = timeProvider.GetUtcNow();
@@ -58,7 +58,7 @@ public static class ShipEndpoints
     }
 
     [WolverineDelete("/api/planets/{planetId}/ship-queue/{buildId}")]
-    public static async Task<Results<Ok<PlanetResponse>, NotFound, ForbidHttpResult>> Cancel(
+    public static async Task<Results<Ok<PlanetResponse>, ProblemHttpResult>> Cancel(
         Guid planetId,
         Guid buildId,
         ClaimsPrincipal principal,
@@ -71,19 +71,19 @@ public static class ShipEndpoints
         var planet = stream.Aggregate;
         if (planet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         if (principal.PlayerId() is not { } playerId || !planet.IsOwnedBy(playerId))
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden);
         }
 
         var now = timeProvider.GetUtcNow();
         var events = planet.CancelShipBuild(buildId, now);
         if (events.Count == 0)
         {
-            return TypedResults.NotFound();   // unknown build id
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);   // unknown build id
         }
 
         stream.AppendMany([.. events]);
@@ -96,7 +96,7 @@ public static class ShipEndpoints
 
     // Active builds first (with ETA), then queued FIFO. Paginated per the #29 contract.
     [WolverineGet("/api/planets/{planetId}/ship-queue")]
-    public static async Task<Results<Ok<PagedResponse<ShipBuildResponse>>, NotFound, BadRequest<string>>> GetQueue(
+    public static async Task<Results<Ok<PagedResponse<ShipBuildResponse>>, ProblemHttpResult>> GetQueue(
         Guid planetId,
         IQuerySession session,
         int? page = null,
@@ -105,7 +105,7 @@ public static class ShipEndpoints
         var planet = await session.LoadAsync<Planet>(planetId);
         if (planet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         var parameters = PaginationParameters.Create(
@@ -113,7 +113,7 @@ public static class ShipEndpoints
             pageSize ?? PaginationParameters.DefaultPageSize);
         if (parameters is null)
         {
-            return TypedResults.BadRequest("page and pageSize must be >= 1.");
+            return TypedResults.Problem(detail: "page and pageSize must be >= 1.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         IReadOnlyList<ShipBuild> ordered = planet.ShipQueue
@@ -128,7 +128,7 @@ public static class ShipEndpoints
 
     // Completed-ship roster, optionally filtered by type, sorted (CompletedAt, Id). Paginated.
     [WolverineGet("/api/planets/{planetId}/ships")]
-    public static async Task<Results<Ok<PagedResponse<RosterShipResponse>>, NotFound, BadRequest<string>>> GetRoster(
+    public static async Task<Results<Ok<PagedResponse<RosterShipResponse>>, ProblemHttpResult>> GetRoster(
         Guid planetId,
         IQuerySession session,
         ShipType? type = null,
@@ -138,7 +138,7 @@ public static class ShipEndpoints
         var planet = await session.LoadAsync<Planet>(planetId);
         if (planet is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
         var parameters = PaginationParameters.Create(
@@ -146,7 +146,7 @@ public static class ShipEndpoints
             pageSize ?? PaginationParameters.DefaultPageSize);
         if (parameters is null)
         {
-            return TypedResults.BadRequest("page and pageSize must be >= 1.");
+            return TypedResults.Problem(detail: "page and pageSize must be >= 1.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         IReadOnlyList<RosterShip> ordered = planet.Ships

--- a/src/Voidforge.Api/Endpoints/ShipEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/ShipEndpoints.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Marten;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
+using Voidforge.Api.Auth;
 using Voidforge.Api.Balance;
 using Voidforge.Api.Domain;
 using Voidforge.Api.Domain.Events;
@@ -34,7 +35,7 @@ public static class ShipEndpoints
             return TypedResults.NotFound();
         }
 
-        if (!IsOwner(principal, planet))
+        if (principal.PlayerId() is not { } playerId || !planet.IsOwnedBy(playerId))
         {
             return TypedResults.Forbid();
         }
@@ -73,7 +74,7 @@ public static class ShipEndpoints
             return TypedResults.NotFound();
         }
 
-        if (!IsOwner(principal, planet))
+        if (principal.PlayerId() is not { } playerId || !planet.IsOwnedBy(playerId))
         {
             return TypedResults.Forbid();
         }
@@ -157,11 +158,5 @@ public static class ShipEndpoints
         var response = ordered.ToPagedResponse(parameters,
             s => new RosterShipResponse(s.Id, s.Type, s.CompletedAt, s.OwnerId));
         return TypedResults.Ok(response);
-    }
-
-    private static bool IsOwner(ClaimsPrincipal principal, Planet planet)
-    {
-        var idClaim = principal.FindFirstValue(ClaimTypes.NameIdentifier);
-        return Guid.TryParse(idClaim, out var playerId) && planet.OwnerId == playerId;
     }
 }

--- a/src/Voidforge.Api/Endpoints/SolarSystemEndpoints.cs
+++ b/src/Voidforge.Api/Endpoints/SolarSystemEndpoints.cs
@@ -12,7 +12,7 @@ public static class SolarSystemEndpoints
     // Nullable int params distinguish "omitted" (null → default) from "explicitly zero"
     // (0 → rejected as invalid) so Wolverine's missing-param-as-null binding works correctly.
     [WolverineGet("/api/solar-systems")]
-    public static async Task<Results<Ok<PagedResponse<SolarSystemResponse>>, BadRequest<string>>> GetAll(
+    public static async Task<Results<Ok<PagedResponse<SolarSystemResponse>>, ProblemHttpResult>> GetAll(
         IQuerySession session,
         int? page = null,
         int? pageSize = null)
@@ -23,7 +23,7 @@ public static class SolarSystemEndpoints
 
         if (parameters is null)
         {
-            return TypedResults.BadRequest("page and pageSize must be >= 1.");
+            return TypedResults.Problem(detail: "page and pageSize must be >= 1.", statusCode: StatusCodes.Status400BadRequest);
         }
 
         var response = await session.Query<SolarSystem>()

--- a/src/Voidforge.Api/Http/ConcurrencyConflictExceptionHandler.cs
+++ b/src/Voidforge.Api/Http/ConcurrencyConflictExceptionHandler.cs
@@ -9,7 +9,12 @@ namespace Voidforge.Api.Http;
 // returns, so it cannot be caught inside the endpoint — this handler turns it into a retryable 409
 // instead of a 500. Scheduled message handlers are unaffected: their conflicts are retried via the
 // Wolverine OnException policy in Program.cs.
-internal sealed class ConcurrencyConflictExceptionHandler : IExceptionHandler
+//
+// Emits the 409 as a ProblemDetails through the registered IProblemDetailsService (D12/#74) so it
+// carries the exact same shape — Instance, traceId, framework-defaulted title/type — as every
+// endpoint's TypedResults.Problem responses.
+internal sealed class ConcurrencyConflictExceptionHandler(IProblemDetailsService problemDetailsService)
+    : IExceptionHandler
 {
     public async ValueTask<bool> TryHandleAsync(
         HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
@@ -20,9 +25,14 @@ internal sealed class ConcurrencyConflictExceptionHandler : IExceptionHandler
         }
 
         httpContext.Response.StatusCode = StatusCodes.Status409Conflict;
-        await httpContext.Response.WriteAsJsonAsync(
-            new { detail = "Concurrent modification of this resource; please retry." },
-            cancellationToken);
-        return true;
+        return await problemDetailsService.TryWriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = httpContext,
+            ProblemDetails =
+            {
+                Status = StatusCodes.Status409Conflict,
+                Detail = "Concurrent modification of this resource; please retry.",
+            },
+        });
     }
 }

--- a/src/Voidforge.Api/Program.cs
+++ b/src/Voidforge.Api/Program.cs
@@ -78,7 +78,16 @@ builder.Services.AddWolverineHttp();
 // conflicting commit is issued by Wolverine's transactional middleware after the endpoint returns,
 // so it must be handled here rather than inside the endpoint.
 builder.Services.AddExceptionHandler<ConcurrencyConflictExceptionHandler>();
-builder.Services.AddProblemDetails();
+// One uniform error shape for every non-2xx (D12/#74): stamp each ProblemDetails with the request
+// path as `Instance` and a `traceId` extension for correlation. Title/type are left to the framework
+// defaults derived from the status code so the shape stays consistent across endpoints and the
+// concurrency handler (which emits through this same IProblemDetailsService).
+builder.Services.AddProblemDetails(options =>
+    options.CustomizeProblemDetails = context =>
+    {
+        context.ProblemDetails.Instance = context.HttpContext.Request.Path;
+        context.ProblemDetails.Extensions["traceId"] = context.HttpContext.TraceIdentifier;
+    });
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<ITravelPlanner, LinearTravelPlanner>();
 builder.Services.AddEndpointsApiExplorer();

--- a/src/Voidforge.Tests/Colonize/FullLoopEndToEndTests.cs
+++ b/src/Voidforge.Tests/Colonize/FullLoopEndToEndTests.cs
@@ -1,7 +1,11 @@
 using Alba;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
 using Voidforge.Api.Domain;
+using Voidforge.Api.Domain.Events;
 using Voidforge.Api.Endpoints;
 using Voidforge.Tests.Support;
+using Wolverine;
 using Xunit;
 
 namespace Voidforge.Tests.Colonize;
@@ -29,6 +33,13 @@ public sealed class FullLoopEndToEndTests
     private const decimal _transportCargoIronIngot = 50m;
 
     private static readonly TimeSpan _arrivalTimeout = TestTimeouts.FullLoopArrival;
+
+    // Ore carried off-planet in the capstone's resume leg. Deliberately LARGE (of the CargoVessel's
+    // 500 cap): the assemble endpoint reschedules a CheckStorageFull for when the freed pool would
+    // refill to capacity, so a tiny load would re-halt the Drill within ~2s. 400 leaves ~80s of
+    // headroom (400 / 5 net-ore-per-second) — well past this test's wall-clock — so the resumed Drill
+    // stays Operational through to the final read-API assertion.
+    private const decimal _capstoneOreCarriedOffPlanet = 400m;
 
     private readonly IAlbaHost _host;
 
@@ -129,5 +140,181 @@ public sealed class FullLoopEndToEndTests
         Assert.Equal(settler.PlayerId, colonyAfterTransport.OwnerId);
         Assert.Equal(_colonizeCargoIronOre + _transportCargoIronOre, colonyAfterTransport.IronOre.CurrentValue);
         Assert.Equal(_colonizeCargoIronIngot + _transportCargoIronIngot, colonyAfterTransport.IronIngot.CurrentValue);
+    }
+
+    // #74 Task 4 (D13, capstone): the whole Phase-5 surface stitched into ONE cohesive flight,
+    // verified through the READ API — register -> build an economy -> a producer HALTS on
+    // storage-full (#69) -> transport ore away -> the producer RESUMES (#69/D6) -> CANCEL a build
+    // (#72) -> RECALL a fleet (#73/D10) -> COLONIZE (#51) -> assert final state via GET endpoints.
+    // Explicitly NO score assertion (D13).
+    //
+    // Determinism note (mirrors StorageHaltingTests / FleetRecallTests / ColonizeMissionTests): a
+    // 5 net-ore/s Drill would take ~1900s to fill the 10000-cap ore pool by wall clock, so the
+    // halt leg is driven by seeding the pool to capacity and invoking CheckStorageFullHandler
+    // DIRECTLY at that instant; the recall-return and colonize arrivals are driven by direct
+    // handler invocation (LaunchAndArriveInstantly / CompleteFleetArrivalHandler) rather than
+    // real-scheduler wall-clock waits. Everything else — register, place/cancel building, assemble,
+    // launch, recall, and all reads — runs through the real HTTP API. The existing full-loop test
+    // above already covers the real-scheduler Colonize + Transport arrivals, so this capstone does
+    // not duplicate that and uses the fast, deterministic handler-invocation path instead.
+    [Fact]
+    public async Task CapstoneHaltResumeCancelRecallColonizeVerifiedThroughTheReadApi()
+    {
+        var settler = await _host.RegisterPlayer("Capstone74_");
+        var homeworld = await _host.GetPlanet(settler);
+        Assert.Equal(settler.PlayerId, homeworld.OwnerId);
+
+        var (cargoVesselId, colonyShipId) = await BuildEconomy(settler);
+
+        await HaltHomeworldDrillOnStorageFull(settler);
+        var supplyFleetId = await TransportOreAwayAndResumeDrill(settler, cargoVesselId);
+        var cancelledSlot = await CancelAConstruction(settler);
+        await RecallTheSupplyFleet(settler, supplyFleetId);
+        var colonyId = await ColonizeAnUncolonizedPlanet(settler, homeworld.SolarSystemId, colonyShipId);
+
+        await AssertFinalStateThroughTheReadApi(settler, supplyFleetId, cancelledSlot, colonyId);
+    }
+
+    // Economy: BuildRosterShip places an operational Shipyard via the API on the first call, then
+    // completes each ship onto the roster. One CargoVessel (carries ore off-planet for the resume +
+    // recall legs) and one ColonyShip (the colonize leg).
+    private async Task<(Guid CargoVesselId, Guid ColonyShipId)> BuildEconomy(RegisterPlayerResponse settler)
+    {
+        var cargoVesselId = await _host.BuildRosterShip(settler, ShipType.CargoVessel);
+        var colonyShipId = await _host.BuildRosterShip(settler, ShipType.ColonyShip);
+        return (cargoVesselId, colonyShipId);
+    }
+
+    // Producer halts on storage-full (#69), made deterministic exactly as StorageHaltingTests do:
+    // pin the ore pool to capacity with a single oversized CargoDeliveredToStorage (Apply clamps
+    // CheckpointValue + amount into [0, cap]) and drive CheckStorageFullHandler DIRECTLY at that
+    // instant. Only this fill/halt leg uses the handler-invocation shortcut — a real-scheduler fill
+    // cannot fit the timeout budget.
+    private async Task HaltHomeworldDrillOnStorageFull(RegisterPlayerResponse settler)
+    {
+        var planetId = settler.HomeworldId;
+        var before = await _host.GetPlanet(settler);
+        var at = DateTimeOffset.UtcNow;
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+
+        await using (var seedSession = store.LightweightSession())
+        {
+            var seedStream = await seedSession.Events.FetchForWriting<Planet>(planetId);
+            seedStream.AppendOne(new CargoDeliveredToStorage(
+                Guid.NewGuid(), before.IronOre.StorageCapacity, 0m, at));
+            await seedSession.SaveChangesAsync();
+        }
+
+        using (var scope = _host.Services.CreateScope())
+        {
+            var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+            await using var session = store.LightweightSession();
+            await CheckStorageFullHandler.Handle(
+                new CheckStorageFull(planetId, ResourceType.IronOre, at), session, bus);
+        }
+
+        var halted = await _host.PollBuildingUntilHalted(settler, BuildingType.Drill, HaltReason.OutputStorageFull);
+        Assert.Equal(BuildingStatus.Halted, halted.Status);
+        Assert.Equal(HaltReason.OutputStorageFull, halted.HaltReason);
+    }
+
+    // Transport ore off-planet -> the freed output storage resumes the Drill in the SAME assemble
+    // commit (D6, #69). The loaded CargoVessel fleet is returned so the recall leg can reuse it.
+    private async Task<Guid> TransportOreAwayAndResumeDrill(RegisterPlayerResponse settler, Guid cargoVesselId)
+    {
+        var fleet = await _host.AssembleFleet(
+            settler, [cargoVesselId], new CargoRequest(_capstoneOreCarriedOffPlanet, 0m));
+        Assert.Equal(_capstoneOreCarriedOffPlanet, fleet.CargoIronOre);   // ore transported off the planet
+
+        var resumed = await _host.PollBuildingUntilOperational(settler, BuildingType.Drill);
+        Assert.Equal(BuildingStatus.Operational, resumed.Status);
+        Assert.Null(resumed.HaltReason);
+
+        var afterResume = await _host.GetPlanet(settler);
+        Assert.True(
+            afterResume.IronOre.Rate > 0m,
+            $"Resumed Drill should produce ore again: rate={afterResume.IronOre.Rate}.");
+        return fleet.Id;
+    }
+
+    // Cancel a build (#72): place a Generator construction via the API and cancel it while it is
+    // still UnderConstruction (the 5s test build duration is a comfortable window). The slot becomes
+    // a Cancelled tombstone. A Generator (not a Drill) is chosen so the single-Drill halt/resume
+    // assertions stay unambiguous. Returns the tombstoned slot index for the final read.
+    private async Task<int> CancelAConstruction(RegisterPlayerResponse settler)
+    {
+        var placed = await _host.PlaceBuilding(settler, BuildingType.Generator);
+        var slotIndex = placed.Buildings.Count - 1;
+        Assert.Equal(BuildingStatus.UnderConstruction, placed.Buildings[slotIndex].Status);
+
+        await _host.CancelConstruction(settler, slotIndex);
+
+        var afterCancel = await _host.GetPlanet(settler);
+        Assert.Equal(BuildingStatus.Cancelled, afterCancel.Buildings[slotIndex].Status);
+        return slotIndex;
+    }
+
+    // Recall (#73/D10): send the supply fleet outbound on a Move, then recall it — it turns around
+    // and heads back to its origin. Launch + recall run through the real HTTP API; the return
+    // arrival is driven by invoking CompleteFleetArrivalHandler at the recall's fresh ArrivesAt
+    // (mirrors FleetRecallTests), idempotent if the durable scheduler already landed it.
+    private async Task RecallTheSupplyFleet(RegisterPlayerResponse settler, Guid fleetId)
+    {
+        var destination = await _host.FindPlanetOtherThan(settler);
+        await _host.Launch(settler, fleetId, MissionType.Move, destination);
+
+        var recalled = await _host.Recall(settler, fleetId);
+        Assert.Equal(FleetStatus.InTransit, recalled.Status);
+        Assert.Equal(settler.HomeworldId, recalled.DestinationPlanetId);   // heading back to origin
+        Assert.NotNull(recalled.RecalledAt);
+        Assert.NotNull(recalled.ArrivesAt);
+
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession();
+        await CompleteFleetArrivalHandler.Handle(
+            new CompleteFleetArrival(fleetId, recalled.ArrivesAt.Value), session);
+    }
+
+    // Colonize (#51): assemble the ColonyShip and claim an uncolonized planet in ANOTHER system.
+    // Launch runs through the real HTTP API; the arrival is driven by the shared
+    // LaunchAndArriveInstantly handler-invocation helper. Returns the colonized planet's id.
+    private async Task<Guid> ColonizeAnUncolonizedPlanet(
+        RegisterPlayerResponse settler, Guid homeSystemId, Guid colonyShipId)
+    {
+        var colonizeFleet = await _host.AssembleFleet(settler, [colonyShipId]);
+        var destinationId = await _host.FindUncolonizedPlanet(settler, excludeSystemId: homeSystemId);
+
+        var arrived = await _host.LaunchAndArriveInstantly(
+            settler, colonizeFleet.Id, MissionType.Colonize, destinationId);
+        Assert.Equal(FleetStatus.Stationed, arrived.Status);
+        Assert.Equal(destinationId, arrived.LocationPlanetId);
+        Assert.DoesNotContain(arrived.Ships, s => s.Id == colonyShipId);   // colony ship consumed on claim
+        return destinationId;
+    }
+
+    // Final state, read entirely through the public GET API (D13: NO score assertion).
+    private async Task AssertFinalStateThroughTheReadApi(
+        RegisterPlayerResponse settler, Guid supplyFleetId, int cancelledSlot, Guid colonyId)
+    {
+        // Homeworld: the Drill resumed (Operational, no halt reason), its output pool sits below cap,
+        // and the cancelled construction is a terminal tombstone.
+        var homeworld = await _host.GetPlanet(settler);
+        var drill = homeworld.Buildings.Single(b => b.Type == BuildingType.Drill);
+        Assert.Equal(BuildingStatus.Operational, drill.Status);
+        Assert.Null(drill.HaltReason);
+        Assert.True(
+            homeworld.IronOre.CurrentValue < homeworld.IronOre.StorageCapacity,
+            $"Ore should be below cap after the off-planet load: {homeworld.IronOre.CurrentValue} / {homeworld.IronOre.StorageCapacity}.");
+        Assert.Equal(BuildingStatus.Cancelled, homeworld.Buildings[cancelledSlot].Status);
+
+        // Supply fleet: recalled home — Stationed at the origin with its carried ore intact.
+        var supplyFleet = await _host.GetJson<FleetResponse>(settler, $"/api/fleets/{supplyFleetId}");
+        Assert.Equal(FleetStatus.Stationed, supplyFleet.Status);
+        Assert.Equal(settler.HomeworldId, supplyFleet.LocationPlanetId);
+        Assert.Equal(_capstoneOreCarriedOffPlanet, supplyFleet.CargoIronOre);
+
+        // Colony: owned by the settler after the Colonize claim.
+        var colony = await _host.GetPlanetById(settler, colonyId);
+        Assert.Equal(settler.PlayerId, colony.OwnerId);
     }
 }

--- a/src/Voidforge.Tests/Fleets/FleetEndpointTests.cs
+++ b/src/Voidforge.Tests/Fleets/FleetEndpointTests.cs
@@ -227,4 +227,38 @@ public sealed class FleetEndpointTests
         var history = await _host.GetJson<PagedResponse<FleetSummaryResponse>>(a, "/api/fleets?status=Disbanded");
         Assert.Contains(history.Items, f => f.Id == fleet.Id);
     }
+
+    // #63: an unparseable ?status= is a 400 ProblemDetails, not a silently-empty list.
+    [Fact]
+    public async Task OwnFleetsRejectsUnknownStatusWith400()
+    {
+        var registration = await _host.RegisterPlayer("Fleet_Test_");
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url("/api/fleets?status=bogus");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(400);
+        });
+
+        var body = result.ReadAsText();
+        Assert.Contains("Unknown fleet status 'bogus'.", body, StringComparison.Ordinal);
+    }
+
+    // #63: a valid ?status= (case-insensitive) stays 200 and filters to exactly that status.
+    [Fact]
+    public async Task OwnFleetsFilterByValidStatusReturns200AndFilters()
+    {
+        var owner = await _host.RegisterPlayer("Fleet_Test_");
+        var shipId = await _host.BuildRosterShip(owner);
+        var fleet = await _host.AssembleFleet(owner, [shipId]);   // freshly assembled → Stationed
+
+        // The matching status includes the fleet (lower-case proves ignoreCase parsing).
+        var stationed = await _host.GetJson<PagedResponse<FleetSummaryResponse>>(owner, "/api/fleets?status=stationed");
+        Assert.Contains(stationed.Items, f => f.Id == fleet.Id);
+
+        // A different valid status filters it out — still 200, not an error.
+        var inTransit = await _host.GetJson<PagedResponse<FleetSummaryResponse>>(owner, "/api/fleets?status=InTransit");
+        Assert.DoesNotContain(inTransit.Items, f => f.Id == fleet.Id);
+    }
 }

--- a/src/Voidforge.Tests/OpenApi/OpenApiContractTests.cs
+++ b/src/Voidforge.Tests/OpenApi/OpenApiContractTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using Alba;
+using Xunit;
+
+namespace Voidforge.Tests.OpenApi;
+
+/// <summary>
+/// Guards the acceptance criterion "OpenAPI document reflects all Phase 5 endpoints" (#74).
+/// Fetches the live Swagger document from the running host and asserts every current API
+/// operation (path + HTTP method) is present, so a newly-added endpoint that is missing from
+/// the emitted contract fails the build instead of silently drifting (as the committed
+/// frontend snapshot did — it was 14 operations behind before this test existed).
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+public sealed class OpenApiContractTests
+{
+    private readonly IAlbaHost _host;
+
+    // Every operation the API currently exposes, as (route template, HTTP method) pairs.
+    // The route templates are the exact strings from the [Wolverine*] endpoint attributes,
+    // which Swashbuckle emits verbatim as OpenAPI path keys.
+    private static readonly (string Path, string Method)[] _expectedOperations =
+    [
+        // Phase 1 — baseline surface
+        ("/api/ping", "get"),
+        ("/api/planets/{id}", "get"),
+        ("/api/players/register", "post"),
+        ("/api/players/me", "get"),
+        ("/api/solar-systems", "get"),
+
+        // Phase 2-3 — ships & buildings
+        ("/api/planets/{planetId}/ship-queue", "post"),
+        ("/api/planets/{planetId}/ship-queue", "get"),
+        ("/api/planets/{planetId}/ship-queue/{buildId}", "delete"),
+        ("/api/planets/{planetId}/ships", "get"),
+        ("/api/planets/{planetId}/buildings", "post"),
+        ("/api/planets/{planetId}/buildings/{slotIndex}/construction", "delete"),
+        ("/api/planets/{planetId}/buildings/{slotIndex}/demolish", "post"),
+
+        // Phase 4-5 — fleets & missions
+        ("/api/fleets/{fleetId}/missions", "post"),
+        ("/api/planets/{planetId}/fleets", "post"),
+        ("/api/planets/{planetId}/fleets", "get"),
+        ("/api/fleets/{fleetId}/disband", "post"),
+        ("/api/fleets/{fleetId}/cancel", "post"),
+        ("/api/fleets/{fleetId}/unload", "post"),
+        ("/api/fleets", "get"),
+        ("/api/fleets/{fleetId}", "get"),
+    ];
+
+    public OpenApiContractTests(AppFixture fixture)
+    {
+        _host = fixture.Host;
+    }
+
+    [Fact]
+    public async Task SwaggerDocumentContainsEveryCurrentApiOperation()
+    {
+        // The Swagger endpoint is anonymous (see ApiKeyAuthTests.SwaggerWithoutKeyReturns200).
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url("/swagger/v1/swagger.json");
+            s.StatusCodeShouldBe(200);
+        });
+
+        using var document = JsonDocument.Parse(result.ReadAsText());
+        var root = document.RootElement;
+
+        Assert.True(
+            root.TryGetProperty("paths", out var paths),
+            "OpenAPI document is missing the 'paths' object.");
+
+        var missing = new List<string>();
+        foreach (var (path, method) in _expectedOperations)
+        {
+            if (!paths.TryGetProperty(path, out var pathItem)
+                || !pathItem.TryGetProperty(method, out _))
+            {
+                missing.Add($"{method.ToUpperInvariant()} {path}");
+            }
+        }
+
+        Assert.True(
+            missing.Count == 0,
+            $"OpenAPI document is missing {missing.Count} operation(s): {string.Join(", ", missing)}");
+    }
+}

--- a/src/Voidforge.Tests/Support/IntegrationApiExtensions.cs
+++ b/src/Voidforge.Tests/Support/IntegrationApiExtensions.cs
@@ -398,4 +398,77 @@ public static class IntegrationApiExtensions
 
         throw new InvalidOperationException("No uncolonized planet found in the universe.");
     }
+
+    /// <summary>
+    /// Places a building via <c>POST /api/planets/{id}/buildings</c>, asserts 200, and returns the
+    /// post-place planet. The just-placed slot is the LAST entry in <see cref="PlanetResponse.Buildings"/>
+    /// — the Buildings list is append-only, so <c>Buildings.Count - 1</c> is its stable SlotIndex.
+    /// </summary>
+    public static async Task<PlanetResponse> PlaceBuilding(
+        this IAlbaHost host, RegisterPlayerResponse registration, BuildingType type, Guid? planetId = null)
+    {
+        var result = await host.Scenario(s =>
+        {
+            s.Post.Json(new PlaceBuildingRequest(type))
+                .ToUrl($"/api/planets/{planetId ?? registration.HomeworldId}/buildings");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(200);
+        });
+
+        var planet = await result.ReadAsJsonAsync<PlanetResponse>();
+        Assert.NotNull(planet);
+        return planet;
+    }
+
+    /// <summary>
+    /// Cancels an in-progress construction via <c>DELETE /api/planets/{id}/buildings/{slot}/construction</c>
+    /// and asserts the 204 No Content the endpoint returns (#72); the slot becomes a Cancelled tombstone.
+    /// </summary>
+    public static async Task CancelConstruction(
+        this IAlbaHost host, RegisterPlayerResponse registration, int slotIndex, Guid? planetId = null)
+    {
+        await host.Scenario(s =>
+        {
+            s.Delete.Url($"/api/planets/{planetId ?? registration.HomeworldId}/buildings/{slotIndex}/construction");
+            s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
+            s.StatusCodeShouldBe(204);
+        });
+    }
+
+    /// <summary>
+    /// Polls the planet until a building of <paramref name="type"/> is <see cref="BuildingStatus.Halted"/>
+    /// with <paramref name="reason"/>, then returns that slot. PollUntil returns the last-seen state on
+    /// timeout, so the trailing NotNull surfaces a failure to halt as the assertion.
+    /// </summary>
+    public static async Task<BuildingSlotResponse> PollBuildingUntilHalted(
+        this IAlbaHost host, RegisterPlayerResponse registration, BuildingType type, HaltReason reason)
+    {
+        var planet = await host.PollUntil(
+            registration,
+            p => p.Buildings.Any(b => b.Type == type && b.Status == BuildingStatus.Halted && b.HaltReason == reason),
+            TestTimeouts.Completion);
+
+        var slot = planet.Buildings.FirstOrDefault(
+            b => b.Type == type && b.Status == BuildingStatus.Halted && b.HaltReason == reason);
+        Assert.NotNull(slot);
+        return slot;
+    }
+
+    /// <summary>
+    /// Polls the planet until a building of <paramref name="type"/> is back to
+    /// <see cref="BuildingStatus.Operational"/> (the resume assertion, #69), then returns that slot.
+    /// PollUntil returns the last-seen state on timeout, so the trailing NotNull surfaces a failure.
+    /// </summary>
+    public static async Task<BuildingSlotResponse> PollBuildingUntilOperational(
+        this IAlbaHost host, RegisterPlayerResponse registration, BuildingType type)
+    {
+        var planet = await host.PollUntil(
+            registration,
+            p => p.Buildings.Any(b => b.Type == type && b.Status == BuildingStatus.Operational),
+            TestTimeouts.Completion);
+
+        var slot = planet.Buildings.FirstOrDefault(b => b.Type == type && b.Status == BuildingStatus.Operational);
+        Assert.NotNull(slot);
+        return slot;
+    }
 }

--- a/technical-design/authentication.md
+++ b/technical-design/authentication.md
@@ -36,7 +36,12 @@ Authentication (every request):
 
 - **Fallback policy**: `RequireAuthenticatedUser()` — all endpoints require auth by default
 - **Anonymous endpoints**: `[AllowAnonymous]` on registration, health check, Swagger
-- **Accessing player identity**: `ClaimsPrincipal.FindFirstValue(ClaimTypes.NameIdentifier)` returns the PlayerId as string
+- **Accessing player identity (D11, #74)**: the single primitive is `ClaimsPrincipal.PlayerId()` (`Auth/ClaimsPrincipalExtensions.cs`) — parses the `NameIdentifier` claim to a `Guid?` (null when absent/unparseable). This is the ONLY place that reads the claim; the former per-file `IsOwner`/`PlayerId` copies in Ship/Building/Fleet endpoints were removed.
+- **Ownership checks**: each mutation endpoint resolves `principal.PlayerId()` then compares against the target aggregate's owner — `planet.IsOwnedBy(playerId)` for planet-scoped endpoints, `fleet.OwnerId` for fleet-scoped ones (Unload checks both fleet AND planet ownership). A null id or non-owner is a **403**; an unknown aggregate is a **404** (the 404-then-403 ordering is preserved per endpoint).
+
+### Error Responses (D12, #74)
+
+Every non-2xx response across the API is a **ProblemDetails** (RFC 7807) with a uniform shape: `AddProblemDetails(CustomizeProblemDetails …)` in `Program.cs` stamps `Instance` (request path) and a `traceId` extension; `title`/`type` default from the status. Endpoints emit errors via `TypedResults.Problem(detail, statusCode)` (each `Results<Ok<T>, ProblemHttpResult>`), and the `ConcurrencyConflictExceptionHandler` writes its 409 through the same `IProblemDetailsService`. Human-readable messages live in the `detail` field. Invalid enum query params (e.g. `?status=` on `GET /api/fleets`) return a 400 ProblemDetails rather than binding-failing or silently emptying (#63).
 
 ### Post-MVP
 

--- a/technical-design/testing.md
+++ b/technical-design/testing.md
@@ -67,6 +67,11 @@ Deliberately local (not shared): race-specific arrival retries (`ClaimRaceTests`
 
 No new machinery (design D5): all halting/depletion/demolition/ingot behaviour already exists (#69/#70/#72/#83); #71 is test-only. Integration tests use the deterministic direct-handler-invocation pattern (`InvokeHandler` + `PredictX` deadline math + pool-pinning via oversized `CargoLoadedFromStorage`) — **no wall-clock waits**. Scenario 2's full chain is intentionally multi-checkpoint (three scheduled checks); its single-checkpoint claim is scoped to the ingot-consumer tail (one `CheckIngotStarved` pauses every consumer together). Edge cases and even-split proofs are pure-domain unit slices — the individual handler commit paths are already covered, and the novel content (two evaluators at one instant; the scalar-pool clamp; a shared buffer emptying for both consumers) is an aggregate property expressed directly without the runtime-marginal integration host. Even-split 7 uses 3 refineries vs 1 drill so the `min(demand, inflow)` clamp genuinely bites (2-vs-1 is tautological — demand equals inflow at every multiplier).
 
+## Capstone & Contract Coverage (#74)
+
+- **Capstone e2e** — `Colonize/FullLoopEndToEndTests.CapstoneHaltResumeCancelRecallColonizeVerifiedThroughTheReadApi` stitches the whole Phase-5 surface into one flight (register → build economy → storage-full **halt** → transport ore away → **resume** → **cancel** a build → **recall** a fleet → **colonize**) and verifies final state through the read API. NO score assertion (D13 — scoring moved to #67/#68). Halt/resume/arrival legs use the deterministic direct-handler-invocation pattern (a real-scheduler ore-pool fill would take ~1900s); everything else runs through the real HTTP API.
+- **OpenAPI contract** — `OpenApi/OpenApiContractTests` fetches the live `/swagger/v1/swagger.json` and asserts every current route+method is present, so a new endpoint missing from the emitted doc fails the build. The committed frontend snapshot (`frontend/app/openapi/voidforge.json`) recapture + the zod client regen (#64/#41) stay parked (spec L94 — not near-free).
+
 ## Known Pitfalls
 
 ### Do Not Dispose DI-Owned IDocumentStore


### PR DESCRIPTION
Closes #74. Folds #63.

Phase 5's closing issue: one ownership check, one error shape, and a capstone e2e. Spec `plans/phase-5-hardening-design.md` §7, D11–D13.

## Changes
- **D11 — shared ownership check.** New `Auth/ClaimsPrincipalExtensions.PlayerId()` is the single claim-parse primitive; the three ad-hoc copies (`ShipEndpoints.IsOwner`, `BuildingEndpoints.IsOwner`, `FleetEndpoints.PlayerId`) + the inline parse in `PlayerEndpoints.Me` are gone. `git grep FindFirstValue(ClaimTypes.NameIdentifier)` now returns only the extension. Pure refactor — 403/404 semantics preserved at every call site.
- **D12 — ProblemDetails everywhere.** Every deliberate non-2xx across all six endpoint files is now `TypedResults.Problem(...)` (each `Results<Ok<T>, ProblemHttpResult>`); the concurrency handler emits its 409 through `IProblemDetailsService`; `AddProblemDetails(CustomizeProblemDetails …)` stamps a uniform `Instance` + `traceId`. Existing human-readable messages preserved as `detail`.
- **#63 — invalid `?status=`.** `GET /api/fleets` binds `status` as a string, validates against `FleetStatus` (`TryParse` + `IsDefined`), and returns a 400 ProblemDetails on unparseable input. New tests cover the 400 and a valid case-insensitive filter.
- **OpenAPI review.** New `OpenApiContractTests` asserts the live `/swagger/v1/swagger.json` contains every current route+method (no such guard existed). The committed frontend snapshot recapture + zod client regen (#64/#41) stay **parked** (spec L94 — not near-free; the app's `RunJasperFxCommands` entrypoint also defeats the Swashbuckle CLI).
- **Capstone e2e (D13, no score assertion).** `FullLoopEndToEndTests.Capstone…` exercises register → economy → storage-full halt → transport away → resume → cancel a build → recall a fleet → colonize, verified through the read API. Halt/resume/arrival legs use the deterministic handler-invocation pattern (a real-scheduler pool-fill would take ~1900s); the rest runs through the real HTTP API.
- Docs: `technical-design/authentication.md` (ownership helper + error-shape), `technical-design/testing.md` (capstone + contract coverage).

## Acceptance
- [x] One ownership-check implementation; grep finds no per-file variants
- [x] Every non-2xx is ProblemDetails (incl. 409 concurrency + validation 400s)
- [x] Invalid `?status=` returns 400 — fixes #63
- [x] OpenAPI document reflects all Phase 5 endpoints (contract test guards it)
- [x] Capstone e2e (no score assertion — D13)
- [ ] `dotnet test` green — verified by CI

CI note: the `test` job runs a ~11.5-min integration suite that has flakily been killed under load (no xUnit summary + `pk_mt_events_stream_and_version` flood); re-run before diagnosing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)