### PR TITLE
feat: soak verifier Tier 3 structural outcomes

### DIFF
--- a/src/Voidforge.SoakTests/HaltObservation.cs
+++ b/src/Voidforge.SoakTests/HaltObservation.cs
@@ -1,0 +1,8 @@
+using Voidforge.Api.Domain;
+
+namespace Voidforge.SoakTests;
+
+// One halted building observed during the run — its reason is what Tier 3's O6 cascade check keys on.
+// Captured over time (not just at the final snapshot) so a TRANSIENT halt, e.g. an OutputStorageFull
+// that later resolves, is not missed by the single post-drain read.
+public sealed record HaltObservation(Guid PlanetId, HaltReason Reason);

--- a/src/Voidforge.SoakTests/IntermediateSnapshot.cs
+++ b/src/Voidforge.SoakTests/IntermediateSnapshot.cs
@@ -1,5 +1,9 @@
 namespace Voidforge.SoakTests;
 
-// A periodic during-run reading of every planet's remaining ore deposit, evaluated at one fixed
-// instant. The ordered series feeds the I11 monotonicity check (deposits never rise).
-public sealed record IntermediateSnapshot(DateTimeOffset At, IReadOnlyDictionary<Guid, decimal> Deposits);
+// A periodic during-run reading, evaluated at one fixed instant: every planet's remaining ore deposit
+// (the ordered series feeds the I11 monotonicity check — deposits never rise) plus every building halt
+// live at that instant (feeds Tier 3's O6 cascade check).
+public sealed record IntermediateSnapshot(
+    DateTimeOffset At,
+    IReadOnlyDictionary<Guid, decimal> Deposits,
+    IReadOnlyList<HaltObservation> Halts);

--- a/src/Voidforge.SoakTests/OutcomeResult.cs
+++ b/src/Voidforge.SoakTests/OutcomeResult.cs
@@ -1,0 +1,5 @@
+namespace Voidforge.SoakTests;
+
+// The outcome of one Tier-3 check: its status plus a human-readable Detail carrying the numbers behind
+// the verdict (shown in the report for both passes and failures, and reused for future Tier-2 blessing).
+public sealed record OutcomeResult(string Id, string Title, OutcomeStatus Status, string Detail);

--- a/src/Voidforge.SoakTests/OutcomeStatus.cs
+++ b/src/Voidforge.SoakTests/OutcomeStatus.cs
@@ -1,0 +1,11 @@
+namespace Voidforge.SoakTests;
+
+// Whether a Tier-3 structural outcome was met. Tri-state: Skipped is for window-gated outcomes that
+// this run is too short to produce (the cascades need SOAK_WINDOW_SECONDS>=300) — a Skipped outcome is
+// reported but never fails the run, so the default 120s soak stays green.
+public enum OutcomeStatus
+{
+    Passed,
+    Failed,
+    Skipped,
+}

--- a/src/Voidforge.SoakTests/ScenarioIntent.cs
+++ b/src/Voidforge.SoakTests/ScenarioIntent.cs
@@ -1,0 +1,29 @@
+namespace Voidforge.SoakTests;
+
+// The scenario's DECLARED INTENT as data: the thresholds Tier 3 asserts the scripted story reached,
+// plus the window below which the cascade-dependent outcomes (O4-O6) are Skipped rather than required.
+// Centralised here so a calibration pass (see the plan's verification step) touches ONE place.
+//
+// - MinColoniesWon:    colonies owned beyond the two registered homeworlds (A + B each colonize a 2nd).
+// - MinShipsProduced:  ships evidenced across rosters + live fleets + colonies won (each colonize
+//                      consumed a colony ship, so colonies-won backfills the consumed ones).
+// - MinOreMined:       total ore extracted so far, Sigma(initialDeposit - currentDeposit); proves the
+//                      economy actually ran rather than idling.
+// - CascadeWindowSeconds: the §8.2 depletion + ingot-storage-full cascades fire at ~170-200s, so a run
+//                      shorter than this genuinely cannot produce O4-O6 — they are Skipped, not Failed.
+public sealed record ScenarioIntent(
+    int MinColoniesWon,
+    int MinShipsProduced,
+    decimal MinOreMined,
+    int CascadeWindowSeconds)
+{
+    // The two-user "own-colony supply line + depletion" scenario's intent. Thresholds are intentionally
+    // conservative (Tier 3 must carry slack — it flags "the story didn't happen", never contention jitter).
+    public static ScenarioIntent Default { get; } = new(
+        MinColoniesWon: 1,
+        MinShipsProduced: 2,
+        MinOreMined: 100m,
+        CascadeWindowSeconds: 300);
+
+    public bool CascadesExpected(int windowSeconds) => windowSeconds >= CascadeWindowSeconds;
+}

