### PR TITLE
feat: live soak-run verifier v1 + universal no-5xx helper tripwire

### DIFF
--- a/src/Voidforge.Api/Voidforge.Api.csproj
+++ b/src/Voidforge.Api/Voidforge.Api.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Voidforge.Tests" />
+    <InternalsVisibleTo Include="Voidforge.SoakTests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Voidforge.SoakTests/Deadline.cs
+++ b/src/Voidforge.SoakTests/Deadline.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+
+namespace Voidforge.SoakTests;
+
+// A soft wall-clock budget shared by the concurrent user scripts. <see cref="Reached"/> lets a script
+// stop STARTING new legs once the window elapses; <see cref="PauseAsync"/> spaces successive legs by
+// LegPause so their actions spread across the run. A leg already in flight is allowed to finish.
+public sealed class Deadline
+{
+    private readonly Stopwatch _stopwatch;
+    private readonly TimeSpan _window;
+
+    public Deadline(Stopwatch stopwatch, TimeSpan window)
+    {
+        _stopwatch = stopwatch;
+        _window = window;
+    }
+
+    public bool Reached => _stopwatch.Elapsed >= _window;
+
+    public TimeSpan Remaining
+    {
+        get
+        {
+            var remaining = _window - _stopwatch.Elapsed;
+            return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+        }
+    }
+
+    public async Task PauseAsync()
+    {
+        var pause = SoakTimeouts.LegPause;
+        await Task.Delay(pause < Remaining ? pause : Remaining);
+    }
+}

--- a/src/Voidforge.SoakTests/IntermediateSnapshot.cs
+++ b/src/Voidforge.SoakTests/IntermediateSnapshot.cs
@@ -1,0 +1,5 @@
+namespace Voidforge.SoakTests;
+
+// A periodic during-run reading of every planet's remaining ore deposit, evaluated at one fixed
+// instant. The ordered series feeds the I11 monotonicity check (deposits never rise).
+public sealed record IntermediateSnapshot(DateTimeOffset At, IReadOnlyDictionary<Guid, decimal> Deposits);

--- a/src/Voidforge.SoakTests/InvariantResult.cs
+++ b/src/Voidforge.SoakTests/InvariantResult.cs
@@ -1,0 +1,7 @@
+namespace Voidforge.SoakTests;
+
+// The outcome of one Tier-1 invariant: an empty Violations list means it held.
+public sealed record InvariantResult(string Id, string Title, IReadOnlyList<string> Violations)
+{
+    public bool Passed => Violations.Count == 0;
+}

--- a/src/Voidforge.SoakTests/ScenarioScript.cs
+++ b/src/Voidforge.SoakTests/ScenarioScript.cs
@@ -1,0 +1,315 @@
+using Alba;
+using Voidforge.Api.Domain;
+using Voidforge.Api.Endpoints;
+using Voidforge.Tests.Support;
+
+namespace Voidforge.SoakTests;
+
+// The two-user "economy + own-colony supply line + depletion" scenario, driven over real HTTP with
+// ONLY the real scheduler (Launch + PollFleetUntil — never LaunchAndArriveInstantly). Each leg is
+// wrapped so an EXPECTED contention outcome (a 4xx surfaced as an Alba assertion, or a polling helper
+// timing out) is recorded and the script continues; only a truly unexpected fault propagates.
+public static class ScenarioScript
+{
+    // Modest cargo load: well within two CargoVessels' combined capacity and the homeworld's stored ore.
+    private const decimal _transportOre = 100m;
+
+    // Player A (industrialist): grow the economy (a 2nd Drill drives the depletion), colonize a second
+    // planet in another system, then run a real ore supply line home -> its OWN colony. Transport to a
+    // same-owner destination delivers and auto-unloads (contrast a foreign destination, which 403s).
+    public static async Task RunIndustrialistAsync(
+        IAlbaHost host, SoakRecorder recorder, RegisterPlayerResponse reg, Guid excludeSystemId, Deadline deadline)
+    {
+        await RunLeg(recorder, "A: place 2nd Drill", () => host.PlaceBuilding(reg, BuildingType.Drill), deadline);
+        await RunLeg(recorder, "A: place Shipyard", () => host.PlaceBuilding(reg, BuildingType.Shipyard), deadline);
+        await RunLeg(recorder, "A: shipyard operational", () => host.EnsureOperationalShipyard(reg), deadline);
+
+        var colonyId = await ColonizeSecondPlanetAsync(host, recorder, reg, excludeSystemId, deadline);
+        if (deadline.Reached || colonyId is null)
+        {
+            return;
+        }
+
+        await RunSupplyLineAsync(host, recorder, reg, colonyId.Value, deadline);
+    }
+
+    // Player B (colonizer): build a Colony Ship, launch a real-scheduler Colonize at an uncolonized
+    // planet, then recall the fleet mid-transit (turning it around back home).
+    public static async Task RunColonizerAsync(
+        IAlbaHost host, SoakRecorder recorder, RegisterPlayerResponse reg, Guid excludeSystemId, Deadline deadline)
+    {
+        await RunLeg(recorder, "B: place Shipyard", () => host.PlaceBuilding(reg, BuildingType.Shipyard), deadline);
+        await RunLeg(recorder, "B: shipyard operational", () => host.EnsureOperationalShipyard(reg), deadline);
+
+        var colonyShipId = await TryBuildColonyShipAsync(host, recorder, reg, "B", deadline);
+        if (deadline.Reached || colonyShipId is null)
+        {
+            return;
+        }
+
+        await RunColonizeThenRecallLegAsync(host, recorder, reg, colonyShipId.Value, excludeSystemId, deadline);
+    }
+
+    // Builds a Colony Ship, colonizes a planet in another system, and — after the real scheduler
+    // delivers the arrival — confirms ownership (a colonize race with player B could leave the planet
+    // owned by the other player). Returns the owned colony id, or null if the colony was not won.
+    private static async Task<Guid?> ColonizeSecondPlanetAsync(
+        IAlbaHost host, SoakRecorder recorder, RegisterPlayerResponse reg, Guid excludeSystemId, Deadline deadline)
+    {
+        var colonyShipId = await TryBuildColonyShipAsync(host, recorder, reg, "A", deadline);
+        if (deadline.Reached || colonyShipId is null)
+        {
+            return null;
+        }
+
+        var fleet = await RunLegForResult(
+            recorder, "A: assemble colony fleet", () => host.AssembleFleet(reg, [colonyShipId.Value]), deadline);
+        if (deadline.Reached || fleet is null)
+        {
+            return null;
+        }
+
+        var target = await FindColonizeTargetAsync(host, recorder, reg, "A", excludeSystemId, deadline);
+        if (target is null)
+        {
+            return null;
+        }
+
+        var launched = await RunLegForResult(
+            recorder, "A: launch colonize",
+            () => host.Launch(reg, fleet.Id, MissionType.Colonize, target.Value), deadline);
+        if (launched is null)
+        {
+            return null;
+        }
+
+        await RunLeg(
+            recorder, "A: colony fleet arrives",
+            () => host.PollFleetUntil(reg, fleet.Id, f => f.Status == FleetStatus.Stationed, SoakTimeouts.FleetArrival),
+            deadline);
+
+        if (!await OwnsPlanetAsync(host, recorder, reg, target.Value))
+        {
+            recorder.RecordEvent($"A: did not win colony {target.Value}; skipping supply line.");
+            return null;
+        }
+
+        recorder.RecordEvent($"A: colonized {target.Value}");
+        return target;
+    }
+
+    // Builds cargo vessels and runs a Transport ore supply line from A's homeworld to its OWN colony.
+    private static async Task RunSupplyLineAsync(
+        IAlbaHost host, SoakRecorder recorder, RegisterPlayerResponse reg, Guid colonyId, Deadline deadline)
+    {
+        var cargoShipIds = await BuildCargoVesselsAsync(host, recorder, reg, deadline);
+        if (deadline.Reached || cargoShipIds.Count < 1)
+        {
+            recorder.RecordEvent("A: no cargo vessel available; skipping supply line.");
+            return;
+        }
+
+        var shipIds = cargoShipIds.Take(2).ToList();
+        var fleet = await RunLegForResult(
+            recorder, "A: assemble supply fleet",
+            () => host.AssembleFleet(reg, shipIds, new CargoRequest(_transportOre, 0m)), deadline);
+        if (deadline.Reached || fleet is null)
+        {
+            return;
+        }
+
+        // Transport to A's OWN colony — a same-owner destination, so a real delivery + auto-unload.
+        // Capture the raw status (200 launched; a rare 409 if a scheduled completion races the stream).
+        await deadline.PauseAsync();
+        var status = await host.PostForStatus(
+            reg, $"/api/fleets/{fleet.Id}/missions", new LaunchMissionRequest(MissionType.Transport, colonyId));
+        recorder.RecordStatus(status);
+        recorder.RecordEvent($"A: supply transport -> {status}");
+
+        await RunLeg(
+            recorder, "A: supply fleet settles",
+            () => host.PollFleetUntil(reg, fleet.Id, f => f.Status == FleetStatus.Stationed, SoakTimeouts.FleetArrival),
+            deadline);
+    }
+
+    private static async Task<IReadOnlyList<Guid>> BuildCargoVesselsAsync(
+        IAlbaHost host, SoakRecorder recorder, RegisterPlayerResponse reg, Deadline deadline)
+    {
+        if (deadline.Reached)
+        {
+            return [];
+        }
+
+        await deadline.PauseAsync();
+        try
+        {
+            var ids = await host.BuildRosterShips(reg, 2);
+            recorder.RecordEvent($"A: built {ids.Count} cargo vessels");
+            return ids;
+        }
+        catch (Exception ex) when (IsExpected(ex))
+        {
+            // Ingot starvation can leave a build ConstructionHalted so the batch never fully completes —
+            // a modeled outcome under this depletion theme. Recover whatever DID reach the roster.
+            recorder.RecordEvent($"A: cargo-vessel batch incomplete ({ex.Message}); recovering roster.");
+            return await AvailableCargoVesselIdsAsync(host, recorder, reg);
+        }
+    }
+
+    private static async Task<IReadOnlyList<Guid>> AvailableCargoVesselIdsAsync(
+        IAlbaHost host, SoakRecorder recorder, RegisterPlayerResponse reg)
+    {
+        try
+        {
+            var roster = await host.GetRoster(reg);
+            return roster.Items.Where(s => s.Type == ShipType.CargoVessel).Select(s => s.Id).ToList();
+        }
+        catch (Exception ex) when (IsExpected(ex))
+        {
+            recorder.RecordEvent($"A: roster read failed ({ex.Message}).");
+            return [];
+        }
+    }
+
+    private static async Task<Guid?> TryBuildColonyShipAsync(
+        IAlbaHost host, SoakRecorder recorder, RegisterPlayerResponse reg, string who, Deadline deadline)
+    {
+        if (deadline.Reached)
+        {
+            return null;
+        }
+
+        await deadline.PauseAsync();
+        try
+        {
+            var id = await host.BuildRosterShip(reg, ShipType.ColonyShip);
+            recorder.RecordEvent($"{who}: colony ship built");
+            return id;
+        }
+        catch (Exception ex) when (IsExpected(ex))
+        {
+            recorder.RecordEvent($"{who}: colony ship did not complete ({ex.Message}).");
+            return null;
+        }
+    }
+
+    private static async Task RunColonizeThenRecallLegAsync(
+        IAlbaHost host, SoakRecorder recorder, RegisterPlayerResponse reg,
+        Guid colonyShipId, Guid excludeSystemId, Deadline deadline)
+    {
+        var fleet = await RunLegForResult(
+            recorder, "B: assemble colony fleet", () => host.AssembleFleet(reg, [colonyShipId]), deadline);
+        if (deadline.Reached || fleet is null)
+        {
+            return;
+        }
+
+        var destinationId = await FindColonizeTargetAsync(host, recorder, reg, "B", excludeSystemId, deadline);
+        if (destinationId is null)
+        {
+            return;
+        }
+
+        var launched = await RunLegForResult(
+            recorder, "B: launch colonize",
+            () => host.Launch(reg, fleet.Id, MissionType.Colonize, destinationId.Value), deadline);
+        if (launched is null)
+        {
+            return;
+        }
+
+        // Recall the colony fleet mid-transit — a real-scheduler reschedule. Capture the raw status;
+        // an already-arrived fleet yields a modeled 409.
+        await deadline.PauseAsync();
+        var status = await host.CancelForStatus(reg, fleet.Id);
+        recorder.RecordStatus(status);
+        recorder.RecordEvent($"B: recall -> {status}");
+
+        await RunLeg(
+            recorder, "B: colony fleet settles",
+            () => host.PollFleetUntil(reg, fleet.Id, f => f.Status == FleetStatus.Stationed, SoakTimeouts.FleetArrival),
+            deadline);
+    }
+
+    private static async Task<Guid?> FindColonizeTargetAsync(
+        IAlbaHost host, SoakRecorder recorder, RegisterPlayerResponse reg, string who, Guid excludeSystemId, Deadline deadline)
+    {
+        await deadline.PauseAsync();
+        try
+        {
+            return await host.FindUncolonizedPlanet(reg, excludeSystemId);
+        }
+        catch (Exception ex) when (IsExpected(ex))
+        {
+            recorder.RecordEvent($"{who}: no uncolonized planet ({ex.Message}).");
+            return null;
+        }
+    }
+
+    private static async Task<bool> OwnsPlanetAsync(
+        IAlbaHost host, SoakRecorder recorder, RegisterPlayerResponse reg, Guid planetId)
+    {
+        try
+        {
+            var planet = await host.GetPlanetById(reg, planetId);
+            return planet.OwnerId == reg.PlayerId;
+        }
+        catch (Exception ex) when (IsExpected(ex))
+        {
+            recorder.RecordEvent($"A: ownership check failed ({ex.Message}).");
+            return false;
+        }
+    }
+
+    // Runs a value-less leg (result discarded): pauses, invokes, and records any EXPECTED failure.
+    private static async Task RunLeg(SoakRecorder recorder, string name, Func<Task> action, Deadline deadline)
+    {
+        if (deadline.Reached)
+        {
+            return;
+        }
+
+        await deadline.PauseAsync();
+        try
+        {
+            await action();
+            recorder.RecordEvent($"{name}: ok");
+        }
+        catch (Exception ex) when (IsExpected(ex))
+        {
+            recorder.RecordEvent($"{name}: expected failure ({ex.GetType().Name}: {ex.Message})");
+        }
+    }
+
+    // Runs a value-returning leg, yielding null on an EXPECTED failure so the caller can skip downstream legs.
+    private static async Task<T?> RunLegForResult<T>(
+        SoakRecorder recorder, string name, Func<Task<T>> action, Deadline deadline)
+        where T : class
+    {
+        if (deadline.Reached)
+        {
+            return null;
+        }
+
+        await deadline.PauseAsync();
+        try
+        {
+            var result = await action();
+            recorder.RecordEvent($"{name}: ok");
+            return result;
+        }
+        catch (Exception ex) when (IsExpected(ex))
+        {
+            recorder.RecordEvent($"{name}: expected failure ({ex.GetType().Name}: {ex.Message})");
+            return null;
+        }
+    }
+
+    // An UnexpectedStatusException (a modeled non-200 from an asserting helper — 4xx contention such as
+    // 403/409/503) or an InvalidOperationException/TimeoutException from a polling helper timing out are
+    // EXPECTED contention outcomes under this depletion theme; everything else is a real fault and
+    // propagates. Crucially, a 5xx never surfaces as UnexpectedStatusException — the harness raises
+    // ServerErrorException, which is NOT matched here, so a server error always fails the soak.
+    private static bool IsExpected(Exception ex) =>
+        ex is UnexpectedStatusException or InvalidOperationException or TimeoutException;
+}

