### PR TITLE
feat: soak verifier Tier 2 baselines & blessing (#99)

### DIFF
--- a/src/Voidforge.SoakTests/ScenarioIntent.cs
+++ b/src/Voidforge.SoakTests/ScenarioIntent.cs
@@ -17,6 +17,11 @@ public sealed record ScenarioIntent(
     decimal MinOreMined,
     int CascadeWindowSeconds)
 {
+    // Identifies this scenario theme. Stored in the Tier-2 baseline JSON and emitted by
+    // SoakBaselineEmitter so a blessed baseline is unambiguously tied to the scenario it was blessed for.
+    public const string ScenarioId = "two-user-economy-v1";
+
+
     // The two-user "own-colony supply line + depletion" scenario's intent. Thresholds are intentionally
     // conservative (Tier 3 must carry slack — it flags "the story didn't happen", never contention jitter).
     public static ScenarioIntent Default { get; } = new(

--- a/src/Voidforge.SoakTests/SoakAggregates.cs
+++ b/src/Voidforge.SoakTests/SoakAggregates.cs
@@ -1,0 +1,91 @@
+using Voidforge.Api.Domain;
+using Voidforge.Api.Scoring;
+
+namespace Voidforge.SoakTests;
+
+// The low-jitter run aggregates Tier 2 compares against the blessed baseline, computed from the single
+// authoritative post-drain WorldSnapshot at its fixed Now. This is the CANONICAL home for these formulas
+// for Tier 2. The shipped Tier-3 hard gate still computes the same quantities inline (its versions are
+// entangled with per-check detail strings) — the two MUST stay in sync until a CI net lets Tier 3
+// converge onto this type (see verifier-tier2-handover.md). Per §2 the blessed metrics are counts + the
+// exact monotonic ore total + one score scalar: the run-stable signals, never instantaneous buffer levels.
+public sealed record SoakAggregates(
+    decimal OreMinedTotal,
+    int PlanetsColonized,
+    int ShipsProduced,
+    int HaltReasonsSeen,
+    decimal PlayerScoreMax)
+{
+    public static SoakAggregates Compute(WorldSnapshot s, ScoreCalculator scoreCalculator)
+    {
+        // Exact & monotonic (I11): initial deposit (its StorageCapacity) minus what remains.
+        var oreMinedTotal = s.Planets.Sum(p => p.IronOreDeposit.StorageCapacity - p.IronOreDeposit.GetCurrentValue(s.Now));
+
+        // Registration claims exactly one homeworld per player, so owned planets beyond the player count
+        // are colonies won (mirrors Tier3Outcomes.ColoniesWon).
+        var planetsColonized = s.Planets.Count(p => p.OwnerId is not null) - s.Players.Count;
+
+        // Ships evidenced across rosters + live (non-Disbanded) fleets + colonies won (a colonize consumes
+        // a colony ship off its fleet, so colonies-won backfills the consumed ones) — mirrors O2.
+        var rosterShips = s.Planets.Sum(p => p.Ships.Count);
+        var fleetShips = s.Fleets.Where(f => f.Status != FleetStatus.Disbanded).Sum(f => f.Ships.Count);
+        var shipsProduced = rosterShips + fleetShips + planetsColonized;
+
+        var haltReasonsSeen = ObservedHaltReasons(s).Count;
+
+        // Per-player score via the real ScoreCalculator, all pools evaluated at the single snapshot Now.
+        // DefaultIfEmpty guards the (illegal-in-scenario but defensive) zero-players case so Max never throws.
+        var playerScoreMax = s.Players
+            .Select(player => scoreCalculator.Compute(
+                s.Planets.Where(p => p.OwnerId == player.Id).ToList(),
+                s.Fleets.Where(f => f.OwnerId == player.Id).ToList(),
+                s.Now))
+            .DefaultIfEmpty(0m)
+            .Max();
+
+        return new SoakAggregates(oreMinedTotal, planetsColonized, shipsProduced, haltReasonsSeen, playerScoreMax);
+    }
+
+    // Canonical metric-id -> value map: the SINGLE source of the metric ids, shared by the baseline
+    // comparator (Tier2Baseline) and the emitter (SoakBaselineEmitter) so compared ids and emitted ids can
+    // never drift. Concrete Dictionary built here (CA1859); exposed as read-only at the boundary.
+    public IReadOnlyDictionary<string, decimal> ToMetrics()
+    {
+        var metrics = new Dictionary<string, decimal>(StringComparer.Ordinal)
+        {
+            ["oreMinedTotal"] = OreMinedTotal,
+            ["planetsColonized"] = PlanetsColonized,
+            ["shipsProduced"] = ShipsProduced,
+            ["haltReasonsSeen"] = HaltReasonsSeen,
+            ["playerScoreMax"] = PlayerScoreMax,
+        };
+        return metrics;
+    }
+
+    // Distinct halt reasons observed anywhere during the run: the union of every captured intermediate
+    // snapshot's live halts and the final snapshot's building halt reasons (mirrors Tier3Outcomes).
+    private static HashSet<HaltReason> ObservedHaltReasons(WorldSnapshot s)
+    {
+        var reasons = new HashSet<HaltReason>();
+        foreach (var snap in s.DepositSeries)
+        {
+            foreach (var halt in snap.Halts)
+            {
+                reasons.Add(halt.Reason);
+            }
+        }
+
+        foreach (var p in s.Planets)
+        {
+            foreach (var b in p.Buildings)
+            {
+                if (b.HaltReason is { } reason)
+                {
+                    reasons.Add(reason);
+                }
+            }
+        }
+
+        return reasons;
+    }
+}

--- a/src/Voidforge.SoakTests/SoakBaseline.cs
+++ b/src/Voidforge.SoakTests/SoakBaseline.cs
@@ -1,0 +1,12 @@
+namespace Voidforge.SoakTests;
+
+// The deserialized blessed baseline (baselines/soak-baseline.json). Keyed by ScenarioId + the embedded
+// Config block + WindowSeconds (§3.3): a baseline is only valid for the exact theme and window it was
+// blessed against. Tolerances are named bands ("scorePct", "countAbs", "oreEpsilon") referenced by each
+// metric's Tol. Dictionaries keep the schema open so adding a metric never touches this type.
+public sealed record SoakBaseline(
+    string ScenarioId,
+    int WindowSeconds,
+    IReadOnlyDictionary<string, string> Config,
+    IReadOnlyDictionary<string, decimal> Tolerances,
+    IReadOnlyDictionary<string, SoakBaselineMetric> Expected);

--- a/src/Voidforge.SoakTests/SoakBaseline.cs
+++ b/src/Voidforge.SoakTests/SoakBaseline.cs
@@ -1,12 +1,19 @@
 namespace Voidforge.SoakTests;
 
-// The deserialized blessed baseline (baselines/soak-baseline.json). Keyed by ScenarioId + the embedded
-// Config block + WindowSeconds (§3.3): a baseline is only valid for the exact theme and window it was
-// blessed against. Tolerances are named bands ("scorePct", "countAbs", "oreEpsilon") referenced by each
-// metric's Tol. Dictionaries keep the schema open so adding a metric never touches this type.
+// The deserialized blessed baseline (baselines/soak-baseline.json). Runtime compatibility is gated on
+// ScenarioId + WindowSeconds: Tier2Baseline.EvaluateOrSkip SKIPs a run whose scenario or window does not
+// match the blessed one (mirroring Tier 3's window-gated O4-O6 SKIP). The embedded Config block travels
+// with the baseline as PROVENANCE — the exact env theme it was blessed against, for human re-bless review
+// (§3.3) — but is deliberately NOT machine-compared: reproducing and diffing the full env theme is an
+// error-prone heavy lift unjustified for an advisory tier, and a config change that should move the numbers
+// already surfaces as a Tier-2 WARN that §3.3 tells the reviewer to re-bless. Reference-typed members are
+// nullable because System.Text.Json assigns null for any omitted JSON property; EvaluateOrSkip treats a
+// missing required block as a SKIP so a malformed/truncated baseline never fails this advisory tier.
+// Tolerances are named bands ("scorePct", "countAbs", "oreEpsilon") referenced by each metric's Tol.
+// Dictionaries keep the schema open so adding a metric never touches this type.
 public sealed record SoakBaseline(
-    string ScenarioId,
+    string? ScenarioId,
     int WindowSeconds,
-    IReadOnlyDictionary<string, string> Config,
-    IReadOnlyDictionary<string, decimal> Tolerances,
-    IReadOnlyDictionary<string, SoakBaselineMetric> Expected);
+    IReadOnlyDictionary<string, string>? Config,
+    IReadOnlyDictionary<string, decimal>? Tolerances,
+    IReadOnlyDictionary<string, SoakBaselineMetric>? Expected);

--- a/src/Voidforge.SoakTests/SoakBaselineEmitter.cs
+++ b/src/Voidforge.SoakTests/SoakBaselineEmitter.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+
+namespace Voidforge.SoakTests;
+
+// Emit mode (SOAK_EMIT_BASELINE=1): after a run computes its SoakAggregates, log ONE compact, grep-able
+// marker line carrying the machine-readable metrics. Feeds the N-run blessing envelope (§6): run the 300s
+// soak 5x, grep the marker, and fold the JSON objects into the baseline. Chosen over a file write so it is
+// immune to dotnet test working-dir / shadow-copy uncertainty — surface it with
+// `dotnet test -l "console;verbosity=detailed"`. System.Text.Json writes numbers culture-invariantly, and
+// the marker line is built by plain concatenation (no interpolation), so no culture surface leaks in.
+public static class SoakBaselineEmitter
+{
+    public const string Marker = "SOAK_BASELINE_EMIT";
+
+    public static void Emit(SoakAggregates aggregates, int windowSeconds, Action<string> log)
+    {
+        var payload = new
+        {
+            scenarioId = ScenarioIntent.ScenarioId,
+            windowSeconds,
+            metrics = aggregates.ToMetrics(),
+        };
+        log(Marker + " " + JsonSerializer.Serialize(payload));
+    }
+}

--- a/src/Voidforge.SoakTests/SoakBaselineMetric.cs
+++ b/src/Voidforge.SoakTests/SoakBaselineMetric.cs
@@ -1,0 +1,7 @@
+namespace Voidforge.SoakTests;
+
+// One blessed metric in the baseline JSON: the expected value, its comparison kind ("exact-ish",
+// "count", "count-min", "scalar") and the named tolerance it references in the baseline's "tolerances"
+// block. Kind stays a string here (the JSON values contain hyphens System.Text.Json cannot map to enum
+// names); Tier2Baseline maps it to Tier2ToleranceKind at compare time.
+public sealed record SoakBaselineMetric(decimal Value, string Kind, string Tol);

--- a/src/Voidforge.SoakTests/SoakBaselineMetric.cs
+++ b/src/Voidforge.SoakTests/SoakBaselineMetric.cs
@@ -3,5 +3,7 @@ namespace Voidforge.SoakTests;
 // One blessed metric in the baseline JSON: the expected value, its comparison kind ("exact-ish",
 // "count", "count-min", "scalar") and the named tolerance it references in the baseline's "tolerances"
 // block. Kind stays a string here (the JSON values contain hyphens System.Text.Json cannot map to enum
-// names); Tier2Baseline maps it to Tier2ToleranceKind at compare time.
-public sealed record SoakBaselineMetric(decimal Value, string Kind, string Tol);
+// names); Tier2Baseline maps it to Tier2ToleranceKind at compare time. Kind/Tol are nullable because
+// System.Text.Json assigns null for an omitted property — Tier2Baseline records such a metric as an
+// Unresolved row rather than throwing, keeping the tier advisory-only.
+public sealed record SoakBaselineMetric(decimal Value, string? Kind, string? Tol);

--- a/src/Voidforge.SoakTests/SoakConfig.cs
+++ b/src/Voidforge.SoakTests/SoakConfig.cs
@@ -24,6 +24,10 @@ public static class SoakConfig
     // The Tier-1 invariants hold at every instant regardless of window, so 120s is fine for the skeleton.
     public static int WindowSeconds => ReadWindowSeconds();
 
+    // Emit mode: when set, the test logs its computed SoakAggregates as one grep-able marker line
+    // (SoakBaselineEmitter) so the N-run blessing envelope can be built from machine-readable output.
+    public static bool EmitBaseline => ReadFlag("SOAK_EMIT_BASELINE");
+
     public static void ApplyEnvironmentOverrides()
     {
         // Set the connection string before AlbaHost.For<Program>() so the host binds it via `__` -> `:`
@@ -75,5 +79,13 @@ public static class SoakConfig
         return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds) && seconds > 0
             ? seconds
             : _defaultWindowSeconds;
+    }
+
+    // A plain on/off env flag: "1" or "true" (case-insensitive) enables it; anything else (unset included)
+    // is off. Deliberately not culture- or number-parsed — it is a switch, not a value.
+    private static bool ReadFlag(string name)
+    {
+        var raw = Environment.GetEnvironmentVariable(name);
+        return raw is "1" || string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Voidforge.SoakTests/SoakReport.cs
+++ b/src/Voidforge.SoakTests/SoakReport.cs
@@ -89,6 +89,14 @@ public static class SoakReport
 
         foreach (var r in report.Results)
         {
+            // An Unresolved row is a baseline/aggregate gap (missing metric, unknown kind, undefined
+            // tolerance) — render the reason, not a bogus observed-vs-expected comparison.
+            if (r.Status == Tier2Status.Unresolved)
+            {
+                Emit(sb, $"  [UNRESOLVED] {r.Id}: {r.Reason}");
+                continue;
+            }
+
             var tag = r.Status == Tier2Status.WithinBand ? "BAND" : "WARN";
             Emit(sb, $"  [{tag}] {r.Id}: observed {r.Observed} vs expected {r.Expected} {FormatBand(r)}");
         }

--- a/src/Voidforge.SoakTests/SoakReport.cs
+++ b/src/Voidforge.SoakTests/SoakReport.cs
@@ -10,10 +10,10 @@ namespace Voidforge.SoakTests;
 public static class SoakReport
 {
     public static string Render(
-        WorldSnapshot s, Tier1Report tier1, Tier3Report tier3, ScoreCalculator scoreCalculator, IReadOnlyList<string> legEvents)
+        WorldSnapshot s, Tier1Report tier1, Tier2Report tier2, Tier3Report tier3, ScoreCalculator scoreCalculator, IReadOnlyList<string> legEvents)
     {
         var sb = new StringBuilder();
-        sb.AppendLine("=== Voidforge Soak Report (Tier 1 + Tier 3) ===");
+        sb.AppendLine("=== Voidforge Soak Report (Tier 1 + Tier 2 + Tier 3) ===");
         Emit(sb, $"Snapshot instant : {s.Now}");
         Emit(sb, $"Planets {s.Planets.Count}  Fleets {s.Fleets.Count}  Players {s.Players.Count}");
         Emit(sb, $"Dead letters     : {s.DeadLetterCount}");
@@ -23,6 +23,8 @@ public static class SoakReport
         AppendInvariants(sb, tier1);
         sb.AppendLine();
         AppendOutcomes(sb, tier3);
+        sb.AppendLine();
+        AppendBaseline(sb, tier2);
         sb.AppendLine();
         AppendOreMined(sb, s);
         sb.AppendLine();
@@ -73,6 +75,32 @@ public static class SoakReport
             Emit(sb, $"  [{tag}] {result.Id} {result.Title} - {result.Detail}");
         }
     }
+
+    // Tier-2 baseline matrix: [BAND]/[WARN] per metric, or a single [SKIP] line when no baseline is
+    // committed / the window does not match. Advisory only — a [WARN] never fails the run.
+    private static void AppendBaseline(StringBuilder sb, Tier2Report report)
+    {
+        sb.AppendLine("Baseline comparison (Tier 2, advisory):");
+        if (report.Skipped)
+        {
+            Emit(sb, $"  [SKIP] {report.SkipReason}");
+            return;
+        }
+
+        foreach (var r in report.Results)
+        {
+            var tag = r.Status == Tier2Status.WithinBand ? "BAND" : "WARN";
+            Emit(sb, $"  [{tag}] {r.Id}: observed {r.Observed} vs expected {r.Expected} {FormatBand(r)}");
+        }
+    }
+
+    private static string FormatBand(Tier2Result r) =>
+        r.Kind switch
+        {
+            Tier2ToleranceKind.CountMin => FormattableString.Invariant($">={r.Expected}"),
+            Tier2ToleranceKind.Scalar => FormattableString.Invariant($"±{r.Tolerance}%"),
+            _ => FormattableString.Invariant($"±{r.Tolerance}"),
+        };
 
     private static void AppendOreMined(StringBuilder sb, WorldSnapshot s)
     {

--- a/src/Voidforge.SoakTests/Tier2Baseline.cs
+++ b/src/Voidforge.SoakTests/Tier2Baseline.cs
@@ -26,7 +26,12 @@ public static class Tier2Baseline
         "playerScoreMax",
     ];
 
-    public static Tier2Report EvaluateOrSkip(SoakAggregates actual, int windowSeconds)
+    // Loads the committed baseline and compares against it, or SKIPs. Every load failure — file absent,
+    // unreadable, malformed/truncated JSON, a null deserialization, or a missing required block — becomes a
+    // SKIP, never a throw: Tier 2 is advisory (§2/§7.3), so a bad baseline must not fail the xUnit run
+    // before Tier 1/Tier 3 render. Compatibility is gated on ScenarioId + WindowSeconds (the Config block is
+    // provenance only — see SoakBaseline); a mismatch on either SKIPs, mirroring Tier 3's window-gated SKIP.
+    public static Tier2Report EvaluateOrSkip(SoakAggregates actual, string scenarioId, int windowSeconds)
     {
         var path = Path.Combine(AppContext.BaseDirectory, "baselines", "soak-baseline.json");
         if (!File.Exists(path))
@@ -34,8 +39,26 @@ public static class Tier2Baseline
             return Tier2Report.SkippedReport("no baseline committed — run SOAK_EMIT_BASELINE=1 at 300s to bless");
         }
 
-        var baseline = JsonSerializer.Deserialize<SoakBaseline>(File.ReadAllText(path), _json)
-            ?? throw new InvalidOperationException($"Baseline at {path} deserialized to null.");
+        SoakBaseline? baseline;
+        try
+        {
+            baseline = JsonSerializer.Deserialize<SoakBaseline>(File.ReadAllText(path), _json);
+        }
+        catch (Exception ex) when (ex is JsonException or IOException)
+        {
+            return Tier2Report.SkippedReport($"baseline at {path} could not be read: {ex.Message}");
+        }
+
+        if (baseline is null || baseline.Tolerances is null || baseline.Expected is null)
+        {
+            return Tier2Report.SkippedReport($"baseline at {path} is missing required 'tolerances'/'expected' blocks");
+        }
+
+        if (!string.Equals(baseline.ScenarioId, scenarioId, StringComparison.Ordinal))
+        {
+            return Tier2Report.SkippedReport(
+                $"baseline scenario '{baseline.ScenarioId}' != run scenario '{scenarioId}' (baselines are per theme)");
+        }
 
         if (baseline.WindowSeconds != windowSeconds)
         {
@@ -49,19 +72,35 @@ public static class Tier2Baseline
     public static Tier2Report Evaluate(SoakAggregates actual, SoakBaseline baseline)
     {
         var metrics = actual.ToMetrics();
+        var expected = baseline.Expected ?? new Dictionary<string, SoakBaselineMetric>(StringComparer.Ordinal);
+        var tolerances = baseline.Tolerances ?? new Dictionary<string, decimal>(StringComparer.Ordinal);
         var results = new List<Tier2Result>();
         foreach (var id in _metricOrder)
         {
-            if (!metrics.TryGetValue(id, out var observed) ||
-                !baseline.Expected.TryGetValue(id, out var expected))
+            // Surface a gap as data rather than dropping the row: a silently-missing blessed metric would let
+            // AllWithinBand read "clean" while a metric was never compared.
+            if (!metrics.TryGetValue(id, out var observed) || !expected.TryGetValue(id, out var metric))
             {
+                results.Add(Tier2Result.Unresolved(id, $"metric '{id}' missing from run aggregates or baseline"));
                 continue;
             }
 
-            var kind = ParseKind(expected.Kind);
-            var tolerance = baseline.Tolerances.TryGetValue(expected.Tol, out var t) ? t : 0m;
-            var status = WithinBand(observed, expected.Value, tolerance, kind) ? Tier2Status.WithinBand : Tier2Status.Warn;
-            results.Add(new Tier2Result(id, observed, expected.Value, tolerance, kind, status));
+            if (!TryParseKind(metric.Kind, out var kind))
+            {
+                results.Add(Tier2Result.Unresolved(id, $"unknown tolerance kind '{metric.Kind}' in baseline"));
+                continue;
+            }
+
+            // A missing named tolerance is a baseline typo, not a drift — never collapse the band to 0m (that
+            // would manufacture a spurious Warn); record it as Unresolved instead.
+            if (metric.Tol is null || !tolerances.TryGetValue(metric.Tol, out var tolerance))
+            {
+                results.Add(Tier2Result.Unresolved(id, $"tolerance '{metric.Tol}' not defined in baseline"));
+                continue;
+            }
+
+            var status = WithinBand(observed, metric.Value, tolerance, kind) ? Tier2Status.WithinBand : Tier2Status.Warn;
+            results.Add(new Tier2Result(id, observed, metric.Value, tolerance, kind, status));
         }
 
         return new Tier2Report(results, SkipReason: null);
@@ -77,13 +116,17 @@ public static class Tier2Baseline
             _ => throw new InvalidOperationException($"Unhandled Tier-2 tolerance kind '{kind}'."),
         };
 
-    private static Tier2ToleranceKind ParseKind(string kind) =>
-        kind switch
+    // Non-throwing: an unknown or absent kind in the baseline JSON becomes an Unresolved row (advisory
+    // tier never throws), not an exception that would fail the whole soak run before Tier 1/Tier 3 render.
+    private static bool TryParseKind(string? kind, out Tier2ToleranceKind result)
+    {
+        switch (kind)
         {
-            "exact-ish" => Tier2ToleranceKind.ExactIsh,
-            "count" => Tier2ToleranceKind.Count,
-            "count-min" => Tier2ToleranceKind.CountMin,
-            "scalar" => Tier2ToleranceKind.Scalar,
-            _ => throw new InvalidOperationException($"Unknown Tier-2 tolerance kind '{kind}' in baseline JSON."),
-        };
+            case "exact-ish": result = Tier2ToleranceKind.ExactIsh; return true;
+            case "count": result = Tier2ToleranceKind.Count; return true;
+            case "count-min": result = Tier2ToleranceKind.CountMin; return true;
+            case "scalar": result = Tier2ToleranceKind.Scalar; return true;
+            default: result = default; return false;
+        }
+    }
 }