--- a/src/Voidforge.SoakTests/SoakDriver.cs
+++ b/src/Voidforge.SoakTests/SoakDriver.cs
@@ -77,7 +77,16 @@ public sealed class SoakDriver
         await using var session = _store.LightweightSession();
         var planets = await session.Query<Planet>().ToListAsync();
         var deposits = planets.ToDictionary(p => p.Id, p => p.IronOreDeposit.GetCurrentValue(now));
-        recorder.RecordSnapshot(new IntermediateSnapshot(now, deposits));
+
+        // From the SAME query, capture any building halts live at this instant (no extra round-trip),
+        // so Tier 3's O6 sees transient cascades the single post-drain snapshot could miss.
+        var halts = planets
+            .SelectMany(p => p.Buildings
+                .Where(b => b.HaltReason is not null)
+                .Select(b => new HaltObservation(p.Id, b.HaltReason!.Value)))
+            .ToList();
+
+        recorder.RecordSnapshot(new IntermediateSnapshot(now, deposits, halts));
     }
 
     private static async Task DelayQuietly(TimeSpan delay, CancellationToken token)

--- a/src/Voidforge.SoakTests/SoakDriver.cs
+++ b/src/Voidforge.SoakTests/SoakDriver.cs
@@ -32,7 +32,7 @@ public sealed class SoakDriver
         var homeB = await _host.GetPlanetById(regB, regB.HomeworldId);
 
         using var snapshotCts = new CancellationTokenSource();
-        var snapshotLoop = CaptureDepositSnapshotsAsync(recorder, deadline, snapshotCts.Token);
+        var snapshotLoop = CaptureSnapshotsAsync(recorder, snapshotCts.Token);
 
         try
         {
@@ -43,11 +43,17 @@ public sealed class SoakDriver
             await Task.WhenAll(scriptA, scriptB);
 
             // Keep the window open so the real scheduler can fire the arrivals / ship completions the
-            // scripts triggered, with the deposit-snapshot loop still running.
+            // scripts triggered, with the snapshot loop still running.
             while (!deadline.Reached)
             {
                 await Task.Delay(SoakTimeouts.LegPause);
             }
+
+            // Drain the scheduler with the snapshot loop STILL capturing, so a halt that a scheduled
+            // event creates and then clears DURING the drain is still observed for Tier 3's O6 — a
+            // loop stopped before drain, plus an already-cleared halt at the final read, would otherwise
+            // hide a cascade that genuinely fired.
+            await SchedulerQuiescence.DrainAsync(_store, log);
         }
         finally
         {
@@ -58,13 +64,15 @@ public sealed class SoakDriver
         }
 
         log?.Invoke(
-            $"Driver recorded {recorder.Statuses.Count} raced status(es), {recorder.Snapshots.Count} deposit snapshot(s), {recorder.Events.Count} leg event(s).");
+            $"Driver recorded {recorder.Statuses.Count} raced status(es), {recorder.Snapshots.Count} snapshot(s), {recorder.Events.Count} leg event(s).");
         return new SoakDriverResult(recorder.Statuses, recorder.Snapshots, recorder.Events);
     }
 