--- a/src/Voidforge.SoakTests/SchedulerQuiescence.cs
+++ b/src/Voidforge.SoakTests/SchedulerQuiescence.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+using Marten;
+using Voidforge.Api.Domain;
+
+namespace Voidforge.SoakTests;
+
+// Aggregate-quiesce + settle-cap drain of the REAL Wolverine scheduler (no coupling to Wolverine's
+// internal envelope tables). Polls world state until nothing is overdue (or a hard cap elapses), then
+// waits a fixed settle window before the authoritative snapshot is taken.
+public static class SchedulerQuiescence
+{
+    // Overdue tolerance: the ~5s durability poll plus the #39 ConcurrencyException retry span (~7s),
+    // times a safety factor. A completion later than this is genuinely stuck, not merely in flight.
+    private static readonly TimeSpan _overdueMargin = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan _pollInterval = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan _hardCap = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan _settle = TimeSpan.FromSeconds(15);
+
+    public static async Task DrainAsync(IDocumentStore store, Action<string>? log = null)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var quiescent = false;
+        while (stopwatch.Elapsed < _hardCap)
+        {
+            if (!await AnythingOverdueAsync(store))
+            {
+                quiescent = true;
+                break;
+            }
+
+            await Task.Delay(_pollInterval);
+        }
+
+        var elapsed = Math.Round(stopwatch.Elapsed.TotalSeconds, 1);
+        log?.Invoke(quiescent
+            ? $"Scheduler quiesced after {elapsed}s; settling {_settle.TotalSeconds}s."
+            : $"Drain hard cap ({_hardCap.TotalSeconds}s) reached before quiescence; settling {_settle.TotalSeconds}s.");
+
+        await Task.Delay(_settle);
+    }
+
+    private static async Task<bool> AnythingOverdueAsync(IDocumentStore store)
+    {
+        var cutoff = TimeProvider.System.GetUtcNow() - _overdueMargin;
+        await using var session = store.LightweightSession();
+        var planets = await session.Query<Planet>().ToListAsync();
+        var fleets = await session.Query<Fleet>().ToListAsync();
+
+        var buildingOverdue = planets.Any(p => p.Buildings.Any(b => IsBuildingOverdue(b, cutoff)));
+        var shipOverdue = planets.Any(p => p.ShipQueue.Any(b => IsShipBuildOverdue(b, cutoff)));
+        var fleetOverdue = fleets.Any(f => IsFleetOverdue(f, cutoff));
+
+        return buildingOverdue || shipOverdue || fleetOverdue;
+    }
+
+    // A ConstructionHalted build is a MODELED (ingot-starved) state, not "stuck", so only
+    // UnderConstruction counts as overdue.
+    private static bool IsBuildingOverdue(BuildingSlot slot, DateTimeOffset cutoff) =>
+        slot.Status == BuildingStatus.UnderConstruction && slot.CompletesAt is { } at && at < cutoff;
+
+    // Queued builds wait on shipyard capacity (not the scheduler) and Halted builds are ingot-starved;
+    // only an Active build past its deadline is genuinely overdue.
+    private static bool IsShipBuildOverdue(ShipBuild build, DateTimeOffset cutoff) =>
+        build.Status == ShipBuildStatus.Active && build.CompletesAt is { } at && at < cutoff;
+
+    private static bool IsFleetOverdue(Fleet fleet, DateTimeOffset cutoff) =>
+        fleet.Status == FleetStatus.InTransit && fleet.ArrivesAt is { } at && at < cutoff;
+}

--- a/src/Voidforge.SoakTests/SoakCollection.cs
+++ b/src/Voidforge.SoakTests/SoakCollection.cs
@@ -1,0 +1,11 @@
+using Xunit;
+
+namespace Voidforge.SoakTests;
+
+#pragma warning disable CA1711 // xUnit collection definition types conventionally end in 'Collection'
+[CollectionDefinition(SoakCollection.Name)]
+public sealed class SoakCollection : ICollectionFixture<SoakHostFixture>
+{
+    public const string Name = "Soak";
+}
+#pragma warning restore CA1711

--- a/src/Voidforge.SoakTests/SoakConfig.cs
+++ b/src/Voidforge.SoakTests/SoakConfig.cs
@@ -13,9 +13,11 @@ public static class SoakConfig
 
     private const int _defaultWindowSeconds = 120;
 
-    // Overridable via the ConnectionStrings__Marten env var (read first, soak default second).
+    // Overridable via the dedicated VOIDFORGE_SOAK_CONNECTION_STRING env var (read first, soak default
+    // second). Deliberately NOT the shared ConnectionStrings__Marten host key, so a stray host-level
+    // Marten connection string can never be picked up here and have its schema dropped.
     public static string ConnectionString =>
-        Environment.GetEnvironmentVariable("ConnectionStrings__Marten") ?? DefaultConnectionString;
+        Environment.GetEnvironmentVariable("VOIDFORGE_SOAK_CONNECTION_STRING") ?? DefaultConnectionString;
 
     // Bounded soak window. 120s exercises the whole loop; the §8.2 depletion + ingot-storage-full
     // cascades fire at ~170-200s, so OBSERVING them (a Tier-3 follow-up) needs SOAK_WINDOW_SECONDS=300.

--- a/src/Voidforge.SoakTests/SoakConfig.cs
+++ b/src/Voidforge.SoakTests/SoakConfig.cs
@@ -1,0 +1,77 @@
+using System.Globalization;
+
+namespace Voidforge.SoakTests;
+
+// The §8.2 "depletion + ingot-storage-full" soak theme, expressed as env-var overrides applied before
+// the real host boots (ASP.NET Core maps `__` to the `:` config hierarchy). Mirrors AppFixture's
+// env-var-before-boot approach so it uses the WithWebHostBuilder-avoiding path.
+public static class SoakConfig
+{
+    // The DB name contains "test" so SoakHostFixture's drop-schema safety guard passes unmodified.
+    public const string DefaultConnectionString =
+        "Host=localhost;Port=5432;Database=voidforge_soak_test;Username=postgres;Password=voidforge_dev";
+
+    private const int _defaultWindowSeconds = 120;
+
+    // Overridable via the ConnectionStrings__Marten env var (read first, soak default second).
+    public static string ConnectionString =>
+        Environment.GetEnvironmentVariable("ConnectionStrings__Marten") ?? DefaultConnectionString;
+
+    // Bounded soak window. 120s exercises the whole loop; the §8.2 depletion + ingot-storage-full
+    // cascades fire at ~170-200s, so OBSERVING them (a Tier-3 follow-up) needs SOAK_WINDOW_SECONDS=300.
+    // The Tier-1 invariants hold at every instant regardless of window, so 120s is fine for the skeleton.
+    public static int WindowSeconds => ReadWindowSeconds();
+
+    public static void ApplyEnvironmentOverrides()
+    {
+        // Set the connection string before AlbaHost.For<Program>() so the host binds it via `__` -> `:`
+        // (the WithWebHostBuilder-avoiding path AppFixture documents to dodge a .NET 9 disposal race).
+        SetEnv("ConnectionStrings__Marten", ConnectionString);
+
+        // Rich-economy world: a finite ore deposit and an ingot store both sized so depletion and
+        // ingot-storage-full can be reached within a few-minute window.
+        SetEnv("WorldGeneration__IronOrePool", "4000");
+        SetEnv("WorldGeneration__IronIngotStorageCapacity", "2500");
+        SetEnv("WorldGeneration__StartingIronOre", "2000");
+        SetEnv("WorldGeneration__StartingIronIngots", "800");
+        SetEnv("WorldGeneration__SolarSystemCount", "40");
+
+        // Soak-scale construction durations and ship costs/speeds: fast enough to complete within the
+        // window, slow enough that the real scheduler genuinely spreads completions across wall-clock.
+        SetEnv("Balance__Drill__BuildDurationSeconds", "20");
+        SetEnv("Balance__Refinery__BuildDurationSeconds", "20");
+        SetEnv("Balance__Generator__BuildDurationSeconds", "20");
+        SetEnv("Balance__Shipyard__BuildDurationSeconds", "20");
+        SetEnv("Balance__ColonyShip__BuildDurationSeconds", "15");
+        SetEnv("Balance__CargoVessel__BuildDurationSeconds", "15");
+        SetEnv("Balance__ColonyShip__IngotCost", "60");
+        SetEnv("Balance__CargoVessel__IngotCost", "60");
+        SetEnv("Balance__Ships__ColonyShip__SpeedPerSecond", "100");
+        SetEnv("Balance__Ships__CargoVessel__SpeedPerSecond", "100");
+
+        // Economy is deliberately left unset: it binds from appsettings.json (10/s drill, 5/s refinery,
+        // 1:2 ratio), which is exactly what the §4.2 depletion math assumes.
+
+        PinLogLevels();
+    }
+
+    // Copied from AppFixture.PinTestLogLevels: silence the per-SQL Debug/Info logging the Development
+    // environment defaults switch on, so a long soak run does not bury real failures in log noise.
+    private static void PinLogLevels()
+    {
+        SetEnv("Logging__LogLevel__Default", "Information");
+        SetEnv("Logging__LogLevel__Marten", "Warning");
+        SetEnv("Logging__LogLevel__Wolverine", "Warning");
+        SetEnv("Logging__LogLevel__Npgsql", "Warning");
+    }
+
+    private static void SetEnv(string key, string value) => Environment.SetEnvironmentVariable(key, value);
+
+    private static int ReadWindowSeconds()
+    {
+        var raw = Environment.GetEnvironmentVariable("SOAK_WINDOW_SECONDS");
+        return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds) && seconds > 0
+            ? seconds
+            : _defaultWindowSeconds;
+    }
+}

--- a/src/Voidforge.SoakTests/SoakDriver.cs
+++ b/src/Voidforge.SoakTests/SoakDriver.cs
@@ -34,21 +34,28 @@ public sealed class SoakDriver
         using var snapshotCts = new CancellationTokenSource();
         var snapshotLoop = CaptureDepositSnapshotsAsync(recorder, deadline, snapshotCts.Token);
 