--- a/src/Voidforge.SoakTests/Tier2Baseline.cs
+++ b/src/Voidforge.SoakTests/Tier2Baseline.cs
@@ -44,7 +44,7 @@ public static class Tier2Baseline
         {
             baseline = JsonSerializer.Deserialize<SoakBaseline>(File.ReadAllText(path), _json);
         }
-        catch (Exception ex) when (ex is JsonException or IOException)
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
         {
             return Tier2Report.SkippedReport($"baseline at {path} could not be read: {ex.Message}");
         }

--- a/src/Voidforge.SoakTests/Tier2Baseline.cs
+++ b/src/Voidforge.SoakTests/Tier2Baseline.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+
+namespace Voidforge.SoakTests;
+
+// Loads the committed blessed baseline and compares a run's SoakAggregates against it, producing a
+// render-only Tier2Report. NEVER asserts — Tier 2 is advisory (a miss is a WARN, not a test failure;
+// §2/§7.3). Skips (rather than fails) when no baseline is committed or when the run window does not match
+// the baseline's, exactly mirroring Tier 3's window-gated O4-O6 SKIP.
+public static class Tier2Baseline
+{
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    // Canonical comparison order, tightest -> jitteriest (§5). A fixed array drives iteration so the matrix
+    // is deterministic and we never order-by strings or rely on dictionary enumeration order (MA0002).
+    private static readonly string[] _metricOrder =
+    [
+        "oreMinedTotal",
+        "planetsColonized",
+        "shipsProduced",
+        "haltReasonsSeen",
+        "playerScoreMax",
+    ];
+
+    public static Tier2Report EvaluateOrSkip(SoakAggregates actual, int windowSeconds)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "baselines", "soak-baseline.json");
+        if (!File.Exists(path))
+        {
+            return Tier2Report.SkippedReport("no baseline committed — run SOAK_EMIT_BASELINE=1 at 300s to bless");
+        }
+
+        var baseline = JsonSerializer.Deserialize<SoakBaseline>(File.ReadAllText(path), _json)
+            ?? throw new InvalidOperationException($"Baseline at {path} deserialized to null.");
+
+        if (baseline.WindowSeconds != windowSeconds)
+        {
+            return Tier2Report.SkippedReport(
+                $"baseline window {baseline.WindowSeconds}s != run window {windowSeconds}s (bless & compare at 300s)");
+        }
+
+        return Evaluate(actual, baseline);
+    }
+
+    public static Tier2Report Evaluate(SoakAggregates actual, SoakBaseline baseline)
+    {
+        var metrics = actual.ToMetrics();
+        var results = new List<Tier2Result>();
+        foreach (var id in _metricOrder)
+        {
+            if (!metrics.TryGetValue(id, out var observed) ||
+                !baseline.Expected.TryGetValue(id, out var expected))
+            {
+                continue;
+            }
+
+            var kind = ParseKind(expected.Kind);
+            var tolerance = baseline.Tolerances.TryGetValue(expected.Tol, out var t) ? t : 0m;
+            var status = WithinBand(observed, expected.Value, tolerance, kind) ? Tier2Status.WithinBand : Tier2Status.Warn;
+            results.Add(new Tier2Result(id, observed, expected.Value, tolerance, kind, status));
+        }
+
+        return new Tier2Report(results, SkipReason: null);
+    }
+
+    private static bool WithinBand(decimal observed, decimal expected, decimal tolerance, Tier2ToleranceKind kind) =>
+        kind switch
+        {
+            Tier2ToleranceKind.ExactIsh => Math.Abs(observed - expected) <= tolerance,
+            Tier2ToleranceKind.Count => Math.Abs(observed - expected) <= tolerance,
+            Tier2ToleranceKind.CountMin => observed >= expected,
+            Tier2ToleranceKind.Scalar => Math.Abs(observed - expected) <= expected * (tolerance / 100m),
+            _ => throw new InvalidOperationException($"Unhandled Tier-2 tolerance kind '{kind}'."),
+        };
+
+    private static Tier2ToleranceKind ParseKind(string kind) =>
+        kind switch
+        {
+            "exact-ish" => Tier2ToleranceKind.ExactIsh,
+            "count" => Tier2ToleranceKind.Count,
+            "count-min" => Tier2ToleranceKind.CountMin,
+            "scalar" => Tier2ToleranceKind.Scalar,
+            _ => throw new InvalidOperationException($"Unknown Tier-2 tolerance kind '{kind}' in baseline JSON."),
+        };
+}