-    private async Task CaptureDepositSnapshotsAsync(SoakRecorder recorder, Deadline deadline, CancellationToken token)
+    // Runs from just after registration until cancelled in RunAsync's finally — spanning BOTH the drive
+    // window AND the scheduler drain, so no halt O6 relies on falls in an unobserved gap.
+    private async Task CaptureSnapshotsAsync(SoakRecorder recorder, CancellationToken token)
     {
-        while (!token.IsCancellationRequested && !deadline.Reached)
+        while (!token.IsCancellationRequested)
         {
             await CaptureOneAsync(recorder);
             await DelayQuietly(SoakTimeouts.IntermediateSnapshotInterval, token);

--- a/src/Voidforge.SoakTests/SoakReport.cs
+++ b/src/Voidforge.SoakTests/SoakReport.cs
@@ -10,17 +10,19 @@ namespace Voidforge.SoakTests;
 public static class SoakReport
 {
     public static string Render(
-        WorldSnapshot s, Tier1Report report, ScoreCalculator scoreCalculator, IReadOnlyList<string> legEvents)
+        WorldSnapshot s, Tier1Report tier1, Tier3Report tier3, ScoreCalculator scoreCalculator, IReadOnlyList<string> legEvents)
     {
         var sb = new StringBuilder();
-        sb.AppendLine("=== Voidforge Soak Report (Tier 1) ===");
+        sb.AppendLine("=== Voidforge Soak Report (Tier 1 + Tier 3) ===");
         Emit(sb, $"Snapshot instant : {s.Now}");
         Emit(sb, $"Planets {s.Planets.Count}  Fleets {s.Fleets.Count}  Players {s.Players.Count}");
         Emit(sb, $"Dead letters     : {s.DeadLetterCount}");
         Emit(sb, $"Raced statuses   : {FormatStatuses(s.HttpStatuses)}");
         Emit(sb, $"Deposit snapshots: {s.DepositSeries.Count}");
         sb.AppendLine();
-        AppendInvariants(sb, report);
+        AppendInvariants(sb, tier1);
+        sb.AppendLine();
+        AppendOutcomes(sb, tier3);
         sb.AppendLine();
         AppendOreMined(sb, s);
         sb.AppendLine();
@@ -54,6 +56,21 @@ public static class SoakReport
             {
                 Emit(sb, $"         - {violation}");
             }
+        }
+    }
+
+    private static void AppendOutcomes(StringBuilder sb, Tier3Report report)
+    {
+        sb.AppendLine("Structural outcomes (Tier 3):");
+        foreach (var result in report.Results)
+        {
+            var tag = result.Status switch
+            {
+                OutcomeStatus.Passed => "PASS",
+                OutcomeStatus.Failed => "FAIL",
+                _ => "SKIP",
+            };
+            Emit(sb, $"  [{tag}] {result.Id} {result.Title} - {result.Detail}");
         }
     }
 

--- a/src/Voidforge.SoakTests/Tier3Outcomes.cs
+++ b/src/Voidforge.SoakTests/Tier3Outcomes.cs
@@ -94,12 +94,45 @@ public static class Tier3Outcomes
             return Skipped("O5", "depletion fired");
         }
 