-        // A colonizes a second system and supplies it; B colonizes and recalls mid-transit. Each
-        // excludes its own home system so the colonize legs reach out to another system.
-        var scriptA = ScenarioScript.RunIndustrialistAsync(_host, recorder, regA, homeA.SolarSystemId, deadline);
-        var scriptB = ScenarioScript.RunColonizerAsync(_host, recorder, regB, homeB.SolarSystemId, deadline);
-        await Task.WhenAll(scriptA, scriptB);
-
-        // Keep the window open so the real scheduler can fire the arrivals / ship completions the
-        // scripts triggered, with the deposit-snapshot loop still running.
-        while (!deadline.Reached)
+        try
         {
-            await Task.Delay(SoakTimeouts.LegPause);
-        }
+            // A colonizes a second system and supplies it; B colonizes and recalls mid-transit. Each
+            // excludes its own home system so the colonize legs reach out to another system.
+            var scriptA = ScenarioScript.RunIndustrialistAsync(_host, recorder, regA, homeA.SolarSystemId, deadline);
+            var scriptB = ScenarioScript.RunColonizerAsync(_host, recorder, regB, homeB.SolarSystemId, deadline);
+            await Task.WhenAll(scriptA, scriptB);
 
-        await snapshotCts.CancelAsync();
-        await snapshotLoop;
+            // Keep the window open so the real scheduler can fire the arrivals / ship completions the
+            // scripts triggered, with the deposit-snapshot loop still running.
+            while (!deadline.Reached)
+            {
+                await Task.Delay(SoakTimeouts.LegPause);
+            }
+        }
+        finally
+        {
+            // Always stop the snapshot loop first, even if a script or the wait loop threw, so it never
+            // outlives this method (unobserved exception / queries during host disposal).
+            await snapshotCts.CancelAsync();
+            await snapshotLoop;
+        }
 
         log?.Invoke(
             $"Driver recorded {recorder.Statuses.Count} raced status(es), {recorder.Snapshots.Count} deposit snapshot(s), {recorder.Events.Count} leg event(s).");

--- a/src/Voidforge.SoakTests/SoakDriver.cs
+++ b/src/Voidforge.SoakTests/SoakDriver.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics;
+using Alba;
+using Marten;
+using Voidforge.Api.Domain;
+using Voidforge.Tests.Support;
+
+namespace Voidforge.SoakTests;
+
+// Orchestrates the two-user scenario concurrently under one wall-clock window while a background loop
+// captures the intermediate deposit series. After the scripts finish it keeps observing until the
+// window closes, so the real scheduler has time to fire the completions the scripts triggered.
+public sealed class SoakDriver
+{
+    private readonly IAlbaHost _host;
+    private readonly IDocumentStore _store;
+
+    public SoakDriver(IAlbaHost host, IDocumentStore store)
+    {
+        _host = host;
+        _store = store;
+    }
+
+    public async Task<SoakDriverResult> RunAsync(TimeSpan window, Action<string>? log = null)
+    {
+        var recorder = new SoakRecorder();
+        var stopwatch = Stopwatch.StartNew();
+        var deadline = new Deadline(stopwatch, window);
+
+        var regA = await _host.RegisterPlayer("SoakA_");
+        var regB = await _host.RegisterPlayer("SoakB_");
+        var homeA = await _host.GetPlanetById(regA, regA.HomeworldId);
+        var homeB = await _host.GetPlanetById(regB, regB.HomeworldId);
+
+        using var snapshotCts = new CancellationTokenSource();
+        var snapshotLoop = CaptureDepositSnapshotsAsync(recorder, deadline, snapshotCts.Token);
+
+        // A colonizes a second system and supplies it; B colonizes and recalls mid-transit. Each
+        // excludes its own home system so the colonize legs reach out to another system.
+        var scriptA = ScenarioScript.RunIndustrialistAsync(_host, recorder, regA, homeA.SolarSystemId, deadline);
+        var scriptB = ScenarioScript.RunColonizerAsync(_host, recorder, regB, homeB.SolarSystemId, deadline);
+        await Task.WhenAll(scriptA, scriptB);
+
+        // Keep the window open so the real scheduler can fire the arrivals / ship completions the
+        // scripts triggered, with the deposit-snapshot loop still running.
+        while (!deadline.Reached)
+        {
+            await Task.Delay(SoakTimeouts.LegPause);
+        }
+
+        await snapshotCts.CancelAsync();
+        await snapshotLoop;
+
+        log?.Invoke(
+            $"Driver recorded {recorder.Statuses.Count} raced status(es), {recorder.Snapshots.Count} deposit snapshot(s), {recorder.Events.Count} leg event(s).");
+        return new SoakDriverResult(recorder.Statuses, recorder.Snapshots, recorder.Events);
+    }
+
+    private async Task CaptureDepositSnapshotsAsync(SoakRecorder recorder, Deadline deadline, CancellationToken token)
+    {
+        while (!token.IsCancellationRequested && !deadline.Reached)
+        {
+            await CaptureOneAsync(recorder);
+            await DelayQuietly(SoakTimeouts.IntermediateSnapshotInterval, token);
+        }
+    }
+
+    private async Task CaptureOneAsync(SoakRecorder recorder)
+    {
+        var now = TimeProvider.System.GetUtcNow();
+        await using var session = _store.LightweightSession();
+        var planets = await session.Query<Planet>().ToListAsync();
+        var deposits = planets.ToDictionary(p => p.Id, p => p.IronOreDeposit.GetCurrentValue(now));
+        recorder.RecordSnapshot(new IntermediateSnapshot(now, deposits));
+    }
+
+    private static async Task DelayQuietly(TimeSpan delay, CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(delay, token);
+        }
+        catch (TaskCanceledException)
+        {
+            // Cancellation simply ends the snapshot loop; not an error.
+        }
+    }
+}

--- a/src/Voidforge.SoakTests/SoakDriverResult.cs
+++ b/src/Voidforge.SoakTests/SoakDriverResult.cs
@@ -1,0 +1,8 @@
+namespace Voidforge.SoakTests;
+
+// Everything the driver collected during the window: raw raced HTTP statuses (I4/I5), the ordered
+// deposit series (I11), and the human-readable leg outcomes (report only).
+public sealed record SoakDriverResult(
+    IReadOnlyList<int> HttpStatuses,
+    IReadOnlyList<IntermediateSnapshot> DepositSeries,
+    IReadOnlyList<string> Events);

--- a/src/Voidforge.SoakTests/SoakHostFixture.cs
+++ b/src/Voidforge.SoakTests/SoakHostFixture.cs
@@ -1,0 +1,75 @@
+using Alba;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Xunit;
+
+namespace Voidforge.SoakTests;
+
+// Clone of AppFixture for the soak run: applies the SoakConfig env overrides, auto-creates the
+// isolated soak DB, drops the schema so WorldSeeder reseeds fresh, then boots the real host.
+public sealed class SoakHostFixture : IAsyncLifetime
+{
+    public IAlbaHost Host { get; private set; } = null!;
+
+    // The DI-owned document store. NEVER `await using` this — that disposes the singleton the host
+    // still depends on (see technical-design/testing.md's Marten read discipline).
+    public IDocumentStore Store => Host.Services.GetRequiredService<IDocumentStore>();
+
+    public async Task InitializeAsync()
+    {
+        SoakConfig.ApplyEnvironmentOverrides();
+
+        var connStr = SoakConfig.ConnectionString;
+
+        // Safety check FIRST: refuse to touch (or create) a database whose name does not contain "test".
+        var builder = new NpgsqlConnectionStringBuilder(connStr);
+        if (builder.Database is not { } db || !db.Contains("test", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to reset database '{builder.Database}'. Soak connection string must target a database containing 'test' in its name.");
+        }
+
+        await EnsureDatabaseExistsAsync(connStr, db);
+
+        // Drop the schema before the host starts so the WorldSeeder re-seeds fresh data.
+        await using (var conn = new NpgsqlConnection(connStr))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "DROP SCHEMA IF EXISTS voidforge CASCADE;";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        Host = await AlbaHost.For<Program>();
+    }
+
+    public Task DisposeAsync() => Host?.DisposeAsync().AsTask() ?? Task.CompletedTask;
+
+    // start-infra only provisions voidforge_test; the soak DB is separate, so create it if missing to
+    // keep the run self-contained. Connect to the `voidforge` maintenance DB on the same server and,
+    // because CREATE DATABASE cannot run inside a transaction, issue it as a plain command.
+    private static async Task EnsureDatabaseExistsAsync(string connStr, string targetDb)
+    {
+        var admin = new NpgsqlConnectionStringBuilder(connStr) { Database = "voidforge" };
+        await using var conn = new NpgsqlConnection(admin.ConnectionString);
+        await conn.OpenAsync();
+
+        await using (var check = conn.CreateCommand())
+        {
+            check.CommandText = "SELECT 1 FROM pg_database WHERE datname = @name;";
+            check.Parameters.AddWithValue("name", targetDb);
+            var exists = await check.ExecuteScalarAsync();
+            if (exists is not null)
+            {
+                return;
+            }
+        }
+
+        await using var create = conn.CreateCommand();
+        // A database identifier cannot be parameterized. targetDb is our own constant/env value and the
+        // caller has already required it to contain "test", so this interpolation is safe.
+        create.CommandText = $"CREATE DATABASE \"{targetDb}\";";
+        await create.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Voidforge.SoakTests/SoakHostFixture.cs
+++ b/src/Voidforge.SoakTests/SoakHostFixture.cs
@@ -47,11 +47,12 @@ public sealed class SoakHostFixture : IAsyncLifetime
     public Task DisposeAsync() => Host?.DisposeAsync().AsTask() ?? Task.CompletedTask;
 
     // start-infra only provisions voidforge_test; the soak DB is separate, so create it if missing to
-    // keep the run self-contained. Connect to the `voidforge` maintenance DB on the same server and,
-    // because CREATE DATABASE cannot run inside a transaction, issue it as a plain command.
+    // keep the run self-contained. Connect to the standard `postgres` maintenance database on the same
+    // server (it always exists) and, because CREATE DATABASE cannot run inside a transaction, issue it
+    // as a plain command.
     private static async Task EnsureDatabaseExistsAsync(string connStr, string targetDb)
     {
-        var admin = new NpgsqlConnectionStringBuilder(connStr) { Database = "voidforge" };
+        var admin = new NpgsqlConnectionStringBuilder(connStr) { Database = "postgres" };
         await using var conn = new NpgsqlConnection(admin.ConnectionString);
         await conn.OpenAsync();
 
@@ -67,9 +68,10 @@ public sealed class SoakHostFixture : IAsyncLifetime
         }
 
         await using var create = conn.CreateCommand();
-        // A database identifier cannot be parameterized. targetDb is our own constant/env value and the
-        // caller has already required it to contain "test", so this interpolation is safe.
-        create.CommandText = $"CREATE DATABASE \"{targetDb}\";";
+        // A database identifier cannot be parameterized, so escape it via NpgsqlCommandBuilder.QuoteIdentifier
+        // (the "test"-guard on targetDb still applies).
+        var quotedDb = new NpgsqlCommandBuilder().QuoteIdentifier(targetDb);
+        create.CommandText = $"CREATE DATABASE {quotedDb};";
         await create.ExecuteNonQueryAsync();
     }
 }

--- a/src/Voidforge.SoakTests/SoakRecorder.cs
+++ b/src/Voidforge.SoakTests/SoakRecorder.cs
@@ -1,0 +1,26 @@
+using System.Collections.Concurrent;
+
+namespace Voidforge.SoakTests;
+
+// Thread-safe collector shared by the two concurrent user scripts and the deposit-snapshot loop.
+public sealed class SoakRecorder
+{
+    private readonly ConcurrentBag<int> _statuses = [];
+    private readonly ConcurrentBag<string> _events = [];
+    private readonly ConcurrentBag<IntermediateSnapshot> _snapshots = [];
+
+    // Raw HTTP status codes from deliberately-raced calls (PostForStatus / CancelForStatus) — the
+    // trustworthy signal for I4/I5.
+    public void RecordStatus(int statusCode) => _statuses.Add(statusCode);
+
+    // Human-readable leg outcomes (ok / expected failure) for the report.
+    public void RecordEvent(string message) => _events.Add(message);
+
+    public void RecordSnapshot(IntermediateSnapshot snapshot) => _snapshots.Add(snapshot);
+
+    public IReadOnlyList<int> Statuses => [.. _statuses];
+
+    public IReadOnlyList<string> Events => [.. _events];
+
+    public IReadOnlyList<IntermediateSnapshot> Snapshots => [.. _snapshots.OrderBy(s => s.At)];
+}

--- a/src/Voidforge.SoakTests/SoakReport.cs
+++ b/src/Voidforge.SoakTests/SoakReport.cs
@@ -1,0 +1,107 @@
+using System.Globalization;
+using System.Text;
+using Voidforge.Api.Domain;
+using Voidforge.Api.Scoring;
+
+namespace Voidforge.SoakTests;
+
+// A compact human-readable console report: the per-invariant PASS/FAIL matrix plus raw aggregates
+// (ore mined per planet, asset counts, per-player score). The seed for a future Tier-2 blessing.
+public static class SoakReport
+{
+    public static string Render(
+        WorldSnapshot s, Tier1Report report, ScoreCalculator scoreCalculator, IReadOnlyList<string> legEvents)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("=== Voidforge Soak Report (Tier 1) ===");
+        Emit(sb, $"Snapshot instant : {s.Now}");
+        Emit(sb, $"Planets {s.Planets.Count}  Fleets {s.Fleets.Count}  Players {s.Players.Count}");
+        Emit(sb, $"Dead letters     : {s.DeadLetterCount}");
+        Emit(sb, $"Raced statuses   : {FormatStatuses(s.HttpStatuses)}");
+        Emit(sb, $"Deposit snapshots: {s.DepositSeries.Count}");
+        sb.AppendLine();
+        AppendInvariants(sb, report);
+        sb.AppendLine();
+        AppendOreMined(sb, s);
+        sb.AppendLine();
+        AppendScores(sb, s, scoreCalculator);
+        sb.AppendLine();
+        AppendLegEvents(sb, legEvents);
+        return sb.ToString();
+    }
+
+    private static string FormatStatuses(IReadOnlyList<int> statuses)
+    {
+        if (statuses.Count == 0)
+        {
+            return "none";
+        }
+
+        var grouped = statuses
+            .GroupBy(c => c)
+            .OrderBy(g => g.Key)
+            .Select(g => $"{g.Key}x{g.Count()}");
+        return string.Join(", ", grouped);
+    }
+
+    private static void AppendInvariants(StringBuilder sb, Tier1Report report)
+    {
+        sb.AppendLine("Invariants:");
+        foreach (var result in report.Results)
+        {
+            Emit(sb, $"  [{(result.Passed ? "PASS" : "FAIL")}] {result.Id} {result.Title}");
+            foreach (var violation in result.Violations)
+            {
+                Emit(sb, $"         - {violation}");
+            }
+        }
+    }
+
+    private static void AppendOreMined(StringBuilder sb, WorldSnapshot s)
+    {
+        sb.AppendLine("Ore mined (initial deposit - current), producing planets only:");
+        var any = false;
+        foreach (var p in s.Planets)
+        {
+            var initial = p.IronOreDeposit.StorageCapacity;
+            var current = p.IronOreDeposit.GetCurrentValue(s.Now);
+            var mined = initial - current;
+            if (mined > 0m)
+            {
+                any = true;
+                Emit(sb, $"  planet {p.Id}: {mined} mined ({current}/{initial} remaining)");
+            }
+        }
+
+        if (!any)
+        {
+            sb.AppendLine("  (none)");
+        }
+    }
+
+    private static void AppendScores(StringBuilder sb, WorldSnapshot s, ScoreCalculator scoreCalculator)
+    {
+        sb.AppendLine("Per-player score:");
+        foreach (var player in s.Players)
+        {
+            var ownedPlanets = s.Planets.Where(p => p.OwnerId == player.Id).ToList();
+            var ownedFleets = s.Fleets.Where(f => f.OwnerId == player.Id).ToList();
+            var score = scoreCalculator.Compute(ownedPlanets, ownedFleets, s.Now);
+            Emit(sb, $"  {player.Name}: score {score} ({ownedPlanets.Count} planet(s), {ownedFleets.Count} fleet(s))");
+        }
+    }
+
+    private static void AppendLegEvents(StringBuilder sb, IReadOnlyList<string> legEvents)
+    {
+        sb.AppendLine("Driver leg events:");
+        foreach (var evt in legEvents)
+        {
+            Emit(sb, $"  {evt}");
+        }
+    }
+
+    // Appends an interpolated line under the invariant culture — avoids CA1305/MA0011 on the
+    // interpolated StringBuilder.AppendLine overload while keeping the call sites readable.
+    private static void Emit(StringBuilder sb, FormattableString line) =>
+        sb.AppendLine(line.ToString(CultureInfo.InvariantCulture));
+}