--- a/src/Voidforge.SoakTests/Tier2Report.cs
+++ b/src/Voidforge.SoakTests/Tier2Report.cs
@@ -8,7 +8,10 @@ public sealed record Tier2Report(IReadOnlyList<Tier2Result> Results, string? Ski
 {
     public bool Skipped => SkipReason is not null;
 
-    public bool AllWithinBand => Results.All(r => r.Status == Tier2Status.WithinBand);
+    // A skipped report never ran a comparison, so it is NOT "all within band" (an empty Results would
+    // otherwise make Enumerable.All vacuously true). An Unresolved row also fails this — only a real
+    // WithinBand-for-every-metric run is a clean advisory signal.
+    public bool AllWithinBand => !Skipped && Results.All(r => r.Status == Tier2Status.WithinBand);
 
     public string WarnSummary() =>
         string.Join(Environment.NewLine, Results.Where(r => r.Status == Tier2Status.Warn).Select(r => r.Id));

--- a/src/Voidforge.SoakTests/Tier2Report.cs
+++ b/src/Voidforge.SoakTests/Tier2Report.cs
@@ -1,0 +1,17 @@
+namespace Voidforge.SoakTests;
+
+// The full Tier-2 baseline comparison. Kept as data (mirrors Tier1Report/Tier3Report) so the test can
+// render a per-metric matrix without re-evaluating. Advisory ONLY: there is deliberately no AssertAll and
+// no failing state — AllWithinBand is a human-review signal, not a gate. A non-null SkipReason means the
+// comparison did not run (no baseline committed, or the run window does not match the baseline's window).
+public sealed record Tier2Report(IReadOnlyList<Tier2Result> Results, string? SkipReason)
+{
+    public bool Skipped => SkipReason is not null;
+
+    public bool AllWithinBand => Results.All(r => r.Status == Tier2Status.WithinBand);
+
+    public string WarnSummary() =>
+        string.Join(Environment.NewLine, Results.Where(r => r.Status == Tier2Status.Warn).Select(r => r.Id));
+
+    public static Tier2Report SkippedReport(string reason) => new([], reason);
+}

--- a/src/Voidforge.SoakTests/Tier2Result.cs
+++ b/src/Voidforge.SoakTests/Tier2Result.cs
@@ -2,11 +2,21 @@ namespace Voidforge.SoakTests;
 
 // One metric's Tier-2 comparison: the observed run value against the blessed expected value within its
 // tolerance band. Carries numbers + enums only (no pre-formatted strings) so all culture-sensitive
-// rendering stays in the SoakReport.Emit invariant-culture choke point.
+// rendering stays in the SoakReport.Emit invariant-culture choke point. Reason is set only for an
+// Unresolved row (the human-readable gap); the numeric fields are then placeholders the renderer ignores.
 public sealed record Tier2Result(
     string Id,
     decimal Observed,
     decimal Expected,
     decimal Tolerance,
     Tier2ToleranceKind Kind,
-    Tier2Status Status);
+    Tier2Status Status,
+    string? Reason = null)
+{
+    // A metric that could not be compared: absent from the run aggregates or the baseline, an unknown
+    // tolerance kind, or an undefined named tolerance. Kept as data (never thrown) so the advisory tier
+    // surfaces the gap in the matrix instead of dropping the row or collapsing its band. Kind is a
+    // placeholder — the renderer branches on Status before reading it.
+    public static Tier2Result Unresolved(string id, string reason) =>
+        new(id, 0m, 0m, 0m, Tier2ToleranceKind.ExactIsh, Tier2Status.Unresolved, reason);
+}

--- a/src/Voidforge.SoakTests/Tier2Result.cs
+++ b/src/Voidforge.SoakTests/Tier2Result.cs
@@ -1,0 +1,12 @@
+namespace Voidforge.SoakTests;
+
+// One metric's Tier-2 comparison: the observed run value against the blessed expected value within its
+// tolerance band. Carries numbers + enums only (no pre-formatted strings) so all culture-sensitive
+// rendering stays in the SoakReport.Emit invariant-culture choke point.
+public sealed record Tier2Result(
+    string Id,
+    decimal Observed,
+    decimal Expected,
+    decimal Tolerance,
+    Tier2ToleranceKind Kind,
+    Tier2Status Status);

--- a/src/Voidforge.SoakTests/Tier2Status.cs
+++ b/src/Voidforge.SoakTests/Tier2Status.cs
@@ -1,9 +1,13 @@
 namespace Voidforge.SoakTests;
 
-// Whether one Tier-2 metric landed inside its tolerance band. TWO states only — Tier 2 is advisory, so
-// there is no hard-fail state: a miss is a WARN a human reviews, never an xUnit failure (§2/§7.3).
+// Whether one Tier-2 metric landed inside its tolerance band. Advisory only — NONE of these is an xUnit
+// failure (§2/§7.3): WithinBand and Warn are the two comparison outcomes a human reviews, and Unresolved
+// records a baseline/aggregate GAP (a metric absent from the run or the baseline, an unknown tolerance
+// kind, or an undefined named tolerance) as data — surfaced instead of silently dropping the row or
+// collapsing its band to a spurious Warn. A miss is still never a test failure, only a WARN a human reads.
 public enum Tier2Status
 {
     WithinBand,
     Warn,
+    Unresolved,
 }

--- a/src/Voidforge.SoakTests/Tier2Status.cs
+++ b/src/Voidforge.SoakTests/Tier2Status.cs
@@ -1,0 +1,9 @@
+namespace Voidforge.SoakTests;
+
+// Whether one Tier-2 metric landed inside its tolerance band. TWO states only — Tier 2 is advisory, so
+// there is no hard-fail state: a miss is a WARN a human reviews, never an xUnit failure (§2/§7.3).
+public enum Tier2Status
+{
+    WithinBand,
+    Warn,
+}

--- a/src/Voidforge.SoakTests/Tier2ToleranceKind.cs
+++ b/src/Voidforge.SoakTests/Tier2ToleranceKind.cs
@@ -1,0 +1,14 @@
+namespace Voidforge.SoakTests;
+
+// How a blessed metric's tolerance is applied when comparing observed vs expected (the baseline JSON
+// "kind"):
+//   ExactIsh / Count -> absolute epsilon band: |observed - expected| <= tol
+//   CountMin         -> at-least floor: observed >= expected (tol ignored)
+//   Scalar           -> relative percent band: |observed - expected| <= expected * tol/100
+public enum Tier2ToleranceKind
+{
+    ExactIsh,
+    Count,
+    CountMin,
+    Scalar,
+}

--- a/src/Voidforge.SoakTests/TwoUserEconomySoakTests.cs
+++ b/src/Voidforge.SoakTests/TwoUserEconomySoakTests.cs
@@ -54,9 +54,21 @@ public sealed class TwoUserEconomySoakTests
         var tier1 = Tier1Invariants.Evaluate(snapshot, capacityOf, _overdueMargin);
         var tier3 = Tier3Outcomes.Evaluate(snapshot, ScenarioIntent.Default, SoakConfig.WindowSeconds);
 
+        // Tier 2 is advisory: compute the run aggregates and compare them to the blessed baseline (skipped
+        // when none is committed or the window does not match). It NEVER asserts — only Tier 1 and Tier 3
+        // hard-fail the run.
+        var aggregates = SoakAggregates.Compute(snapshot, scoreCalculator);
+        var tier2 = Tier2Baseline.EvaluateOrSkip(aggregates, SoakConfig.WindowSeconds);
+
         // Render the full report BEFORE asserting, so the per-tier matrices reach the test output even
         // when an assertion below fails the run.
-        _output.WriteLine(SoakReport.Render(snapshot, tier1, tier3, scoreCalculator, driverResult.Events));
+        _output.WriteLine(SoakReport.Render(snapshot, tier1, tier2, tier3, scoreCalculator, driverResult.Events));
+
+        // Emit mode: log the machine-readable aggregates for the N-run blessing envelope (§6).
+        if (SoakConfig.EmitBaseline)
+        {
+            SoakBaselineEmitter.Emit(aggregates, SoakConfig.WindowSeconds, _output.WriteLine);
+        }
 
         Tier1Invariants.AssertAll(tier1);
         Tier3Outcomes.AssertAll(tier3);

--- a/src/Voidforge.SoakTests/TwoUserEconomySoakTests.cs
+++ b/src/Voidforge.SoakTests/TwoUserEconomySoakTests.cs
@@ -58,7 +58,7 @@ public sealed class TwoUserEconomySoakTests
         // when none is committed or the window does not match). It NEVER asserts — only Tier 1 and Tier 3
         // hard-fail the run.
         var aggregates = SoakAggregates.Compute(snapshot, scoreCalculator);
-        var tier2 = Tier2Baseline.EvaluateOrSkip(aggregates, SoakConfig.WindowSeconds);
+        var tier2 = Tier2Baseline.EvaluateOrSkip(aggregates, ScenarioIntent.ScenarioId, SoakConfig.WindowSeconds);
 
         // Render the full report BEFORE asserting, so the per-tier matrices reach the test output even
         // when an assertion below fails the run.

--- a/src/Voidforge.SoakTests/Voidforge.SoakTests.csproj
+++ b/src/Voidforge.SoakTests/Voidforge.SoakTests.csproj
@@ -9,6 +9,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Copy the blessed Tier-2 baseline to the output dir so Tier2Baseline can load it from
+         AppContext.BaseDirectory. A glob (not an explicit filename) so the project still builds cleanly
+         BEFORE blessing, when no baseline is committed yet — then picks the file up once it lands. -->
+    <Content Include="baselines/*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../Voidforge.Api/Voidforge.Api.csproj" />
     <ProjectReference Include="../Voidforge.Tests/Voidforge.Tests.csproj" />
   </ItemGroup>

--- a/src/Voidforge.SoakTests/baselines/soak-baseline.json
+++ b/src/Voidforge.SoakTests/baselines/soak-baseline.json
@@ -1,0 +1,33 @@
+{
+  "scenarioId": "two-user-economy-v1",
+  "windowSeconds": 300,
+  "config": {
+    "WorldGeneration__IronOrePool": "4000",
+    "WorldGeneration__IronIngotStorageCapacity": "2500",
+    "WorldGeneration__StartingIronOre": "2000",
+    "WorldGeneration__StartingIronIngots": "800",
+    "WorldGeneration__SolarSystemCount": "40",
+    "Balance__Drill__BuildDurationSeconds": "20",
+    "Balance__Refinery__BuildDurationSeconds": "20",
+    "Balance__Generator__BuildDurationSeconds": "20",
+    "Balance__Shipyard__BuildDurationSeconds": "20",
+    "Balance__ColonyShip__BuildDurationSeconds": "15",
+    "Balance__CargoVessel__BuildDurationSeconds": "15",
+    "Balance__ColonyShip__IngotCost": "60",
+    "Balance__CargoVessel__IngotCost": "60",
+    "Balance__Ships__ColonyShip__SpeedPerSecond": "100",
+    "Balance__Ships__CargoVessel__SpeedPerSecond": "100"
+  },
+  "tolerances": {
+    "scorePct": 10,
+    "countAbs": 1,
+    "oreEpsilon": 150
+  },
+  "expected": {
+    "oreMinedTotal": { "value": 7170, "kind": "exact-ish", "tol": "oreEpsilon" },
+    "planetsColonized": { "value": 1, "kind": "count", "tol": "countAbs" },
+    "shipsProduced": { "value": 4, "kind": "count", "tol": "countAbs" },
+    "haltReasonsSeen": { "value": 2, "kind": "count-min", "tol": "countAbs" },
+    "playerScoreMax": { "value": 10052, "kind": "scalar", "tol": "scorePct" }
+  }
+}

--- a/technical-design/research/verifier-live-soak-run.md
+++ b/technical-design/research/verifier-live-soak-run.md
@@ -1,7 +1,8 @@
 # Verifier Research: Live Soak-Run Verifier
 
-> **Status:** Design + **all three assertion tiers shipped**. This document is the design for the
-> verifier the team is **primarily** implementing; §2–§8 remain the target end-state.
+> **Status:** Design doc — **all three assertion tiers shipped** (Tier 1 #96, Tier 3 #98, Tier 2 #99).
+> §2–§8 are the design of record the shipped code follows; where the code refined a detail, the notes
+> below and the source under `src/Voidforge.SoakTests/` are authoritative.
 >
 > **Shipped (`src/Voidforge.SoakTests/`):** a standalone `dotnet test` project — deliberately
 > **not** in `src/Voidforge.slnx`, so no CI lane or Stop-hook runs it — that boots the real host

--- a/technical-design/research/verifier-live-soak-run.md
+++ b/technical-design/research/verifier-live-soak-run.md
@@ -1,18 +1,26 @@
 # Verifier Research: Live Soak-Run Verifier
 
-> **Status:** Design + **v1 walking skeleton shipped**. This document is the design for the
+> **Status:** Design + **all three assertion tiers shipped**. This document is the design for the
 > verifier the team is **primarily** implementing; §2–§8 remain the target end-state.
 >
-> **v1 (shipped, `src/Voidforge.SoakTests/`):** a standalone `dotnet test` project — deliberately
+> **Shipped (`src/Voidforge.SoakTests/`):** a standalone `dotnet test` project — deliberately
 > **not** in `src/Voidforge.slnx`, so no CI lane or Stop-hook runs it — that boots the real host
 > against an isolated auto-created `voidforge_soak_test` DB with the §8.2 theme config, drives the
 > two-user scenario over real HTTP for a bounded window (`SOAK_WINDOW_SECONDS`, default 120),
-> drains via **aggregate-quiesce + settle-cap**, snapshots via Marten, and asserts **Tier 1
-> (I1–I11)**. Run: `SOAK_WINDOW_SECONDS=300 dotnet test src/Voidforge.SoakTests/Voidforge.SoakTests.csproj`.
-> Validated: a 90 s and a 300 s run each pass all 11 invariants; the run genuinely exercised
-> parallel Planet-stream appends (observed `23505` optimistic-concurrency collisions absorbed by the
-> retry ladder — I3 dead-letters empty, I5 clean). **Deferred to follow-ups:** Tier 2 baselines +
-> blessing, Tier 3 structural outcomes, envelope-based drain, CI gating, multi-theme matrix.
+> drains via **aggregate-quiesce + settle-cap**, snapshots via Marten, and asserts:
+> - **Tier 1 (I1–I11)** — invariants, hard-assert (#96).
+> - **Tier 3 (O1–O6)** — structural outcomes, hard-assert; O4–O6 window-gated at `>= 300s` (#98).
+> - **Tier 2 (baselines & blessing)** — aggregate comparison vs a **blessed baseline**
+>   (`baselines/soak-baseline.json`) within per-metric tolerances, rendered as a `[BAND]`/`[WARN]`
+>   matrix. **Advisory only — never fails the test** (§2/§7.3); `SOAK_EMIT_BASELINE=1` emits the
+>   machine-readable aggregates that feed the N-run blessing envelope. Blessed with N=5 × 300s runs.
+>
+> Run: `SOAK_WINDOW_SECONDS=300 dotnet test src/Voidforge.SoakTests/Voidforge.SoakTests.csproj`.
+> Validated: 90 s / 300 s runs pass all 11 invariants; the run genuinely exercised parallel
+> Planet-stream appends (observed `23505` optimistic-concurrency collisions absorbed by the retry
+> ladder — I3 dead-letters empty, I5 clean). **Deferred to follow-ups:** nightly CI/soak lane +
+> dedicated DB, envelope-based drain, multi-theme matrix, the golden-diff sibling, and converging
+> Tier 3 onto the shared `SoakAggregates` (once a CI net exists).
 >
 > **Two findings from v1 (acted on):**
 > 1. **Transport is own-planets-only, so §8.2's A→B lifeline was infeasible — the scenario was

--- a/technical-design/research/verifier-tier2-handover.md
+++ b/technical-design/research/verifier-tier2-handover.md
@@ -9,13 +9,16 @@
 > `baselines/*.json` **glob** (not an explicit filename) so the project builds cleanly before blessing.
 > The kept-open follow-ups are unchanged (see §10).
 >
-> **For the next agent.** Tier 1 (invariants) and Tier 3 (structural outcomes) are shipped and on
-> `main`. This is the handover to build **Tier 2 — tolerance comparison vs a blessed baseline**, the
-> last of the three assertion tiers. Read this end-to-end before coding; it is written to be executable.
+> **This document is the design-time handover brief, preserved as provenance.** Everything below §1 was
+> written to hand the *unbuilt* Tier 2 to the next agent, so it reads in the future/imperative tense
+> ("proposed design", "suggested first steps"). Tier 2 is now shipped (#99) along these lines — read the
+> prose below as the plan of record, and the ✅ DONE note above plus the code under
+> `src/Voidforge.SoakTests/` as the authoritative shipped state where the two differ. One contract the
+> code refined vs. the plan: runtime compatibility is gated on `scenarioId` + `windowSeconds`; the
+> `config` block is recorded as re-bless provenance, not machine-compared (see §6 and `SoakBaseline`).
 >
 > **Design source of truth:** `technical-design/research/verifier-live-soak-run.md` — §2 "Tier 2",
-> §3 "Baseline Recording & Blessing", §6 "Nondeterminism Ledger", §7.3 "Flakiness control", and the
-> open questions §9 (#2, #3, #4, #8) all bear directly on this work.
+> §3 "Baseline Recording & Blessing", §6 "Nondeterminism Ledger", §7.3 "Flakiness control", §9 (#2–#4, #8).
 
 ## 1. Where things stand
 
@@ -180,7 +183,11 @@ new bookkeeping. Start Tier 2 with the counts + score + ore, which are all alrea
   **legit game change**: re-bless as part of that PR; the baseline diff is reviewable evidence.
 - A Tier-2 drift with **no** such change is a **regression candidate** — investigate, do **not** re-bless
   to make it green. That is how a baseline silently absorbs a bug.
-- The baseline is keyed by `scenarioId` **and** the embedded `config` block **and** `windowSeconds`.
+- The baseline is keyed at compare time by `scenarioId` **and** `windowSeconds` — `EvaluateOrSkip` SKIPs
+  a run whose scenario or window does not match. The embedded `config` block is recorded as re-bless
+  provenance (§3.3), **not** machine-compared: reproducing and diffing the full env theme is an
+  error-prone heavy lift unjustified for an advisory tier, and a config change that moves the numbers
+  surfaces as a WARN the reviewer re-blesses.
 
 ## 7. Open decisions (from design §9)
 

--- a/technical-design/research/verifier-tier2-handover.md
+++ b/technical-design/research/verifier-tier2-handover.md
@@ -1,0 +1,239 @@
+# Handover — Soak Verifier Tier 2 (Baselines & Blessing)
+
+> **✅ DONE (#99).** Tier 2 shipped as designed here. New files under `src/Voidforge.SoakTests/`:
+> `SoakAggregates`, `Tier2Status`/`Tier2ToleranceKind`/`Tier2Result`/`Tier2Report`,
+> `SoakBaselineMetric`/`SoakBaseline`, `Tier2Baseline` (render-only), `SoakBaselineEmitter`, and the
+> blessed `baselines/soak-baseline.json` (N=5 × 300s envelope). Wired into `SoakReport` + the test with
+> **no Tier-2 assert**. Deviations from this doc: Tier 3 was **left untouched** (Option B — the shared
+> `SoakAggregates` is Tier-2-only for now; converge later once a CI net exists) and the `.csproj` uses a
+> `baselines/*.json` **glob** (not an explicit filename) so the project builds cleanly before blessing.
+> The kept-open follow-ups are unchanged (see §10).
+>
+> **For the next agent.** Tier 1 (invariants) and Tier 3 (structural outcomes) are shipped and on
+> `main`. This is the handover to build **Tier 2 — tolerance comparison vs a blessed baseline**, the
+> last of the three assertion tiers. Read this end-to-end before coding; it is written to be executable.
+>
+> **Design source of truth:** `technical-design/research/verifier-live-soak-run.md` — §2 "Tier 2",
+> §3 "Baseline Recording & Blessing", §6 "Nondeterminism Ledger", §7.3 "Flakiness control", and the
+> open questions §9 (#2, #3, #4, #8) all bear directly on this work.
+
+## 1. Where things stand
+
+The soak harness lives at **`src/Voidforge.SoakTests/`**, a standalone xUnit project **deliberately
+out of `src/Voidforge.slnx`** — no CI lane, no Stop-hook. Run it manually against the isolated
+`voidforge_soak_test` DB:
+
+```bash
+dotnet build src/Voidforge.SoakTests/Voidforge.SoakTests.csproj                       # analyzers run as errors
+dotnet test  src/Voidforge.SoakTests/Voidforge.SoakTests.csproj                       # 120s default window
+SOAK_WINDOW_SECONDS=300 dotnet test src/Voidforge.SoakTests/Voidforge.SoakTests.csproj # full story
+```
+
+Shipped:
+- **Tier 1** (`Tier1Invariants.cs`) — I1–I11, hard-assert (#96).
+- **Tier 3** (`Tier3Outcomes.cs`) — O1–O6 structural outcomes, hard-assert; O4–O6 window-gated at
+  `SOAK_WINDOW_SECONDS >= 300` (#98, closed #97).
+
+The single test `TwoUserEconomySoakTests.TwoContendingUsersLeaveEveryTier1InvariantIntact`:
+1. `SoakDriver.RunAsync(window)` — drives the two-user scenario AND drains the scheduler internally
+   (the snapshot loop captures deposits + building halts throughout).
+2. `SoakSnapshotReader.ReadAuthoritativeAsync` — one post-drain read at a fixed `now` →
+   `WorldSnapshot { Planets, Fleets, Players, Now, DeadLetterCount, HttpStatuses, DepositSeries }`.
+3. `Tier1Invariants.Evaluate/AssertAll` + `Tier3Outcomes.Evaluate/AssertAll`, rendered by
+   `SoakReport.Render` **before** asserting.
+
+## 2. Goal of Tier 2
+
+Compare run **aggregates** against a recorded, **blessed baseline** within a per-metric tolerance
+(ε absolute or X% relative). Per §2/§7.3 this tier is **advisory, not a hard gate**: a miss is a
+**WARN**, not a test failure — jitter is expected, and persistent drift across runs is the regression
+signal. Concretely for the manual/nightly harness:
+
+> **Tier 2 must NOT fail the xUnit test.** Only Tier 1 and Tier 3 hard-assert. Tier 2 computes,
+> compares, and renders a PASS/WARN matrix. (When the nightly CI lane lands — a separate follow-up —
+> that lane can parse the WARN lines and raise a soft signal / ping for review. See §9-#3: whether a
+> persistent multi-night drift auto-escalates to hard is an open decision — leave it human-reviewed
+> for v1.)
+
+## 3. What already exists to reuse — do NOT reinvent
+
+- **`SoakReport.cs` already computes the seed aggregates** and says so in its header comment ("The
+  seed for a future Tier-2 blessing"):
+  - `AppendOreMined` — per-planet `IronOreDeposit.StorageCapacity − GetCurrentValue(now)` (the exact,
+    monotonic ore-mined quantity; **the lowest-jitter metric there is**).
+  - `AppendScores` — per-player `ScoreCalculator.Compute(ownedPlanets, ownedFleets, now)` (the single
+    scalar folding planets + buildings + ships + resources).
+  Lift these formulas into a shared aggregate computer rather than duplicating them.
+- **`Tier3Outcomes.cs` already computes the count aggregates** you'll bless:
+  - colonies won = `Planets.Count(OwnerId is not null) − Players.Count`
+  - ships produced = roster ships + non-Disbanded fleet ships + colonies won
+  - ore mined total = `Σ (deposit.StorageCapacity − deposit.GetCurrentValue(now))`
+  - observed halt reasons = union of `DepositSeries[*].Halts` and final `Buildings[*].HaltReason`
+  Consider extracting a `SoakAggregates.Compute(WorldSnapshot)` used by BOTH Tier 3 and Tier 2 so the
+  two tiers can't drift apart.
+- **Tier shape to mirror exactly:** `InvariantResult`/`OutcomeResult` (record) →
+  `Tier1Report`/`Tier3Report` (list + summary) → `Evaluate` + `AssertAll` static class, rendered by a
+  `SoakReport.Append*` method. Copy this shape for Tier 2 (but `AssertAll` becomes a no-op / render-only
+  — see §2).
+- **`ScenarioIntent.cs`** — the pattern for centralising tunables as data + a window gate. The Tier 2
+  baseline JSON is the analogous "declared expectations" artifact.
+- **`ScoreCalculator`** is DI-resolved in the test (`host.Services.GetRequiredService<ScoreCalculator>()`).
+
+## 4. Proposed design
+
+Mirror the existing tiers. New files under `src/Voidforge.SoakTests/`:
+
+| File | Responsibility |
+|------|----------------|
+| `SoakAggregates.cs` | `record` of the computed run aggregates + `Compute(WorldSnapshot, ScoreCalculator)`. Reuse the formulas above. Shared with Tier 3 if you refactor. |
+| `SoakBaseline.cs` | The deserialized baseline model: `scenarioId`, `config` (echoed env theme), `windowSeconds`, `tolerances`, and `expected` metrics (value + kind + tolerance ref). |
+| `Tier2Result.cs` | One metric's comparison: id, observed, expected, tolerance, `Tier2Status { WithinBand, Warn }`. (Two states — no hard fail.) |
+| `Tier2Report.cs` | List of results + `AllWithinBand` (advisory) + a WARN summary. |
+| `Tier2Baseline.cs` | `Evaluate(SoakAggregates actual, SoakBaseline baseline)` → `Tier2Report`; loads the JSON. Render-only, never asserts. |
+| `baselines/soak-baseline.json` | The committed blessed baseline (see §5 for schema). |
+
+**Baseline loading (project is out-of-solution):** add to the `.csproj` so the JSON copies to output:
+```xml
+<ItemGroup>
+  <Content Include="baselines\soak-baseline.json" CopyToOutputDirectory="PreserveNewest" />
+</ItemGroup>
+```
+Load with `System.Text.Json` (in-framework, no package) from
+`Path.Combine(AppContext.BaseDirectory, "baselines", "soak-baseline.json")`. If the file is absent,
+render "Tier 2: no baseline — run in emit mode to bless" and skip (don't throw).
+
+**Emit / re-bless mode:** add a `SOAK_EMIT_BASELINE=1` env switch. When set, after computing
+`SoakAggregates` the test serialises them to a machine-readable JSON (write to the test output dir, or
+log a single-line JSON blob the blessing script can grep). This is what feeds the N-run envelope in §6
+— far better than eyeballing `SoakReport`'s prose.
+
+**Wiring in `TwoUserEconomySoakTests`:**
+```csharp
+var aggregates = SoakAggregates.Compute(snapshot, scoreCalculator);
+var tier2 = Tier2Baseline.EvaluateOrSkip(aggregates, SoakConfig.WindowSeconds); // loads JSON, may be "skipped"
+_output.WriteLine(SoakReport.Render(snapshot, tier1, tier2, tier3, scoreCalculator, driverResult.Events));
+if (SoakConfig.EmitBaseline) SoakBaselineEmitter.Write(aggregates);
+Tier1Invariants.AssertAll(tier1);
+Tier3Outcomes.AssertAll(tier3);
+// NOTE: no Tier2 assert — advisory only.
+```
+Extend `SoakReport.Render` with a `Tier2Report` param and an `AppendBaseline` matrix (mirror
+`AppendOutcomes`): `[BAND]`/`[WARN] <metric>: observed X vs expected Y ±tol`.
+
+## 5. Baseline JSON — schema & what to store
+
+Store **only low-jitter, run-stable quantities**, plus the config that produced them. Do **NOT** store
+raw buffer levels, per-event timestamps, ids, or coordinates — they rot every run (§3.1, §6).
+
+```jsonc
+{
+  "scenarioId": "two-user-economy-v1",
+  "windowSeconds": 300,                       // baselines are WINDOW-SPECIFIC — bless at 300s
+  "config": {                                 // echo the SoakConfig theme this baseline is valid for
+    "WorldGeneration__IronOrePool": "4000",
+    "WorldGeneration__IronIngotStorageCapacity": "2500",
+    "Balance__Drill__BuildDurationSeconds": "20"
+    // ... the full set SoakConfig.ApplyEnvironmentOverrides sets
+  },
+  "tolerances": { "scorePct": 15, "countAbs": 1, "oreEpsilon": 250 },
+  "expected": {
+    "oreMinedTotal":     { "value": 7100, "kind": "exact-ish", "tol": "oreEpsilon" },
+    "shipsProduced":     { "value": 4,    "kind": "count",     "tol": "countAbs" },
+    "planetsColonized":  { "value": 1,    "kind": "count",     "tol": "countAbs" },
+    "haltReasonsSeen":   { "value": 2,    "kind": "count-min", "tol": "countAbs" },
+    "playerScoreMax":    { "value": 830,  "kind": "scalar",    "tol": "scorePct" }
+  }
+}
+```
+
+**Metrics to bless (ordered tightest → jitteriest):**
+
+| Metric | Source | Jitter | Notes |
+|--------|--------|--------|-------|
+| `oreMinedTotal` | `Σ(deposit.cap − current)` | very low | Exact & monotonic (I11). Tightest anchor. |
+| `planetsColonized` | colonies-won formula | low | Count. In this scenario reliably 1 at 300s (A colonizes, B recalls). |
+| `shipsProduced` | roster+fleets+colonies | low | Count. Observed 4 in validation runs. |
+| `haltReasonsSeen` | distinct observed HaltReasons | low | `count-min` ≥ 2 (ResourceDepleted + OutputStorageFull). |
+| `playerScoreMax` (or per-player) | `ScoreCalculator.Compute` | medium | Scalar; use ±% not ±abs. Best single health signal but jittery — widest band. |
+
+**Observed values (from the two shipped 300s validation runs, use as a starting point, then re-bless
+per §6):** oreMinedTotal ≈ 7173, shipsProduced = 4, planetsColonized = 1, haltReasonsSeen = 2. Do NOT
+treat these as blessed — they are two points; bless properly with N runs.
+
+**Advanced / optional metric — conservation reconciliation.** §2 discusses ore/ingot conservation as a
+**bounded inequality**, not an equality (cap-clamp discards overflow; the ADR-0002 under-credit
+residual; the refinery draws the stored buffer). If you add it, it is a Tier-2 ε-band check, e.g.
+`ingotsEverProduced ≤ 2×oreMined + startingIngots`. **Recommendation: defer to a v2** — "ingots ever
+produced" is not directly on the snapshot (the ingot pool is current, capped, and drained), so it needs
+new bookkeeping. Start Tier 2 with the counts + score + ore, which are all already computed.
+
+## 6. Blessing workflow (§3.2)
+
+1. On a **known-good `main`**, run the 300s soak **N times** (design suggests 5; §9-#4 is open — pick 5,
+   note it in the PR). Use `SOAK_EMIT_BASELINE=1` so each run emits machine-readable aggregates.
+2. Take the **min/max envelope** (or mean ± 2σ) of each low-jitter metric across the N runs; widen by
+   the configured tolerance. That becomes the stored `expected` + `tolerances`.
+3. Commit `baselines/soak-baseline.json` alongside `verifier-live-soak-run.md`.
+
+**Re-bless discipline (§3.3) — put this in the PR template / doc:**
+- A change to `Balance` / `WorldGeneration` / `Economy` / `Scoring` config or their defaults is a
+  **legit game change**: re-bless as part of that PR; the baseline diff is reviewable evidence.
+- A Tier-2 drift with **no** such change is a **regression candidate** — investigate, do **not** re-bless
+  to make it green. That is how a baseline silently absorbs a bug.
+- The baseline is keyed by `scenarioId` **and** the embedded `config` block **and** `windowSeconds`.
+
+## 7. Open decisions (from design §9)
+
+- **#2 How many themes?** One 300s themed run can't maximise depletion AND both storage-full variants.
+  v1: one baseline for the shipped `two-user-economy-v1` theme. A themed matrix is a later follow-up.
+- **#3 Tier-2 hardness.** Should a persistent multi-night drift auto-escalate to hard fail? **Keep
+  human-reviewed for v1** (Tier 2 never fails the test).
+- **#4 Storage & N.** Committed JSON next to the doc; N = 5 (suggested). Point value + tolerance, or
+  explicit min/max range — pick one and be consistent.
+- **#8 Conservation ε.** If/when you add the reconciliation metric, track its ε as a balance-owned
+  constant so it tightens when rewind-and-reapply (#81, now closed) semantics change.
+
+## 8. Gotchas (learned the hard way)
+
+- **Analyzers run as errors** even though the project is out of the slnx: Meziantou **MA0048**
+  (one type per file — give the enum/record their own files), **MA0002** (string ordering needs a
+  comparer — order enums by the enum, not `.ToString()`), **CA1859** (use concrete collection types on
+  private members). Build locally after every change; CI will NOT catch these (project not in slnx).
+- **No `dotnet format` gate** on this project — match the existing style by hand (file-scoped
+  namespaces, the `SoakReport.Emit` invariant-culture helper for interpolated `AppendLine`).
+- **DB isolation:** `voidforge_soak_test` only. Never run the slnx suite (`voidforge_test`) concurrently
+  with a soak or a Stop-hook run — shared-DB corruption is a recorded hazard.
+- **Window matters:** the 120s default does NOT reach the cascades; **bless and compare at 300s**. At
+  120s, `EvaluateOrSkip` should return "skipped" (baseline `windowSeconds` won't match), exactly like
+  Tier 3's O4–O6 SKIP.
+- **Non-determinism (§6):** the soak runs **unseeded** — coordinates, ids, and the `Random.Shared`
+  homeworld pick vary run-to-run, and concurrent registration is itself a race. Seeding
+  (`WorldGeneration__Seed`, from #95) fixes world-gen but **not** the concurrent-registration order, so
+  it does not remove score jitter. Absorb the jitter with tolerances; do not chase exact values.
+
+## 9. Verification
+
+1. `dotnet build src/Voidforge.SoakTests/…` — clean (0 warnings under analyzers).
+2. **No baseline file yet:** `SOAK_WINDOW_SECONDS=300 dotnet test …` → Tier 1 + Tier 3 still hard-pass;
+   Tier 2 renders "no baseline — skipped". Test stays green.
+3. **Emit mode:** `SOAK_EMIT_BASELINE=1 SOAK_WINDOW_SECONDS=300 dotnet test …` ×5 → collect aggregates,
+   build `soak-baseline.json` per §6.
+4. **With baseline:** `SOAK_WINDOW_SECONDS=300 dotnet test …` → Tier 2 matrix shows all `[BAND]`; test
+   green. Then deliberately perturb one `Economy`/`Balance` value and confirm the relevant metric flips
+   to `[WARN]` (proves the comparison bites) — revert after.
+5. `dotnet build src/Voidforge.slnx` unaffected (Tier 2 touches only the out-of-solution project).
+
+## 10. Suggested first steps
+
+1. Extract `SoakAggregates.Compute(WorldSnapshot, ScoreCalculator)` from the formulas in
+   `SoakReport`/`Tier3Outcomes` (refactor Tier 3 to consume it — keeps the two tiers consistent).
+2. Add `SoakBaseline` + `Tier2Result`/`Tier2Report` + `Tier2Baseline.EvaluateOrSkip` (render-only).
+3. Add `SOAK_EMIT_BASELINE` to `SoakConfig` + a `SoakBaselineEmitter`.
+4. Wire into `SoakReport.Render` (Tier 2 matrix) and the test (no Tier-2 assert).
+5. Bless with 5×300s runs; commit `baselines/soak-baseline.json`; open the PR (new issue,
+   branch from `main`) and note the blessing runs + N in the description.
+
+**Backlog is empty and we're past the phase plan** — open a fresh issue ("Soak verifier: Tier 2
+baselines & blessing") and branch from `main`. The other deferred follow-ups remain: **nightly CI/soak
+lane + dedicated DB** (arguably do this *with or before* Tier 2 so the WARN signal has somewhere to
+land), **multi-theme matrix**, and the **golden-diff sibling** (`verifier-golden-diff.md`).


### PR DESCRIPTION
Closes #99. Adds **Tier 2** — the last of the three soak-verifier assertion tiers — per `technical-design/research/verifier-tier2-handover.md` and the design `verifier-live-soak-run.md` (§2, §3, §6, §7.3).

## What
Tier 2 compares run **aggregates** against a committed, **blessed baseline** (`baselines/soak-baseline.json`) within per-metric tolerances and renders a `[BAND]`/`[WARN]` matrix. **It is advisory — it never fails the xUnit test**; only Tier 1 and Tier 3 hard-assert. One miss is jitter (WARN); persistent drift across runs is the regression signal a human reviews.

## New files (`src/Voidforge.SoakTests/`, one type per file)
- `SoakAggregates` — canonical low-jitter aggregates (`oreMinedTotal`, `planetsColonized`, `shipsProduced`, `haltReasonsSeen`, `playerScoreMax`) + `ToMetrics()` (single source of metric ids, shared by compare + emit).
- `Tier2Status` / `Tier2ToleranceKind` / `Tier2Result` / `Tier2Report` — the render-only result shape (two states; no hard fail).
- `SoakBaselineMetric` / `SoakBaseline` — the deserialized baseline model.
- `Tier2Baseline` — render-only loader + comparator (`exact-ish` ε / `count` ±abs / `count-min` ≥ / `scalar` ±%); SKIPs when no baseline is committed or the run window ≠ baseline window (mirrors Tier 3's O4–O6 gate).
- `SoakBaselineEmitter` — `SOAK_EMIT_BASELINE=1` logs one grep-able `SOAK_BASELINE_EMIT {…}` marker line feeding the N-run envelope.
- `baselines/soak-baseline.json` — the blessed baseline.

Wired into `SoakReport.Render` (`AppendBaseline` matrix) and `TwoUserEconomySoakTests` (**no Tier-2 assert**).

## Blessing (N=5 × 300s on this branch)
| Metric | 5-run min–max | Blessed |
|---|---|---|
| oreMinedTotal | 7149.5–7188.8 | 7170, exact-ish, ±150 |
| planetsColonized | 1 (stable) | 1, count, ±1 |
| shipsProduced | 4 (stable) | 4, count, ±1 |
| haltReasonsSeen | 2 (stable) | 2, count-min, ≥2 |
| playerScoreMax | 10044–10062 (0.18%) | 10052, scalar, ±10% |

## Decisions (differ slightly from the handover — noted in its DONE banner)
- **Tier 3 left untouched** — `SoakAggregates` is Tier-2-only for now (two of Tier 3's four formulas are entangled with its detail strings; editing a hard gate with no CI net is poor risk/reward). Converge once a nightly CI lane exists. The tiers' numbers cross-checked identical in every blessing run, so no drift today.
- **`.csproj` uses a `baselines/*.json` glob** (not an explicit filename) so the project builds cleanly *before* blessing and picks the file up once it lands.

## Re-bless discipline (design §3.3 / handover §6)
The baseline is keyed by `scenarioId` + the embedded `config` block + `windowSeconds`. A `Balance` / `WorldGeneration` / `Economy` / `Scoring` change is a **legit re-bless** (do it in that PR — the diff is reviewable evidence). A WARN with **no** such change is a **regression candidate** — investigate; never re-bless to make it green.

## Verification (all pass)
1. `dotnet build src/Voidforge.SoakTests/…` — clean, 0 warnings under analyzers.
2. Pre-baseline `SOAK_WINDOW_SECONDS=300 dotnet test …` → Tier 1 + Tier 3 hard-pass, Tier 2 `[SKIP]`, green.
3. `SOAK_EMIT_BASELINE=1 … ×5` → built + committed the baseline.
4. With baseline → Tier 2 all `[BAND]`, green. Perturbing `oreEpsilon` to 1 flipped `oreMinedTotal` to `[WARN]` while the test **stayed green** (proves the comparison bites and stays advisory).
5. `dotnet build src/Voidforge.slnx` unaffected (Tier 2 touches only the out-of-solution project).

## Out of scope (follow-ups)
Nightly CI/soak lane + dedicated DB, multi-theme matrix, golden-diff sibling, Tier 3 → `SoakAggregates` convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added advisory Tier 2 soak-test baseline comparisons for mining, colonization, production, halt reasons, and score metrics.
  - Added configurable tolerance bands, deterministic results, warning summaries, and clear unresolved or skipped statuses.
  - Added optional machine-readable baseline emission for approved test runs.
  - Added a committed baseline for the two-user economy scenario.

- **Documentation**
  - Documented baseline compatibility, configuration, verification results, provenance, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->