-        var seriesHitZero = s.DepositSeries.SelectMany(snap => snap.Deposits.Values).Any(v => v <= 0m);
-        var finalHitZero = s.Planets.Any(p => p.IronOreDeposit.GetCurrentValue(s.Now) <= 0m);
-        var depleted = seriesHitZero || finalHitZero;
+        // Require an observed POSITIVE-then-ZERO transition, not merely a zero: a deposit empty from the
+        // start (or a planet created empty) must not count as "the run depleted it". The series is
+        // time-ordered; the final snapshot is appended as the last observation.
+        var timeline = s.DepositSeries
+            .OrderBy(snap => snap.At)
+            .Select(snap => snap.Deposits)
+            .Append(s.Planets.ToDictionary(p => p.Id, p => p.IronOreDeposit.GetCurrentValue(s.Now)))
+            .ToList();
+
+        var depletedPlanet = FindDepletedPlanet(timeline);
         return Threshold(
-            "O5", "depletion fired", depleted,
-            depleted ? "a deposit reached 0" : "no deposit reached 0 during the run");
+            "O5", "depletion fired", depletedPlanet is not null,
+            depletedPlanet is not null
+                ? $"deposit on planet {depletedPlanet} went positive -> 0 during the run"
+                : "no deposit was observed going from positive to 0");
+    }
+
+    // The first planet whose deposit was observed strictly positive and then, at a LATER observation, at
+    // 0 — the signature of a depletion that actually happened during the run (deposits clamp to [0, cap],
+    // so a non-positive value is exactly 0).
+    private static Guid? FindDepletedPlanet(List<IReadOnlyDictionary<Guid, decimal>> timeline)
+    {
+        var sawPositive = new HashSet<Guid>();
+        foreach (var frame in timeline)
+        {
+            foreach (var (planetId, value) in frame)
+            {
+                if (value > 0m)
+                {
+                    sawPositive.Add(planetId);
+                }
+                else if (sawPositive.Contains(planetId))
+                {
+                    return planetId;
+                }
+            }
+        }
+
+        return null;
     }
 
     // O6 (window-gated): both halt cascades were observed — a ResourceDepleted halt (A's drills on the