--- a/src/Voidforge.SoakTests/SoakSnapshotReader.cs
+++ b/src/Voidforge.SoakTests/SoakSnapshotReader.cs
@@ -1,0 +1,49 @@
+using System.Globalization;
+using Marten;
+using Npgsql;
+using Voidforge.Api.Domain;
+
+namespace Voidforge.SoakTests;
+
+// The authoritative post-drain read. Resolves the DI-owned store, materializes every aggregate list
+// at one fixed `now`, and reads the raw Wolverine dead-letter count for I3.
+public static class SoakSnapshotReader
+{
+    public static async Task<WorldSnapshot> ReadAuthoritativeAsync(
+        IDocumentStore store,
+        DateTimeOffset now,
+        string connectionString,
+        IReadOnlyList<int> httpStatuses,
+        IReadOnlyList<IntermediateSnapshot> depositSeries)
+    {
+        // Store is the DI singleton — a lightweight session over it, NEVER `await using` the store.
+        await using var session = store.LightweightSession();
+        var planets = await session.Query<Planet>().ToListAsync();
+        var fleets = await session.Query<Fleet>().ToListAsync();
+        var players = await session.Query<Player>().ToListAsync();
+
+        var deadLetters = await CountDeadLettersAsync(connectionString);
+
+        return new WorldSnapshot(planets, fleets, players, now, deadLetters, httpStatuses, depositSeries);
+    }
+
+    // Raw count of Wolverine's durable dead-letter queue (I3). The table lives in the Marten schema
+    // (DatabaseSchemaName = "voidforge"). An undefined-table error means Wolverine has not provisioned
+    // it, which is equivalent to zero dead letters.
+    private static async Task<long> CountDeadLettersAsync(string connectionString)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT count(*) FROM voidforge.wolverine_dead_letters;";
+        try
+        {
+            var scalar = await cmd.ExecuteScalarAsync();
+            return scalar is null or DBNull ? 0 : Convert.ToInt64(scalar, CultureInfo.InvariantCulture);
+        }
+        catch (PostgresException ex) when (string.Equals(ex.SqlState, PostgresErrorCodes.UndefinedTable, StringComparison.Ordinal))
+        {
+            return 0;
+        }
+    }
+}

--- a/src/Voidforge.SoakTests/SoakSnapshotReader.cs
+++ b/src/Voidforge.SoakTests/SoakSnapshotReader.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Marten;
+using Marten.Services;
 using Npgsql;
 using Voidforge.Api.Domain;
 
@@ -16,25 +17,36 @@ public static class SoakSnapshotReader
         IReadOnlyList<int> httpStatuses,
         IReadOnlyList<IntermediateSnapshot> depositSeries)
     {
-        // Store is the DI singleton — a lightweight session over it, NEVER `await using` the store.
-        await using var session = store.LightweightSession();
+        // All four reads (planets, fleets, players, dead-letter count) must observe ONE consistent
+        // database snapshot, so run them inside a single REPEATABLE READ transaction. Postgres pins the
+        // snapshot at the transaction's first statement, so the three Marten queries and the raw
+        // dead-letter count all see the same instant. This avoids a false I8 duplicate that a
+        // fleet/roster commit landing mid-read could otherwise produce.
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await using var tx = await conn.BeginTransactionAsync(System.Data.IsolationLevel.RepeatableRead);
+
+        // Store is the DI singleton — open a lightweight session OVER the connection+transaction we own,
+        // NEVER `await using` the store. SessionOptions.ForTransaction leaves OwnsConnection = false and
+        // OwnsTransactionLifecycle = false, so Marten reads through them but disposes neither (we do).
+        await using var session = store.LightweightSession(SessionOptions.ForTransaction(tx));
         var planets = await session.Query<Planet>().ToListAsync();
         var fleets = await session.Query<Fleet>().ToListAsync();
         var players = await session.Query<Player>().ToListAsync();
 
-        var deadLetters = await CountDeadLettersAsync(connectionString);
+        var deadLetters = await CountDeadLettersAsync(conn, tx);
 
         return new WorldSnapshot(planets, fleets, players, now, deadLetters, httpStatuses, depositSeries);
     }
 
-    // Raw count of Wolverine's durable dead-letter queue (I3). The table lives in the Marten schema
+    // Raw count of Wolverine's durable dead-letter queue (I3), run on the SAME connection+transaction as
+    // the aggregate reads so it observes the same snapshot. The table lives in the Marten schema
     // (DatabaseSchemaName = "voidforge"). An undefined-table error means Wolverine has not provisioned
     // it, which is equivalent to zero dead letters.