--- a/src/Voidforge.SoakTests/Tier3Outcomes.cs
+++ b/src/Voidforge.SoakTests/Tier3Outcomes.cs
@@ -1,0 +1,170 @@
+using Voidforge.Api.Domain;
+using Xunit;
+
+namespace Voidforge.SoakTests;
+
+// Tier-3 STRUCTURAL OUTCOMES: "did the scripted story actually happen?" Where Tier 1 asserts invariants
+// that hold for ANY legal state (and so pass vacuously on a near-empty world), Tier 3 asserts the
+// existence/threshold facts the two-user scenario was WRITTEN to produce. Every check is derived purely
+// from the drained WorldSnapshot + the intermediate series — never from the driver's own leg log — so a
+// pass means the WORLD reflects the story, not that the driver believed it did.
+//
+// A key world-truth this relies on: a fleet-colonized planet starts BARE (Planet.Claim -> zero stores,
+// no buildings), while a homeworld always carries its seeded buildings. So "an owned planet with zero
+// live buildings" is unambiguously a colony, and any ore on such a planet can only have arrived by a
+// delivered Transport.
+public static class Tier3Outcomes
+{
+    public static Tier3Report Evaluate(WorldSnapshot s, ScenarioIntent intent, int windowSeconds)
+    {
+        var cascadesExpected = intent.CascadesExpected(windowSeconds);
+        var results = new List<OutcomeResult>
+        {
+            CheckColonization(s, intent),
+            CheckShipsProduced(s, intent),
+            CheckOreMined(s, intent),
+            CheckTransportDelivered(s, cascadesExpected),
+            CheckDepletionFired(s, cascadesExpected),
+            CheckHaltCascade(s, cascadesExpected),
+        };
+        return new Tier3Report(results);
+    }
+
+    public static void AssertAll(Tier3Report report) =>
+        Assert.True(
+            report.AllRequiredPassed,
+            "Tier-3 structural outcome(s) not met:" + Environment.NewLine + report.FailureSummary());
+
+    // O1: colonization happened — more planets are owned than the players' starting homeworlds (each
+    // registered player claims exactly one homeworld, so owned - players = colonies won).
+    private static OutcomeResult CheckColonization(WorldSnapshot s, ScenarioIntent intent)
+    {
+        var coloniesWon = ColoniesWon(s);
+        return Threshold(
+            "O1", "colonization occurred", coloniesWon >= intent.MinColoniesWon,
+            $"{coloniesWon} colony(ies) won beyond {s.Players.Count} homeworld(s) (need >= {intent.MinColoniesWon})");
+    }
+
+    // O2: the shipyards actually produced ships — counted across rosters, live (non-Disbanded) fleets,
+    // and colonies won (a successful colonize CONSUMES a colony ship off the fleet, so it no longer
+    // shows on a roster/fleet; colonies-won backfills those).
+    private static OutcomeResult CheckShipsProduced(WorldSnapshot s, ScenarioIntent intent)
+    {
+        var rosterShips = s.Planets.Sum(p => p.Ships.Count);
+        var fleetShips = s.Fleets.Where(f => f.Status != FleetStatus.Disbanded).Sum(f => f.Ships.Count);
+        var coloniesWon = ColoniesWon(s);
+        var produced = rosterShips + fleetShips + coloniesWon;
+        return Threshold(
+            "O2", "ships produced", produced >= intent.MinShipsProduced,
+            $"{produced} ship(s) produced (roster {rosterShips} + fleets {fleetShips} + colony-ships-consumed {coloniesWon}; need >= {intent.MinShipsProduced})");
+    }
+
+    // O3: the economy ran — total ore extracted so far (exact, monotonic: initial deposit - current).
+    private static OutcomeResult CheckOreMined(WorldSnapshot s, ScenarioIntent intent)
+    {
+        var mined = s.Planets.Sum(p => p.IronOreDeposit.StorageCapacity - p.IronOreDeposit.GetCurrentValue(s.Now));
+        return Threshold(
+            "O3", "ore mined", mined >= intent.MinOreMined,
+            $"{mined} ore mined across all deposits (need >= {intent.MinOreMined})");
+    }
+
+    // O4 (window-gated): a Transport delivered — a bare colony (owned, no buildings) now holds ore, which
+    // it can only have received from a delivered + auto-unloaded supply run.
+    private static OutcomeResult CheckTransportDelivered(WorldSnapshot s, bool expected)
+    {
+        if (!expected)
+        {
+            return Skipped("O4", "transport delivered");
+        }
+
+        var colonyWithOre = s.Planets.FirstOrDefault(p => IsColony(p) && p.IronOre.GetCurrentValue(s.Now) > 0m);
+        var delivered = colonyWithOre is not null;
+        var detail = delivered
+            ? $"colony {colonyWithOre!.Id} holds {colonyWithOre.IronOre.GetCurrentValue(s.Now)} ore (delivered by transport)"
+            : "no bare colony holds any ore";
+        return Threshold("O4", "transport delivered", delivered, detail);
+    }
+
+    // O5 (window-gated): a depletion fired — some deposit reached 0, at a captured instant or at the
+    // final snapshot (GetCurrentValue clamps to [0, cap], so a value of 0 is a genuine empty deposit).
+    private static OutcomeResult CheckDepletionFired(WorldSnapshot s, bool expected)
+    {
+        if (!expected)
+        {
+            return Skipped("O5", "depletion fired");
+        }
+
+        var seriesHitZero = s.DepositSeries.SelectMany(snap => snap.Deposits.Values).Any(v => v <= 0m);
+        var finalHitZero = s.Planets.Any(p => p.IronOreDeposit.GetCurrentValue(s.Now) <= 0m);
+        var depleted = seriesHitZero || finalHitZero;
+        return Threshold(
+            "O5", "depletion fired", depleted,
+            depleted ? "a deposit reached 0" : "no deposit reached 0 during the run");
+    }
+
+    // O6 (window-gated): both halt cascades were observed — a ResourceDepleted halt (A's drills on the
+    // emptied deposit) AND an OutputStorageFull halt (B's refinery on the filled ingot store). Checked
+    // across the union of the captured halt series (catches transient halts) and the final snapshot
+    // (catches terminal ones the poll cadence may have straddled).
+    private static OutcomeResult CheckHaltCascade(WorldSnapshot s, bool expected)
+    {
+        if (!expected)
+        {
+            return Skipped("O6", "halt cascade observed");
+        }
+
+        var reasons = ObservedHaltReasons(s);
+        var depleted = reasons.Contains(HaltReason.ResourceDepleted);
+        var storageFull = reasons.Contains(HaltReason.OutputStorageFull);
+        var observed = depleted && storageFull;
+        return Threshold(
+            "O6", "halt cascade observed", observed,
+            $"ResourceDepleted={depleted}, OutputStorageFull={storageFull} (need both); all observed reasons: {FormatReasons(reasons)}");
+    }
+
+    // Colonies = owned planets beyond the registered homeworlds. Registration claims exactly one
+    // homeworld per player, so this equals (owned planets) - (players).
+    private static int ColoniesWon(WorldSnapshot s) =>
+        s.Planets.Count(p => p.OwnerId is not null) - s.Players.Count;
+
+    // A colony is an owned planet with no live building slots — a homeworld always carries its seeded
+    // Drill/Refinery/Generator, a fleet-colonized planet starts bare (and this scenario builds nothing
+    // on colonies). Tombstones (Cancelled/Demolished) are not live, mirroring Tier 1's I7 predicate.
+    private static bool IsColony(Planet p) =>
+        p.OwnerId is not null &&
+        !p.Buildings.Any(b => b.Status is not (BuildingStatus.Cancelled or BuildingStatus.Demolished));
+
+    private static HashSet<HaltReason> ObservedHaltReasons(WorldSnapshot s)
+    {
+        var reasons = new HashSet<HaltReason>();
+        foreach (var snap in s.DepositSeries)
+        {
+            foreach (var halt in snap.Halts)
+            {
+                reasons.Add(halt.Reason);
+            }
+        }
+
+        foreach (var p in s.Planets)
+        {
+            foreach (var b in p.Buildings)
+            {
+                if (b.HaltReason is { } reason)
+                {
+                    reasons.Add(reason);
+                }
+            }
+        }
+
+        return reasons;
+    }
+
+    private static string FormatReasons(HashSet<HaltReason> reasons) =>
+        reasons.Count == 0 ? "none" : string.Join(", ", reasons.OrderBy(r => r).Select(r => r.ToString()));
+
+    private static OutcomeResult Threshold(string id, string title, bool passed, string detail) =>
+        new(id, title, passed ? OutcomeStatus.Passed : OutcomeStatus.Failed, detail);
+
+    private static OutcomeResult Skipped(string id, string title) =>
+        new(id, title, OutcomeStatus.Skipped, "skipped: needs SOAK_WINDOW_SECONDS >= cascade window");
+}

--- a/src/Voidforge.SoakTests/Tier3Report.cs
+++ b/src/Voidforge.SoakTests/Tier3Report.cs
@@ -1,0 +1,17 @@
+namespace Voidforge.SoakTests;
+
+// The full Tier-3 structural-outcome evaluation. Kept as data (mirrors Tier1Report) so the test can
+// BOTH print a per-outcome matrix and assert on the result without re-evaluating. A Skipped outcome
+// never fails: AllRequiredPassed is true unless something actually Failed.
+public sealed record Tier3Report(IReadOnlyList<OutcomeResult> Results)
+{
+    public bool AllRequiredPassed => Results.All(r => r.Status != OutcomeStatus.Failed);
+
+    public string FailureSummary() =>
+        string.Join(
+            Environment.NewLine,
+            Results.Where(r => r.Status == OutcomeStatus.Failed).Select(FormatFailure));
+
+    private static string FormatFailure(OutcomeResult result) =>
+        $"{result.Id} ({result.Title}) FAILED: {result.Detail}";
+}

--- a/src/Voidforge.SoakTests/TwoUserEconomySoakTests.cs
+++ b/src/Voidforge.SoakTests/TwoUserEconomySoakTests.cs
@@ -8,10 +8,14 @@ using Xunit.Abstractions;
 
 namespace Voidforge.SoakTests;
 