-    private static async Task<long> CountDeadLettersAsync(string connectionString)
+    private static async Task<long> CountDeadLettersAsync(NpgsqlConnection conn, NpgsqlTransaction tx)
     {
-        await using var conn = new NpgsqlConnection(connectionString);
-        await conn.OpenAsync();
         await using var cmd = conn.CreateCommand();
+        cmd.Transaction = tx;
         cmd.CommandText = "SELECT count(*) FROM voidforge.wolverine_dead_letters;";
         try
         {

--- a/src/Voidforge.SoakTests/SoakTimeouts.cs
+++ b/src/Voidforge.SoakTests/SoakTimeouts.cs
@@ -1,0 +1,19 @@
+namespace Voidforge.SoakTests;
+
+// Soak-scale wall-clock cadences and deadlines — deliberately longer than the integration suite's
+// TestTimeouts because the soak drives real, contended, config-heavy economy dynamics.
+public static class SoakTimeouts
+{
+    // Real pause between a user script's legs so its actions spread across the run's polls.
+    public static readonly TimeSpan LegPause = TimeSpan.FromSeconds(5);
+
+    // Waiting for a freshly-placed Shipyard to finish its (soak-config, 20s) construction.
+    public static readonly TimeSpan ShipyardOperational = TimeSpan.FromSeconds(40);
+
+    // A real-scheduler fleet arrival: cross-system transit at the soak ship speed plus the ~5s
+    // durability poll lag and the #39 retry span.
+    public static readonly TimeSpan FleetArrival = TimeSpan.FromSeconds(90);
+
+    // Cadence of the during-run intermediate deposit snapshots (the I11 monotonicity series).
+    public static readonly TimeSpan IntermediateSnapshotInterval = TimeSpan.FromSeconds(10);
+}

--- a/src/Voidforge.SoakTests/Tier1Invariants.cs
+++ b/src/Voidforge.SoakTests/Tier1Invariants.cs
@@ -1,0 +1,274 @@
+using Voidforge.Api.Domain;
+using Xunit;
+
+namespace Voidforge.SoakTests;
+
+// The Tier-1 invariants I1–I11 that must hold for ANY legal run, evaluated against a single
+// authoritative <see cref="WorldSnapshot"/>. Caps/limits are read off the aggregates and the injected
+// options, never hardcoded. Evaluate returns a structured report; AssertAll turns it into a hard fail.
+public static class Tier1Invariants
+{
+    public static Tier1Report Evaluate(
+        WorldSnapshot s, Func<ShipType, decimal> cargoCapacityOf, TimeSpan overdueMargin)
+    {
+        var results = new List<InvariantResult>
+        {
+            CheckOreAndDepositBounds(s),
+            CheckIngotBounds(s),
+            CheckDeadLetters(s),
+            CheckNoServerErrors(s),
+            CheckRacedStatusesClean(s),
+            CheckNothingStuck(s, overdueMargin),
+            CheckLiveSlotCount(s),
+            CheckShipUniqueness(s),
+            CheckCargoBounds(s, cargoCapacityOf),
+            CheckProductivityBounds(s),
+            CheckDepositMonotonicity(s),
+        };
+        return new Tier1Report(results);
+    }
+
+    public static void AssertAll(Tier1Report report) =>
+        Assert.True(
+            report.AllPassed,
+            "Tier-1 invariant(s) violated:" + Environment.NewLine + report.FailureSummary());
+
+    // I1: every planet's stored ore and its finite ore deposit sit within [0, cap]; the deposit cap is
+    // its seeded initial value (IronOreDeposit.StorageCapacity).
+    private static InvariantResult CheckOreAndDepositBounds(WorldSnapshot s)
+    {
+        var v = new List<string>();
+        foreach (var p in s.Planets)
+        {
+            AddIfOutOfBounds(v, p.Id, "IronOre", p.IronOre, s.Now);
+            AddIfOutOfBounds(v, p.Id, "IronOreDeposit", p.IronOreDeposit, s.Now);
+        }
+
+        return new InvariantResult("I1", "planet ore & deposit pools within [0, cap]", v);
+    }
+
+    // I2: every planet's stored ingots sit within [0, cap].
+    private static InvariantResult CheckIngotBounds(WorldSnapshot s)
+    {
+        var v = new List<string>();
+        foreach (var p in s.Planets)
+        {
+            AddIfOutOfBounds(v, p.Id, "IronIngot", p.IronIngot, s.Now);
+        }
+
+        return new InvariantResult("I2", "planet ingot pools within [0, cap]", v);
+    }
+
+    private static void AddIfOutOfBounds(
+        List<string> v, Guid planetId, string pool, ResourcePool resource, DateTimeOffset now)
+    {
+        var value = resource.GetCurrentValue(now);
+        if (value < 0m || value > resource.StorageCapacity)
+        {
+            v.Add($"planet {planetId} {pool}={value} outside [0, {resource.StorageCapacity}]");
+        }
+    }
+
+    // I3: no message reached the Wolverine dead-letter queue.
+    private static InvariantResult CheckDeadLetters(WorldSnapshot s)
+    {
+        var v = new List<string>();
+        if (s.DeadLetterCount != 0)
+        {
+            v.Add($"wolverine_dead_letters count = {s.DeadLetterCount}");
+        }
+
+        return new InvariantResult("I3", "no dead-lettered messages", v);
+    }
+
+    // I4: no recorded response was an unexpected server error. 503 (Service Unavailable) is a MODELED
+    // capacity outcome the engine returns for NoUncolonizedPlanets, so it is allowed per the plan's I4
+    // definition; a 500/502/504 means an unhandled exception escaped a handler.
+    //
+    // Only deliberately-raced calls (PostForStatus/CancelForStatus) contribute to s.HttpStatuses, so this
+    // snapshot check gates those raced paths. A 5xx that surfaces through an asserting helper is NOT
+    // recorded here — but it is no longer swallowed either: the harness raises ServerErrorException, which
+    // ScenarioScript.IsExpected does NOT match, so it propagates and fails the run outright. Between the
+    // two, every path is covered: raced calls by this invariant, asserting helpers by the tripwire.
+    private static InvariantResult CheckNoServerErrors(WorldSnapshot s)
+    {
+        var v = s.HttpStatuses
+            .Where(c => c is >= 500 and < 600 and not 503)
+            .Distinct()
+            .Select(c => $"recorded server-error status {c}")
+            .ToList();
+        return new InvariantResult("I4", "no unexpected 5xx responses (503 is a modeled outcome)", v);
+    }
+
+    // I5: a deliberately-raced call resolves only as a modeled outcome — 200 (won), 403 (foreign
+    // destination / not owner), 409 (concurrency loss), or 503 (capacity) — never a 500 or any other
+    // unexpected code.
+    private static InvariantResult CheckRacedStatusesClean(WorldSnapshot s)
+    {
+        var v = s.HttpStatuses
+            .Where(c => c is not (200 or 403 or 409 or 503))
+            .Distinct()
+            .Select(c => $"unexpected raced status {c}")
+            .ToList();
+        return new InvariantResult("I5", "raced calls resolve as 200/403/409/503 (never 500)", v);
+    }
+
+    // I6: after the drain nothing is overdue past the margin — no building still UnderConstruction, no
+    // Active ship build, no InTransit fleet past its deadline. Halted / ConstructionHalted are MODELED
+    // states, not stuck, so they are excluded.
+    private static InvariantResult CheckNothingStuck(WorldSnapshot s, TimeSpan margin)
+    {
+        var cutoff = s.Now - margin;
+        var v = new List<string>();
+        foreach (var p in s.Planets)
+        {
+            v.AddRange(p.Buildings.Where(b => IsBuildingStuck(b, cutoff))
+                .Select(b => $"planet {p.Id} building {b.Type} overdue UnderConstruction"));
+            v.AddRange(p.ShipQueue.Where(b => IsShipBuildStuck(b, cutoff))
+                .Select(b => $"planet {p.Id} ship build {b.Id} overdue Active"));
+        }
+
+        v.AddRange(s.Fleets.Where(f => IsFleetStuck(f, cutoff))
+            .Select(f => $"fleet {f.Id} overdue InTransit"));
+        return new InvariantResult("I6", "nothing overdue past the drain margin", v);
+    }
+
+    private static bool IsBuildingStuck(BuildingSlot b, DateTimeOffset cutoff) =>
+        b.Status == BuildingStatus.UnderConstruction && b.CompletesAt is { } at && at < cutoff;
+
+    private static bool IsShipBuildStuck(ShipBuild b, DateTimeOffset cutoff) =>
+        b.Status == ShipBuildStatus.Active && b.CompletesAt is { } at && at < cutoff;
+
+    private static bool IsFleetStuck(Fleet f, DateTimeOffset cutoff) =>
+        f.Status == FleetStatus.InTransit && f.ArrivesAt is { } at && at < cutoff;
+
+    // I7: the live building-slot count (excluding the Cancelled/Demolished tombstones) never exceeds
+    // the planet's slot cap.
+    private static InvariantResult CheckLiveSlotCount(WorldSnapshot s)
+    {
+        var v = new List<string>();
+        foreach (var p in s.Planets)
+        {
+            var live = p.Buildings.Count(b => b.Status is not (BuildingStatus.Cancelled or BuildingStatus.Demolished));
+            if (live > p.BuildingSlotCount)
+            {
+                v.Add($"planet {p.Id} has {live} live slots > cap {p.BuildingSlotCount}");
+            }
+        }
+
+        return new InvariantResult("I7", "live building slots within the planet cap", v);
+    }
+
+    // I8: every ship id appears at most once across planet rosters, ship queues, and non-Disbanded
+    // fleets (mirrors ScoreCalculator.CountShips' no-double-count rule).
+    private static InvariantResult CheckShipUniqueness(WorldSnapshot s)
+    {
+        var seen = new HashSet<Guid>();
+        var v = new List<string>();
+
+        void Register(Guid id, string where)
+        {
+            if (!seen.Add(id))
+            {
+                v.Add($"ship {id} appears more than once (again in {where})");
+            }
+        }
+
+        foreach (var p in s.Planets)
+        {
+            foreach (var ship in p.Ships)
+            {
+                Register(ship.Id, $"planet {p.Id} roster");
+            }
+
+            foreach (var build in p.ShipQueue)
+            {
+                Register(build.Id, $"planet {p.Id} queue");
+            }
+        }
+
+        foreach (var f in s.Fleets.Where(f => f.Status != FleetStatus.Disbanded))
+        {
+            foreach (var ship in f.Ships)
+            {
+                Register(ship.Id, $"fleet {f.Id}");
+            }
+        }
+
+        return new InvariantResult("I8", "ship ids unique across rosters, queues, and live fleets", v);
+    }
+
+    // I9: every non-Disbanded fleet has non-negative cargo within its combined ship capacity.
+    private static InvariantResult CheckCargoBounds(WorldSnapshot s, Func<ShipType, decimal> capacityOf)
+    {
+        var v = new List<string>();
+        foreach (var f in s.Fleets.Where(f => f.Status != FleetStatus.Disbanded))
+        {
+            if (f.CargoIronOre < 0m || f.CargoIronIngot < 0m)
+            {
+                v.Add($"fleet {f.Id} negative cargo (ore={f.CargoIronOre}, ingot={f.CargoIronIngot})");
+            }
+
+            var load = f.GetCargoLoad();
+            var capacity = f.GetCargoCapacity(capacityOf);
+            if (load > capacity)
+            {
+                v.Add($"fleet {f.Id} cargo load {load} exceeds capacity {capacity}");
+            }
+        }
+
+        return new InvariantResult("I9", "fleet cargo non-negative and within capacity", v);
+    }
+
+    // I10: every planet's energy productivity multiplier stays within [0, 1].
+    private static InvariantResult CheckProductivityBounds(WorldSnapshot s)
+    {
+        var v = new List<string>();
+        foreach (var p in s.Planets)
+        {
+            var m = p.GetProductivityMultiplier();
+            if (m < 0m || m > 1m)
+            {
+                v.Add($"planet {p.Id} productivity multiplier {m} outside [0, 1]");
+            }
+        }
+
+        return new InvariantResult("I10", "planet productivity multiplier within [0, 1]", v);
+    }
+
+    // I11: at every intermediate snapshot each planet's deposit is non-negative, and across each
+    // consecutive pair it never rises (the deposit's Rate is always <= 0, so it is monotone).
+    private static InvariantResult CheckDepositMonotonicity(WorldSnapshot s)
+    {
+        var v = new List<string>();
+        var series = s.DepositSeries;
+        foreach (var snap in series)
+        {
+            foreach (var (planetId, deposit) in snap.Deposits)
+            {
+                if (deposit < 0m)
+                {
+                    v.Add($"planet {planetId} deposit negative ({deposit}) at {snap.At}");
+                }
+            }
+        }
+
+        for (var i = 1; i < series.Count; i++)
+        {
+            AddDepositRegressions(v, series[i - 1], series[i]);
+        }
+
+        return new InvariantResult("I11", "planet deposits non-negative and non-increasing", v);
+    }
+
+    private static void AddDepositRegressions(List<string> v, IntermediateSnapshot previous, IntermediateSnapshot current)
+    {
+        foreach (var (planetId, deposit) in current.Deposits)
+        {
+            if (previous.Deposits.TryGetValue(planetId, out var earlier) && deposit > earlier)
+            {
+                v.Add($"planet {planetId} deposit rose {earlier} -> {deposit} between {previous.At} and {current.At}");
+            }
+        }
+    }
+}

--- a/src/Voidforge.SoakTests/Tier1Report.cs
+++ b/src/Voidforge.SoakTests/Tier1Report.cs
@@ -1,0 +1,17 @@
+namespace Voidforge.SoakTests;
+
+// The full I1–I11 evaluation. Kept as data so the test can BOTH print a per-invariant matrix and
+// assert on the outcome without re-evaluating.
+public sealed record Tier1Report(IReadOnlyList<InvariantResult> Results)
+{
+    public bool AllPassed => Results.All(r => r.Passed);
+
+    public string FailureSummary() =>
+        string.Join(
+            Environment.NewLine,
+            Results.Where(r => !r.Passed).Select(FormatFailure));
+
+    private static string FormatFailure(InvariantResult result) =>
+        $"{result.Id} ({result.Title}) FAILED:" + Environment.NewLine + "  " +
+        string.Join(Environment.NewLine + "  ", result.Violations);
+}

--- a/src/Voidforge.SoakTests/TwoUserEconomySoakTests.cs
+++ b/src/Voidforge.SoakTests/TwoUserEconomySoakTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Voidforge.Api.Balance;
+using Voidforge.Api.Domain;
+using Voidforge.Api.Scoring;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Voidforge.SoakTests;
+
+// The v1 walking-skeleton soak run: boot the real host with a rich-economy config, drive two
+// contending users over real HTTP for a bounded window (letting the REAL Wolverine scheduler fire
+// completions), drain the scheduler, snapshot world state via Marten, and assert Tier-1 invariants
+// I1-I11. Deliberately out of the slnx, so no CI lane or Stop-hook runs it — invoke manually.
+[Trait("Category", "Soak")]
+[Collection(SoakCollection.Name)]
+public sealed class TwoUserEconomySoakTests
+{
+    // Must match SchedulerQuiescence's overdue margin so I6 uses the same tolerance the drain did.
+    private static readonly TimeSpan _overdueMargin = TimeSpan.FromSeconds(10);
+
+    private readonly SoakHostFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public TwoUserEconomySoakTests(SoakHostFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [Fact]
+    public async Task TwoContendingUsersLeaveEveryTier1InvariantIntact()
+    {
+        var host = _fixture.Host;
+        var store = _fixture.Store;
+
+        var driver = new SoakDriver(host, store);
+        var driverResult = await driver.RunAsync(TimeSpan.FromSeconds(SoakConfig.WindowSeconds), _output.WriteLine);
+
+        await SchedulerQuiescence.DrainAsync(store, _output.WriteLine);
+
+        var now = TimeProvider.System.GetUtcNow();
+        var snapshot = await SoakSnapshotReader.ReadAuthoritativeAsync(
+            store, now, SoakConfig.ConnectionString, driverResult.HttpStatuses, driverResult.DepositSeries);
+
+        var balance = host.Services.GetRequiredService<IOptions<BalanceOptions>>().Value;
+        Func<ShipType, decimal> capacityOf = t => balance.Ships.For(t).CargoCapacity;
+        var scoreCalculator = host.Services.GetRequiredService<ScoreCalculator>();
+
+        var report = Tier1Invariants.Evaluate(snapshot, capacityOf, _overdueMargin);
+        _output.WriteLine(SoakReport.Render(snapshot, report, scoreCalculator, driverResult.Events));
+
+        Tier1Invariants.AssertAll(report);
+    }
+}

--- a/src/Voidforge.SoakTests/Voidforge.SoakTests.csproj
+++ b/src/Voidforge.SoakTests/Voidforge.SoakTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Alba" Version="8.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Npgsql" Version="9.0.4" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Voidforge.Api/Voidforge.Api.csproj" />
+    <ProjectReference Include="../Voidforge.Tests/Voidforge.Tests.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Voidforge.SoakTests/WorldSnapshot.cs
+++ b/src/Voidforge.SoakTests/WorldSnapshot.cs
@@ -1,0 +1,15 @@
+using Voidforge.Api.Domain;
+
+namespace Voidforge.SoakTests;
+
+// The single authoritative, post-drain read of world state — every list materialized at one fixed
+// instant (<see cref="Now"/>) so cross-pool relations are consistent — plus the driver's recorded
+// HTTP statuses (I4/I5) and the during-run deposit series (I11).
+public sealed record WorldSnapshot(
+    IReadOnlyList<Planet> Planets,
+    IReadOnlyList<Fleet> Fleets,
+    IReadOnlyList<Player> Players,
+    DateTimeOffset Now,
+    long DeadLetterCount,
+    IReadOnlyList<int> HttpStatuses,
+    IReadOnlyList<IntermediateSnapshot> DepositSeries);

--- a/src/Voidforge.Tests/Support/IntegrationApiExtensions.cs
+++ b/src/Voidforge.Tests/Support/IntegrationApiExtensions.cs
@@ -18,14 +18,54 @@ namespace Voidforge.Tests.Support;
 /// </summary>
 public static class IntegrationApiExtensions
 {
-    public static async Task<RegisterPlayerResponse> RegisterPlayer(this IAlbaHost host, string namePrefix)
+    /// <summary>
+    /// Runs a scenario WITHOUT asserting status, then enforces the universal "no 5xx" guarantee:
+    /// a 5xx (except the modeled 503) throws <see cref="ServerErrorException"/> — a caller must
+    /// never receive a 500. Returns the raw result so the caller can assert the expected status
+    /// (via <see cref="EnsureExpected"/>) and read the body. This is the single choke point every
+    /// asserting helper flows through.
+    /// </summary>
+    public static async Task<IScenarioResult> Send(this IAlbaHost host, Action<Scenario> configure)
     {
         var result = await host.Scenario(s =>
         {
+            configure(s);
+            s.IgnoreStatusCode();
+        });
+
+        var status = result.Context.Response.StatusCode;
+        if (status is >= 500 and not 503)
+        {
+            var body = await result.ReadAsTextAsync();
+            throw new ServerErrorException(
+                status, result.Context.Request.Method, result.Context.Request.Path.ToString(), body);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Enforces an expected status for the modeled path (5xx is already handled by <see cref="Send"/>).
+    /// A mismatch throws <see cref="UnexpectedStatusException"/>, which contention-tolerant callers MAY catch.
+    /// </summary>
+    public static void EnsureExpected(this IScenarioResult result, int expected)
+    {
+        var status = result.Context.Response.StatusCode;
+        if (status != expected)
+        {
+            throw new UnexpectedStatusException(
+                expected, status, result.Context.Request.Method, result.Context.Request.Path.ToString());
+        }
+    }
+
+    public static async Task<RegisterPlayerResponse> RegisterPlayer(this IAlbaHost host, string namePrefix)
+    {
+        var result = await host.Send(s =>
+        {
             s.Post.Json(new RegisterPlayerRequest($"{namePrefix}{Guid.NewGuid():N}"))
                 .ToUrl("/api/players/register");
-            s.StatusCodeShouldBe(200);
         });
+        result.EnsureExpected(200);
 
         var response = await result.ReadAsJsonAsync<RegisterPlayerResponse>();
         Assert.NotNull(response);
@@ -34,12 +74,12 @@ public static class IntegrationApiExtensions
 
     public static async Task<T> GetJson<T>(this IAlbaHost host, RegisterPlayerResponse asWhom, string url)
     {
-        var result = await host.Scenario(s =>
+        var result = await host.Send(s =>
         {
             s.Get.Url(url);
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, asWhom.ApiKey);
-            s.StatusCodeShouldBe(200);
         });
+        result.EnsureExpected(200);
 
         var response = await result.ReadAsJsonAsync<T>();
         Assert.NotNull(response);
@@ -68,13 +108,13 @@ public static class IntegrationApiExtensions
     public static async Task<ShipBuildResponse> QueueShip(
         this IAlbaHost host, RegisterPlayerResponse registration, ShipType type)
     {
-        var result = await host.Scenario(s =>
+        var result = await host.Send(s =>
         {
             s.Post.Json(new QueueShipRequest(type))
                 .ToUrl($"/api/planets/{registration.HomeworldId}/ship-queue");
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
         });
+        result.EnsureExpected(200);
 
         var build = await result.ReadAsJsonAsync<ShipBuildResponse>();
         Assert.NotNull(build);
@@ -87,13 +127,13 @@ public static class IntegrationApiExtensions
         var planet = await host.GetPlanet(registration);
         if (!planet.Buildings.Any(b => b.Type == BuildingType.Shipyard))
         {
-            await host.Scenario(s =>
+            var result = await host.Send(s =>
             {
                 s.Post.Json(new PlaceBuildingRequest(BuildingType.Shipyard))
                     .ToUrl($"/api/planets/{registration.HomeworldId}/buildings");
                 s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-                s.StatusCodeShouldBe(200);
             });
+            result.EnsureExpected(200);
         }
 
         await host.PollUntil(
@@ -169,13 +209,13 @@ public static class IntegrationApiExtensions
         CargoRequest? cargo = null,
         Guid? planetId = null)
     {
-        var result = await host.Scenario(s =>
+        var result = await host.Send(s =>
         {
             s.Post.Json(new AssembleFleetRequest(shipIds, cargo))
                 .ToUrl($"/api/planets/{planetId ?? registration.HomeworldId}/fleets");
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
         });
+        result.EnsureExpected(200);
 
         var fleet = await result.ReadAsJsonAsync<FleetResponse>();
         Assert.NotNull(fleet);
@@ -189,13 +229,13 @@ public static class IntegrationApiExtensions
         MissionType mission,
         Guid destinationPlanetId)
     {
-        var result = await host.Scenario(s =>
+        var result = await host.Send(s =>
         {
             s.Post.Json(new LaunchMissionRequest(mission, destinationPlanetId))
                 .ToUrl($"/api/fleets/{fleetId}/missions");
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
         });
+        result.EnsureExpected(200);
 
         var fleet = await result.ReadAsJsonAsync<FleetResponse>();
         Assert.NotNull(fleet);
@@ -205,12 +245,12 @@ public static class IntegrationApiExtensions
     public static async Task<FleetResponse> Disband(
         this IAlbaHost host, RegisterPlayerResponse registration, Guid fleetId)
     {
-        var result = await host.Scenario(s =>
+        var result = await host.Send(s =>
         {
             s.Post.Url($"/api/fleets/{fleetId}/disband");
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
         });
+        result.EnsureExpected(200);
 
         var fleet = await result.ReadAsJsonAsync<FleetResponse>();
         Assert.NotNull(fleet);
@@ -220,12 +260,12 @@ public static class IntegrationApiExtensions
     public static async Task<FleetResponse> Recall(
         this IAlbaHost host, RegisterPlayerResponse registration, Guid fleetId)
     {
-        var result = await host.Scenario(s =>
+        var result = await host.Send(s =>
         {
             s.Post.Url($"/api/fleets/{fleetId}/cancel");
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
         });
+        result.EnsureExpected(200);
 
         var fleet = await result.ReadAsJsonAsync<FleetResponse>();
         Assert.NotNull(fleet);
@@ -249,12 +289,12 @@ public static class IntegrationApiExtensions
     public static async Task<FleetResponse> Unload(
         this IAlbaHost host, RegisterPlayerResponse registration, Guid fleetId)
     {
-        var result = await host.Scenario(s =>
+        var result = await host.Send(s =>
         {
             s.Post.Url($"/api/fleets/{fleetId}/unload");
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
         });
+        result.EnsureExpected(200);
 
         var fleet = await result.ReadAsJsonAsync<FleetResponse>();
         Assert.NotNull(fleet);
@@ -448,13 +488,13 @@ public static class IntegrationApiExtensions
     public static async Task<PlanetResponse> PlaceBuilding(
         this IAlbaHost host, RegisterPlayerResponse registration, BuildingType type, Guid? planetId = null)
     {
-        var result = await host.Scenario(s =>
+        var result = await host.Send(s =>
         {
             s.Post.Json(new PlaceBuildingRequest(type))
                 .ToUrl($"/api/planets/{planetId ?? registration.HomeworldId}/buildings");
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(200);
         });
+        result.EnsureExpected(200);
 
         var planet = await result.ReadAsJsonAsync<PlanetResponse>();
         Assert.NotNull(planet);
@@ -468,12 +508,12 @@ public static class IntegrationApiExtensions
     public static async Task CancelConstruction(
         this IAlbaHost host, RegisterPlayerResponse registration, int slotIndex, Guid? planetId = null)
     {
-        await host.Scenario(s =>
+        var result = await host.Send(s =>
         {
             s.Delete.Url($"/api/planets/{planetId ?? registration.HomeworldId}/buildings/{slotIndex}/construction");
             s.WithRequestHeader(ApiKeyAuthenticationDefaults.HeaderName, registration.ApiKey);
-            s.StatusCodeShouldBe(204);
         });
+        result.EnsureExpected(204);
     }
 
     /// <summary>

--- a/src/Voidforge.Tests/Support/ServerErrorException.cs
+++ b/src/Voidforge.Tests/Support/ServerErrorException.cs
@@ -1,0 +1,40 @@
+namespace Voidforge.Tests.Support;
+
+/// <summary>
+/// Thrown when a harness request receives a 5xx server error (except the modeled 503).
+/// This is the universal "no 500" tripwire: nothing in the test harness or the soak driver
+/// should ever catch it, so a genuine server error always fails the test.
+/// </summary>
+public sealed class ServerErrorException : Exception
+{
+    public ServerErrorException()
+    {
+    }
+
+    public ServerErrorException(string message)
+        : base(message)
+    {
+    }
+
+    public ServerErrorException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public ServerErrorException(int statusCode, string method, string path, string? body)
+        : base($"Server error: {method} {path} -> {statusCode}\n{body}")
+    {
+        StatusCode = statusCode;
+        Method = method;
+        Path = path;
+        Body = body;
+    }
+
+    public int StatusCode { get; }
+
+    public string Method { get; } = string.Empty;
+
+    public string Path { get; } = string.Empty;
+
+    public string? Body { get; }
+}

--- a/src/Voidforge.Tests/Support/UnexpectedStatusException.cs
+++ b/src/Voidforge.Tests/Support/UnexpectedStatusException.cs
@@ -1,0 +1,40 @@
+namespace Voidforge.Tests.Support;
+
+/// <summary>
+/// Thrown when a response's status is not the expected code for a modeled non-200 path
+/// (for example 403/409/503). Callers that tolerate contention MAY catch this; a 5xx is
+/// never surfaced this way — it throws <see cref="ServerErrorException"/> instead.
+/// </summary>
+public sealed class UnexpectedStatusException : Exception
+{
+    public UnexpectedStatusException()
+    {
+    }
+
+    public UnexpectedStatusException(string message)
+        : base(message)
+    {
+    }
+
+    public UnexpectedStatusException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public UnexpectedStatusException(int expected, int actual, string method, string path)
+        : base($"Unexpected status: {method} {path} -> expected {expected}, got {actual}")
+    {
+        Expected = expected;
+        Actual = actual;
+        Method = method;
+        Path = path;
+    }
+
+    public int Expected { get; }
+
+    public int Actual { get; }
+
+    public string Method { get; } = string.Empty;
+
+    public string Path { get; } = string.Empty;
+}

--- a/technical-design/research/verifier-live-soak-run.md
+++ b/technical-design/research/verifier-live-soak-run.md
@@ -148,9 +148,9 @@ Concrete, code-grounded invariants:
 | I3 | **No dead-lettered messages.** `wolverine_dead_letters` is empty. | A dead letter means the retry ladder was exhausted — architecture.md:245-249 argues this is "effectively impossible" for the transient collisions in scope, so a non-empty table is a genuine defect. Query the table directly over the same Npgsql connection (see §5.3). |
 | I4 | **No 5xx responses.** Every driven request returned a modeled status (2xx, or an *expected* 4xx the script asked for — 409/403/503). | The driver records every response code. A 500 means an unhandled exception escaped a handler — e.g. a concurrency loser that failed to map to 409 (`ConcurrencyConflictExceptionHandler`, `Program.cs:81`). |
 | I5 | **Concurrency conflicts surface as 409, never lost.** Any conflict the driver provoked came back 409 (HTTP) and the losing command had **no** partial effect; scheduled-side conflicts left no stuck aggregate (see I6). | `Program.cs:59-65,81`; regression baseline is `SameStreamConcurrencyTests` (architecture.md:252). The driver counts 409s as *expected*, not failures. |
-| I6 | **Everything scheduled by T resolves by T + margin.** After the drain window (§5.4), **no** building is `UnderConstruction` or `ConstructionHalted` past its `CompletesAt + margin`; no ship build is `Active`/`Queued`/`Halted` past its deadline; no fleet is `InTransit` past `ArrivesAt + margin`. | Nothing may be stuck. `margin` = poll interval + retry-ladder span ≈ **7 s** (ADR 0002 §"bounded ~7 s") plus a safety multiple. Statuses: `BuildingStatus` (`BuildingStatus.cs`), `ShipBuildStatus` (`ShipBuildStatus.cs`), `FleetStatus.InTransit` (`FleetStatus.cs`). |
+| I6 | **Everything scheduled by T resolves by T + margin.** After the drain window (§5.4), **no** building is `UnderConstruction` past its `CompletesAt + margin`; no ship build is `Active` past its deadline; no fleet is `InTransit` past `ArrivesAt + margin`. `ConstructionHalted`, `Queued`, and `Halted` are modeled (ingot-starved / capacity-waiting) states, not stuck, so they are excluded. | Nothing may be stuck. `margin` = poll interval + retry-ladder span ≈ **7 s** (ADR 0002 §"bounded ~7 s") plus a safety multiple. Statuses: `BuildingStatus` (`BuildingStatus.cs`), `ShipBuildStatus` (`ShipBuildStatus.cs`), `FleetStatus.InTransit` (`FleetStatus.cs`). |
 | I7 | **Slot counts within cap.** For every planet, the count of live building slots (not `Cancelled`/`Demolished` tombstones) `<= BuildingSlotCount`. | `WorldGenOptions.BuildingSlotCount` (default 6, `WorldGenOptions.cs:8`); tombstone statuses per `BuildingStatus.cs:17,27`. |
-| I8 | **Roster / queue consistency.** A ship id appears in exactly one place: a planet roster (`Planet.Ships`) **xor** a fleet (`Fleet.Ships`) — never both, never neither-after-completion. Every `ShipQueue` entry is a live in-progress build (no tombstone status exists there). | The no-double-count rule is documented in `ScoreCalculator.CountShips` (`ScoreCalculator.cs:82-125`): assembly atomically MOVES a ship from roster to fleet; disband reverses it. The verifier re-runs this cross-check as an assertion instead of a scoring convenience. |
+| I8 | **Roster / queue uniqueness.** A ship id appears **at most once** across planet rosters (`Planet.Ships`), ship queues (`Planet.ShipQueue`), and non-`Disbanded` fleets (`Fleet.Ships`) — never in two places at once. Every `ShipQueue` entry is a live in-progress build (no tombstone status exists there). *v1 verifies uniqueness only; asserting that a completed ship never vanishes from **every** collection needs a durable completed-ship ledger and is a documented follow-up.* | The no-double-count rule is documented in `ScoreCalculator.CountShips` (`ScoreCalculator.cs:82-125`): assembly atomically MOVES a ship from roster to fleet; disband reverses it. The verifier re-runs this cross-check as an assertion instead of a scoring convenience. |
 | I9 | **Fleet cargo non-negative and bounded.** `CargoIronOre >= 0`, `CargoIronIngot >= 0`, and `GetCargoLoad() <= GetCargoCapacity(...)` for the fleet's ship mix. | `Fleet.cs:38-39,78-82`; capacity from `ShipsBalanceOptions` (`ShipsBalanceOptions.cs:8-9`). |
 | I10 | **Energy multiplier in `[0, 1]`.** Every planet's productivity multiplier is `<= 1` and `>= 0`; the blackout floor is exactly `0` — a planet with consumers but no generation yields `0` (`GetProductivityMultiplier`, `Planet.Energy.cs`). Halted/tombstone slots draw the documented fractions, not full rating. | `PlanetResponse.Energy.ProductivityMultiplier` (`PlanetResponse.cs:41-44`); halted 5% floor `BuildingSpecs.HaltedDrawFactor`; tombstones draw nothing (`BuildingStatus.cs:15-16,20-22`). |
 
@@ -444,8 +444,8 @@ those are for deterministic tests and are the wrong tool here.)
    on the ~5 s poll (architecture.md:229) with up to the ~7 s race margin (ADR 0002), a snapshot
    taken the instant driving stops would show spurious `UnderConstruction`/`InTransit` that are
    merely *pending*, not *stuck* — false I6 failures. So after stopping, **quiesce**: poll the
-   world until no aggregate has a `CompletesAt`/`ArrivesAt` in the past-minus-margin *and* the
-   outgoing-envelope backlog for due messages is empty, or a hard drain cap (e.g. 3 × poll ≈
+   world until no `Planet`/`Fleet` aggregate has a `CompletesAt`/`ArrivesAt` in the past-minus-margin,
+   or a hard drain cap (e.g. 3 × poll ≈
    15–20 s) elapses. Only then take the **single authoritative snapshot** with one fixed
    `now = TimeProvider.System.GetUtcNow()` reused for the whole snapshot (§2 Tier-2 jitter rule).
 
@@ -593,7 +593,7 @@ overload, `testing.md:20`).
 ## 9. Open Questions / Decisions for the Team
 
 1. **Drain-completeness signal. — RESOLVED for v1 via aggregate-quiesce (no envelope query).** §5.4
-   quiesces by polling aggregates + the outgoing-envelope backlog. Is querying
+   quiesces by polling `Planet`/`Fleet` aggregates only (no envelope query). Is querying
    `wolverine_outgoing_envelopes` for due-but-undelivered messages an acceptable "scheduler is idle"
    signal, or should we expose a small health/introspection hook? Getting this wrong is the most
    likely source of false I6 failures. **v1 decision:** poll aggregates for anything overdue past a

--- a/technical-design/research/verifier-live-soak-run.md
+++ b/technical-design/research/verifier-live-soak-run.md
@@ -1,7 +1,33 @@
 # Verifier Research: Live Soak-Run Verifier
 
-> **Status:** Research / design proposal. No code exists yet. This document is the design
-> for the verifier the team will **primarily** implement.
+> **Status:** Design + **v1 walking skeleton shipped**. This document is the design for the
+> verifier the team is **primarily** implementing; §2–§8 remain the target end-state.
+>
+> **v1 (shipped, `src/Voidforge.SoakTests/`):** a standalone `dotnet test` project — deliberately
+> **not** in `src/Voidforge.slnx`, so no CI lane or Stop-hook runs it — that boots the real host
+> against an isolated auto-created `voidforge_soak_test` DB with the §8.2 theme config, drives the
+> two-user scenario over real HTTP for a bounded window (`SOAK_WINDOW_SECONDS`, default 120),
+> drains via **aggregate-quiesce + settle-cap**, snapshots via Marten, and asserts **Tier 1
+> (I1–I11)**. Run: `SOAK_WINDOW_SECONDS=300 dotnet test src/Voidforge.SoakTests/Voidforge.SoakTests.csproj`.
+> Validated: a 90 s and a 300 s run each pass all 11 invariants; the run genuinely exercised
+> parallel Planet-stream appends (observed `23505` optimistic-concurrency collisions absorbed by the
+> retry ladder — I3 dead-letters empty, I5 clean). **Deferred to follow-ups:** Tier 2 baselines +
+> blessing, Tier 3 structural outcomes, envelope-based drain, CI gating, multi-theme matrix.
+>
+> **Two findings from v1 (acted on):**
+> 1. **Transport is own-planets-only, so §8.2's A→B lifeline was infeasible — the scenario was
+>    reshaped.** `FleetEndpoints.ValidateMissionPrecondition` (`FleetEndpoints.cs:459-461`) 403s a
+>    Transport whose destination is not owned by the caller, so "Player A delivers ore to Player B"
+>    cannot happen. v1 instead runs a faithful **within-player supply line**: Player A colonizes a
+>    second planet in another system, then Transports ore from its homeworld to that **own** colony —
+>    a same-owner destination, so the mission launches 200 and the cargo delivers + auto-unloads on
+>    arrival. Player B keeps the Colonize → mid-transit Recall leg for reschedule coverage. Validated:
+>    a 300 s run shows `A: supply transport -> 200`, A owning 2 planets / 2 fleets, and the delivery
+>    completing over the real scheduler. **§8.2's prose below is superseded** by this shape (its
+>    "B receives A's ore → ingot-storage-full on B" chain does not occur; see the §8.2 note).
+> 2. **Open Question #1 (drain signal) is resolved for v1** by aggregate-quiesce (§5.4), avoiding the
+>    unverified `wolverine_*_envelopes` schema entirely. Envelope introspection remains a possible
+>    hardening but is not required.
 >
 > **Sibling:** [`verifier-golden-diff.md`](verifier-golden-diff.md) — the complementary
 > *exact-logic* verifier that pins the pure domain math (checkpoint arithmetic, cascade
@@ -24,7 +50,7 @@ the resulting world state and assert correctness against a **tiered** assertion 
 It is a *system* test, not a *unit* test. Nothing is faked:
 
 - **Clock is real.** The app injects `TimeProvider.System` as a singleton
-  (`src/Voidforge.Api/Program.cs:92`); endpoints stamp events with `timeProvider.GetUtcNow()`
+  (`src/Voidforge.Api/Program.cs:93`); endpoints stamp events with `timeProvider.GetUtcNow()`
   and the domain computes values as a pure function of a passed-in `now`
   (`ResourcePool.GetCurrentValue`, `src/Voidforge.Api/Domain/ResourcePool.cs:15-19`). The soak
   run does **not** substitute a fake clock — that is the entire point.
@@ -32,15 +58,15 @@ It is a *system* test, not a *unit* test. Nothing is faked:
   depletion / starvation cascade checks are durable scheduled messages
   (`bus.ScheduleAsync(...)`, e.g. `src/Voidforge.Api/Endpoints/ShipConstructionScheduling.cs:16`),
   persisted to Postgres in the triggering transaction and delivered by the single-node
-  durability agent (`DurabilityMode.Solo`, `src/Voidforge.Api/Program.cs:47`) polling on a
+  durability agent (`DurabilityMode.Solo`, `src/Voidforge.Api/Program.cs:48`) polling on a
   ~5 s wall-clock interval (`technical-design/architecture.md:229`; configurable via
   `opts.Durability.ScheduledJobPollingTime`, architecture.md:318). ADR 0001 is the record of
   this "schedule optimistically, validate on arrival" model.
-- **Concurrency is real.** `EventAppendMode.Quick` (`Program.cs:33`) with `FetchForWriting`
+- **Concurrency is real.** `EventAppendMode.Quick` (`Program.cs:34`) with `FetchForWriting`
   optimistic concurrency; multiple paths append to one `Planet` stream (parallel scheduled
   completions plus HTTP commands). A loser fails with `ConcurrencyException`, which for
-  scheduled work is replayed by the retry ladder `Program.cs:59-65` (50 ms → 1 s) and for HTTP
-  is mapped to 409 by `ConcurrencyConflictExceptionHandler` (`Program.cs:81`). The old
+  scheduled work is replayed by the retry ladder `Program.cs:60-66` (50 ms → 1 s) and for HTTP
+  is mapped to 409 by `ConcurrencyConflictExceptionHandler` (`Program.cs:82`). The old
   `MaximumParallelMessages(1)` throttle was **deliberately removed** (architecture.md:252), so
   message processing is genuinely parallel.
 
@@ -273,9 +299,10 @@ constants, rates, or world-gen defaults *should* move the baseline — so:
 - If the diff appears with **no** balance/world/scoring change in the PR, it is a **regression
   candidate**: hard-investigate before re-blessing. Never re-bless to make a red run green
   without a corresponding intentional change — that is how a baseline silently absorbs a bug.
-- Rates that live in `BuildingSpecs` (drill/refinery throughput, 1:2 ratio, 5% floors) are
-  **hardcoded, not config** (`BuildingSpecs.cs`) — a change there is always a "legit game
-  change" that must move the baseline and should be called out in the PR description.
+- Rates that surface through `BuildingSpecs` (drill/refinery throughput, 1:2 ratio, 5% floors) now
+  bind from the **`Economy`** config section into `EconomyRates` (`Program.cs:125-128,139`) — a
+  change to any of them, whether via config or by editing the `EconomyRates` defaults, is a "legit
+  game change" that must move the baseline and be called out in the PR description.
 
 ## 4. World / Config Tuning for a Rich 5-Minute Run
 
@@ -302,10 +329,18 @@ Everything below binds from config sections `Balance` / `WorldGeneration`
 | Starting ore / ingots | `WorldGeneration__StartingIronOre/StartingIronIngots` | 500 / 100 | **bump** (e.g. 2000 / 800) | So construction doesn't starve before the economy ramps. |
 | World size | `WorldGeneration__SolarSystemCount` / `PlanetsPerSystem` | 5 / 3 | **≥ 40 / 3** | Enough uncolonized planets for N users + colonize legs without 503s (`AppFixture.cs:29` already bumps to 80 for the same reason). |
 
-Rates are **not** tunable: Drill `+10 ore/s`, Refinery `5 ore/s → 10 ingot/s`, the 1:2 factor,
-and the 5% floors are hardcoded in `BuildingSpecs.cs` (`:8-49`). Tuning shapes *durations,
-costs, pools, caps, speeds, world size* — never throughput. All balancing must be done around
-those fixed rates.
+Rates **are** tunable (this doc's earlier "not tunable" claim is stale as of the
+deterministic-engine work in #95). Drill ore rate, Refinery consumption, the 1:2
+`RefineryIngotOutputFactor`, generator/draw energy, and the 5% halted/shipyard-idle floors all
+live in `EconomyRates` (`src/Voidforge.Api/Domain/EconomyRates.cs`), bound from the **`Economy`**
+config section (`Program.cs:125-128`) and installed into the process-global `BuildingSpecs` table at
+`Program.cs:139` — so `Economy__DrillOreRatePerSecond`, `Economy__RefineryOreConsumptionPerSecond`,
+`Economy__RefineryIngotOutputFactor`, `Economy__HaltedDrawFactor`, etc. are all `__`-env-bindable
+exactly like `Balance`/`WorldGeneration`. The defaults equal the old constants (Drill `+10 ore/s`,
+Refinery `5 ore/s → 10 ingot/s`), so leaving `Economy` unset preserves the §4.2 math. The genuinely
+non-tunable rules are the per-type building *shapes* (which resource each type produces) and the
+`ShipsBalanceOptions` cargo/speed structure. **A change to any `Economy` value moves the Tier-2
+baseline** and must be called out in the PR (see §3.3), just like `BuildingSpecs` constants were.
 
 ### 4.2 The central tension — you tune for what you want to observe
 
@@ -425,10 +460,10 @@ Every source of run-to-run variation, and which tier absorbs it:
 | Source | Reference | Absorbed by |
 |--------|-----------|-------------|
 | Read-time value = `checkpoint + rate × elapsed(realtime)` | `ResourcePool.cs:15-19` | **Tier 2** (ε/%) and the §5.4 single-`now` drained snapshot; never exact-diffed |
-| Event-order race (scheduled completion vs HTTP command) | ADR 0001; `Program.cs:33,59-65` | **Tier 1** invariants (order-independent by design) + **Tier 2** for totals |
+| Event-order race (scheduled completion vs HTTP command) | ADR 0001; `Program.cs:34,60-66` | **Tier 1** invariants (order-independent by design) + **Tier 2** for totals |
 | Under-credit residual on inverted delivery | ADR 0002 §"Residual under-credit"; `ResourcePool.cs:9-14` | **Tier 2** ε on conservation reconciliation; bounded, never Tier-1 (never corrupts) |
 | ~5 s poll granularity (events fire late) | architecture.md:229,318 | **Tier 3** timing slack (`k × pollInterval`); §5.4 drain before snapshot |
-| Concurrency retry backoff timing (50 ms–1 s) | `Program.cs:59-65` | **Tier 1** I5/I6 (conflicts resolve, nothing lost); adds to I6 margin |
+| Concurrency retry backoff timing (50 ms–1 s) | `Program.cs:60-66` | **Tier 1** I5/I6 (conflicts resolve, nothing lost); adds to I6 margin |
 | Unseeded planet coordinates → travel distances/times vary | `WorldSeeder.cs:57,96-99` | **Tier 3** slack (transit deadlines are `+k×poll`); **Tier 2** count-based, not distance-based |
 | `Guid.NewGuid()` ids everywhere | `WorldSeeder.cs:61,69` | Not asserted on — verifier never checks specific ids, only counts/relationships (I8) |
 | `Random.Shared` homeworld pick (unseeded default) over the id-ordered candidate query | `PlayerEndpoints` (`OrderBy(p => p.Id)`) | **Tier 3** (owns ≥N planets), not "owns planet X" |
@@ -501,6 +536,14 @@ overload, `testing.md:20`).
 
 ### 8.2 A concrete 5-minute scenario: "Two-user economy with a transport lifeline and a depletion"
 
+> ⚠️ **v1 reshape (implemented):** the "transport lifeline from A to B" below is **infeasible** —
+> Transport requires a same-owner destination (`FleetEndpoints.cs:459-461`), so A→B 403s. The
+> shipped v1 driver instead runs a **within-player supply line**: Player A colonizes a second planet
+> in another system and Transports ore from its homeworld to that **own** colony (launches 200,
+> delivers + auto-unloads on arrival); Player B keeps Colonize → mid-transit Recall. Read the A/B
+> walkthrough below as the *original* design intent — the code in `src/Voidforge.SoakTests/` is the
+> source of truth for the shipped scenario.
+
 **Config theme:** tuned for depletion + an ingot-storage-full near the end. Key overrides:
 `IronOrePool=4000`, `IronIngotStorageCapacity=2500`, `StartingIronOre=2000`,
 `StartingIronIngots=800`, all build durations `20 s`, ship durations/costs `15 s`/`60`,
@@ -549,10 +592,14 @@ overload, `testing.md:20`).
 
 ## 9. Open Questions / Decisions for the Team
 
-1. **Drain-completeness signal.** §5.4 quiesces by polling aggregates + the outgoing-envelope
-   backlog. Is querying `wolverine_outgoing_envelopes` for due-but-undelivered messages an
-   acceptable "scheduler is idle" signal, or should we expose a small health/introspection hook?
-   Getting this wrong is the most likely source of false I6 failures.
+1. **Drain-completeness signal. — RESOLVED for v1 via aggregate-quiesce (no envelope query).** §5.4
+   quiesces by polling aggregates + the outgoing-envelope backlog. Is querying
+   `wolverine_outgoing_envelopes` for due-but-undelivered messages an acceptable "scheduler is idle"
+   signal, or should we expose a small health/introspection hook? Getting this wrong is the most
+   likely source of false I6 failures. **v1 decision:** poll aggregates for anything overdue past a
+   ~10 s margin, then wait a fixed settle (~15 s) capped at ~30 s — no dependency on the (unverified)
+   `wolverine_*_envelopes` schema. Held across the validation runs with zero false I6 failures.
+   Envelope introspection stays open only as an optional precision hardening.
 2. **How many scenario themes?** One themed run can't maximize depletion *and* both storage-full
    variants (§4.2). Do we run one broad scenario nightly, or a small matrix of themed scenarios
    (depletion / ore-full / ingot-full / starvation), each with its own baseline?

--- a/technical-design/testing.md
+++ b/technical-design/testing.md
@@ -60,6 +60,8 @@ Every test class carries exactly one xUnit trait: `[Trait("Category", "Unit")]` 
 
 New test classes MUST be tagged — an untagged class silently runs in neither filtered lane.
 
+The out-of-solution `Voidforge.SoakTests` project is the sole exception to the Unit/Integration rule: its `TwoUserEconomySoakTests` is tagged `[Trait("Category", "Soak")]` (see the Soak lane below).
+
 ### Soak lane (`src/Voidforge.SoakTests/`, out of the solution)
 
 The live soak-run verifier (design: `technical-design/research/verifier-live-soak-run.md`) lives in a

--- a/technical-design/testing.md
+++ b/technical-design/testing.md
@@ -38,6 +38,7 @@ This avoids booting the app per test class (Marten schema migration is slow).
 Since #62, API-driving helpers are shared extension methods on `IAlbaHost` — do not re-declare them privately in test classes. Add missing helpers to the shared layer instead.
 
 - `Support/IntegrationApiExtensions.cs` — register/get/build/assemble/launch/poll helpers. All assert success (200) unless the name says otherwise (`PostForStatus`); polling helpers return the last-seen state on timeout so the caller's assertion reports the failure. `CompleteArrivalWithRetry` / `LaunchAndArriveInstantly` invoke `CompleteFleetArrivalHandler` directly with a bounded `ConcurrencyException` retry — always drive handler-invoked arrivals through these, never a bare `Handle(...)` call, because a direct call races the real durable scheduler on the same Fleet stream and bypasses Program.cs's #39 retry ladder.
+- **The universal "no 5xx" tripwire.** Every asserting helper runs through `Send`, which enforces the product invariant *a caller must never receive a 500*: any request that comes back 5xx (except the modeled **503**, returned for `NoUncolonizedPlanets`) throws **`ServerErrorException`** — carrying the method, URL, and body — instead of `StatusCodeShouldBe`. Nothing in the suite (or the soak driver) catches it, so a server error always fails the test loudly, wherever it happens (atomic call, deep inside a composite like `BuildRosterShips`, or a GET poll). Modeled non-200s (403/409/503) throw the **catchable** `UnexpectedStatusException`, so contention-tolerant callers can `catch` those without ever masking a 500. Negative tests that need to inspect a raw code use `PostForStatus` / `CancelForStatus` (raw int, no tripwire).
 - `Support/TestTimeouts.cs` — the suite's named poll cadence and deadlines (`PollInterval`, `Completion`, `StockRecovery`, `QueueDrain`, `Arrival`, `FullLoopArrival`). Use these instead of inline `TimeSpan` literals; they time out real HTTP polling and are unrelated to the app's injected `TimeProvider`.
 
 Usage shape (the class keeps its `[Collection]` + `AppFixture` wiring):
@@ -58,6 +59,21 @@ Every test class carries exactly one xUnit trait: `[Trait("Category", "Unit")]` 
 - **Full lane + coverage:** the CI `test` job runs the whole suite unfiltered with `--collect:"XPlat Code Coverage"`; the 70% line gate (`src/coverlet.runsettings`) is enforced only on this complete run.
 
 New test classes MUST be tagged — an untagged class silently runs in neither filtered lane.
+
+### Soak lane (`src/Voidforge.SoakTests/`, out of the solution)
+
+The live soak-run verifier (design: `technical-design/research/verifier-live-soak-run.md`) lives in a
+**separate `Voidforge.SoakTests` project that is deliberately NOT in `src/Voidforge.slnx`**, so it is
+invisible to `dotnet test src/Voidforge.slnx`, the CI `test`/`unit` jobs, and the Stop-hook. It boots
+the real host against an **isolated, auto-created `voidforge_soak_test` DB** (separate from the shared
+`voidforge_test`, so it never collides with a hook- or CI-triggered run), drives two contending users
+over real HTTP for a bounded window while the real Wolverine scheduler fires completions, then asserts
+Tier-1 invariants. Run it explicitly:
+
+```bash
+SOAK_WINDOW_SECONDS=120 dotnet test src/Voidforge.SoakTests/Voidforge.SoakTests.csproj   # skeleton smoke
+SOAK_WINDOW_SECONDS=300 dotnet test src/Voidforge.SoakTests/Voidforge.SoakTests.csproj   # reaches the depletion cascade
+```
 
 ## Log Level Under Test
 


### PR DESCRIPTION
## What & why

First increment of the **live soak-run verifier** (design: `technical-design/research/verifier-live-soak-run.md`) — the harness that exercises the real scheduler, real wall-clock, and real optimistic concurrency *simultaneously* on the real binary, which no existing test does (the deterministic cascade tests freeze exactly those variables).

Plus a shared-SDK hardening that came out of building it: a **universal "no 5xx" tripwire** enforcing the product invariant *a caller must never receive a 500*.

## Soak verifier (v1 — Tier 1 walking skeleton)

New standalone `src/Voidforge.SoakTests/` project, **deliberately out of `Voidforge.slnx`** so no CI lane or Stop-hook runs it, against an isolated auto-created `voidforge_soak_test` DB.

Boot real host → drive two contending users over real HTTP for a bounded window (`SOAK_WINDOW_SECONDS`, default 120) → **aggregate-quiesce + settle-cap** drain (no dependency on Wolverine's internal envelope schema) → Marten snapshot → assert **I1–I11**.

**Scenario:** Player A grows its economy (2nd Drill → depletion), colonizes a second planet in another system, then runs a real Transport **supply line home → its own colony** (same-owner destination). Player B colonizes + recalls mid-transit.

> Note: the design doc's original A→B transport lifeline is **infeasible** — `FleetEndpoints.ValidateMissionPrecondition` 403s a Transport to a foreign destination (own-planets-only). The scenario is reshaped to the within-player supply line; the doc is updated with the finding.

## Universal no-5xx tripwire (shared SDK)

Every asserting helper now runs through a single `Send` primitive:
- 5xx (except the modeled **503**) → **`ServerErrorException`** (method + URL + body), never caught by the harness or soak driver → a server error always fails the test, wherever it happens.
- Modeled non-200s (403/409/503) → catchable **`UnexpectedStatusException`** → contention-tolerant callers catch those without ever masking a 500.
- `PostForStatus` / `CancelForStatus` keep raw-int behavior for negative tests.

This is a **suite-wide** guarantee now, not soak-only.

## Testing

| Check | Result |
|---|---|
| `Category=Integration` lane (after SDK change) | **142 passed, 0 failed** — no regression |
| Tests depending on old exception type | **none** |
| Soak (90s / 120s / 300s) | all **11 Tier-1 PASS**; 300s drives a deposit to 0 (I1/I11 hold), absorbs 12–18 `23505` concurrency collisions, zero dead letters |
| Build + `dotnet format` (solution + soak) | clean |

Run the soak manually:
```bash
SOAK_WINDOW_SECONDS=300 dotnet test src/Voidforge.SoakTests/Voidforge.SoakTests.csproj
```

## Deferred (follow-ups)

Tier 3 structural outcomes, Tier 2 tolerance baselines + blessing, envelope-based drain, CI gating, multi-theme matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_012ygqYrnZVCmKy7dPJQUK6d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an independently runnable soak-test suite for concurrent two-player economic activity over real HTTP and scheduled operations.
  * Added authoritative world-state snapshots, invariant validation, scheduler draining, result recording, and console reporting.
  * Added configurable timing, database, world-generation, balance, and logging settings.

* **Bug Fixes**
  * Test API helpers now consistently detect unexpected server errors and provide diagnostic response details.

* **Documentation**
  * Documented soak-test execution, validation coverage, configuration, scheduler behavior, and API error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->