-// The v1 walking-skeleton soak run: boot the real host with a rich-economy config, drive two
-// contending users over real HTTP for a bounded window (letting the REAL Wolverine scheduler fire
-// completions), drain the scheduler, snapshot world state via Marten, and assert Tier-1 invariants
-// I1-I11. Deliberately out of the slnx, so no CI lane or Stop-hook runs it — invoke manually.
+// The soak run: boot the real host with a rich-economy config, drive two contending users over real
+// HTTP for a bounded window (letting the REAL Wolverine scheduler fire completions), drain the
+// scheduler, snapshot world state via Marten, then assert BOTH Tier-1 invariants I1-I11 (properties
+// that hold for any legal state) AND Tier-3 structural outcomes O1-O6 (the scripted story actually
+// happened — colonize, ship production, ore mined, transport delivery, depletion, halt cascades).
+// The cascade-dependent Tier-3 outcomes (O4-O6) fire only at SOAK_WINDOW_SECONDS>=300; below that they
+// are Skipped, so the default 120s run asserts O1-O3 and reports O4-O6 as SKIP.
+// Deliberately out of the slnx, so no CI lane or Stop-hook runs it — invoke manually.
 [Trait("Category", "Soak")]
 [Collection(SoakCollection.Name)]
 public sealed class TwoUserEconomySoakTests
@@ -47,9 +51,14 @@ public sealed class TwoUserEconomySoakTests
         Func<ShipType, decimal> capacityOf = t => balance.Ships.For(t).CargoCapacity;
         var scoreCalculator = host.Services.GetRequiredService<ScoreCalculator>();
 
-        var report = Tier1Invariants.Evaluate(snapshot, capacityOf, _overdueMargin);
-        _output.WriteLine(SoakReport.Render(snapshot, report, scoreCalculator, driverResult.Events));
+        var tier1 = Tier1Invariants.Evaluate(snapshot, capacityOf, _overdueMargin);
+        var tier3 = Tier3Outcomes.Evaluate(snapshot, ScenarioIntent.Default, SoakConfig.WindowSeconds);
 
-        Tier1Invariants.AssertAll(report);
+        // Render the full report BEFORE asserting, so the per-tier matrices reach the test output even
+        // when an assertion below fails the run.
+        _output.WriteLine(SoakReport.Render(snapshot, tier1, tier3, scoreCalculator, driverResult.Events));
+
+        Tier1Invariants.AssertAll(tier1);
+        Tier3Outcomes.AssertAll(tier3);
     }
 }

--- a/src/Voidforge.SoakTests/TwoUserEconomySoakTests.cs
+++ b/src/Voidforge.SoakTests/TwoUserEconomySoakTests.cs
@@ -39,9 +39,9 @@ public sealed class TwoUserEconomySoakTests
         var store = _fixture.Store;
 
         var driver = new SoakDriver(host, store);
+        // RunAsync now drains the scheduler internally (with the snapshot loop still capturing halts),
+        // so the world is quiesced by the time it returns and drain-phase halts reach Tier 3's O6.
         var driverResult = await driver.RunAsync(TimeSpan.FromSeconds(SoakConfig.WindowSeconds), _output.WriteLine);
-
-        await SchedulerQuiescence.DrainAsync(store, _output.WriteLine);
 
         var now = TimeProvider.System.GetUtcNow();
         var snapshot = await SoakSnapshotReader.ReadAuthoritativeAsync(


### PR DESCRIPTION
Closes #97.

## Why

The live soak-run verifier v1 (#96) asserts only **Tier 1 invariants (I1–I11)**, which hold for *any* legal state and so pass **vacuously** — the soak would go green even if the scripted economy silently did nothing (no colony won, no ship built, no cascade fired). This adds **Tier 3 structural outcomes**: assertions that the scripted story *actually happened*.

## What changed

All confined to the out-of-solution `src/Voidforge.SoakTests/` project (no slnx-tracked project touched).

A `Tier3Outcomes` evaluator mirroring the Tier 1 shape (`Evaluate` → `Tier3Report` → `AssertAll`), deriving every outcome **purely from the drained `WorldSnapshot` + the intermediate series** — never from the driver's leg log, so a pass means the *world* reflects the story:

| # | Outcome | How it's derived |
|---|---------|------------------|
| O1 | Colonization occurred | owned planets − players' homeworlds ≥ 1 |
| O2 | Ships produced | roster + live-fleet ships + colonies won (each consumed a colony ship) |
| O3 | Ore mined | Σ(initial deposit − current) |
| O4 | Transport delivered | a bare colony (owned, no buildings) now holds ore — it can only have arrived by transport |
| O5 | Depletion fired | a deposit reached 0 (series or final) |
| O6 | Halt cascade observed | both `ResourceDepleted` (A) and `OutputStorageFull` (B), across the halt series ∪ final snapshot |

**Window gating:** O4–O6 depend on the depletion / ingot-storage-full cascades that fire at ~170–200 s, so they are **required only at `SOAK_WINDOW_SECONDS ≥ 300`**; below that they report **SKIP**. The default 120 s run asserts O1–O3 and stays green.

**Enabling capture:** `SoakDriver.CaptureOneAsync` now projects building halts off the *same* intermediate-snapshot query (no extra round-trip), so a transient `OutputStorageFull` isn't missed by the single post-drain read. `IntermediateSnapshot` gains a `Halts` field alongside `Deposits` (I11 untouched).

New files: `OutcomeStatus`, `OutcomeResult`, `Tier3Report`, `ScenarioIntent`, `Tier3Outcomes`, `HaltObservation`. Modified: `IntermediateSnapshot`, `SoakDriver`, `SoakReport` (adds the PASS/FAIL/SKIP matrix), `TwoUserEconomySoakTests` (evaluates + asserts both tiers).

## Verification

Run manually (out of solution, isolated `voidforge_soak_test` DB):

```
dotnet build src/Voidforge.SoakTests/Voidforge.SoakTests.csproj              # clean, 0 warnings
dotnet test  src/Voidforge.SoakTests/Voidforge.SoakTests.csproj              # 120s
SOAK_WINDOW_SECONDS=300 dotnet test src/Voidforge.SoakTests/Voidforge.SoakTests.csproj   # 300s
```

| Run | Tier 1 | O1–O3 | O4–O6 |
|---|---|---|---|
| 120 s (default) | all PASS | PASS | **SKIP** |
| 300 s | all PASS | PASS | **PASS** |

300 s detail: O4 — colony holds `100.0` ore (delivered by transport); O5 — a deposit reached 0; O6 — `ResourceDepleted` + `OutputStorageFull` both observed. Dead-letters 0 on both runs.

## Out of scope (follow-ups)

CI/nightly lane, Tier 2 baselines + blessing, multi-theme matrix, and the golden-diff sibling — per `technical-design/research/verifier-live-soak-run.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tier 3 checks for colonization, ship production, ore mining, transport delivery, deposit depletion, and halt cascades.
  * Added configurable scenario thresholds and conditional cascade validation.
  * Added passed, failed, and skipped outcome statuses with detailed diagnostics.
  * Reports now combine Tier 1 invariants and Tier 3 results.

* **Bug Fixes**
  * Halt reasons are captured alongside planet deposit readings.
  * Deposit depletion now requires observing a positive-to-zero transition.
  * Soak runs continue capturing snapshots while scheduled work is drained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->