### PR TITLE
fix: depletion arms the refinery input-starvation check

### DIFF
--- a/src/Voidforge.Api/Endpoints/CheckPoolDepletedHandler.cs
+++ b/src/Voidforge.Api/Endpoints/CheckPoolDepletedHandler.cs
@@ -32,20 +32,38 @@ public static class CheckPoolDepletedHandler
         await session.SaveChangesAsync();
 
         // Reschedule from the FRESH post-commit aggregate (FetchLatest), same rationale as
-        // CheckStorageFullHandler: AppendMany does not re-apply events to stream.Aggregate. After a
-        // real depletion every Drill is Halted → oreInflow 0 → the deposit's drain Rate 0 →
-        // PredictDepletionDeadline returns null (no reschedule — depletion is terminal). A superseded
-        // no-op reschedules the single next predicted empty instant, keeping the chain linear.
+        // CheckStorageFullHandler: AppendMany does not re-apply events to stream.Aggregate, so its rates
+        // would still be the pre-halt ones.
         var updated = await session.Events.FetchLatest<Planet>(message.PlanetId);
         if (updated is null)
         {
             return;
         }
 
-        var deadline = updated.PredictDepletionDeadline(message.PredictedAt);
-        if (deadline is not null)
+        if (events.Count > 0)
         {
-            await bus.ScheduleAsync(new CheckPoolDepleted(message.PlanetId, deadline.At), deadline.At);
+            // A real depletion just halted the Drill(s) — a rate-changing mutation: oreInflow drops to 0 and
+            // the still-Operational Refinery now drains the stored ore buffer. Arm the WHOLE downstream
+            // cascade from the fresh aggregate, exactly as a mutation site (Place/Queue/Complete*) would, so
+            // the depletion → drill-halt → refinery-InputStarved → build-halt chain fires in production
+            // without a wall clock. Self-guarded and fan-out-free: after a real depletion
+            // PredictDepletionDeadline is null (depletion is terminal, no CheckPoolDepleted re-arm), and the
+            // storage/buffer predicts only schedule when genuinely filling/draining — so this arms the
+            // now-draining buffer's CheckInputStarved and nothing spurious. Previously only CheckPoolDepleted
+            // was rescheduled here, so the refinery-starvation leg was NEVER armed off the depletion path:
+            // the refinery stayed Operational forever and EvaluateOreBufferEmptied never re-clamped the rate,
+            // fabricating ingots from an empty buffer.
+            await StorageHaltScheduling.ScheduleAllChecksAsync(bus, message.PlanetId, updated, message.PredictedAt);
+        }
+        else
+        {
+            // Superseded no-op (deposit not actually empty, or no operational Drill left): keep the chain
+            // linear by rescheduling only the single next predicted empty instant.
+            var deadline = updated.PredictDepletionDeadline(message.PredictedAt);
+            if (deadline is not null)
+            {
+                await bus.ScheduleAsync(new CheckPoolDepleted(message.PlanetId, deadline.At), deadline.At);
+            }
         }
     }
 }

--- a/src/Voidforge.Tests/Halting/DepletionCascadeTests.cs
+++ b/src/Voidforge.Tests/Halting/DepletionCascadeTests.cs
@@ -82,6 +82,44 @@ public sealed class DepletionCascadeTests
         Assert.Equal(HaltReason.ResourceDepleted, drillFinal.HaltReason);
     }
 
+    // Regression (depletion→InputStarved scheduling gap): the test above proves the DOMAIN logic by
+    // manually invoking CheckInputStarvedHandler as step 2 — but in production nothing invokes it unless
+    // CheckPoolDepletedHandler SCHEDULES it. This asserts exactly that: after depletion halts the Drill and
+    // the ore buffer starts draining, the handler must schedule a CheckInputStarved for the planet so the
+    // refinery-starvation leg self-drives (without it, the refinery stays Operational forever and ingots
+    // fabricate from an empty buffer). Captured via a TestMessageContext (no running Wolverine runtime).
+    [Fact]
+    public async Task DepletionSchedulesTheDownstreamRefineryStarvationCheck()
+    {
+        var registration = await _host.RegisterPlayer("DepletionArmsStarve_");
+        var planetId = registration.HomeworldId;
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+
+        var seeded = await FetchPlanet(store, planetId);
+        var depletion = seeded.PredictDepletionDeadline(seeded.IronOreDeposit.CheckpointTime);
+        Assert.NotNull(depletion);
+        var message = new CheckPoolDepleted(planetId, depletion.At);
+
+        // TestMessageContext records everything the handler sends/schedules; use it as the bus while a real
+        // Marten session backs the handler's FetchForWriting / SaveChanges.
+        var context = new TestMessageContext(message);
+        await using (var session = store.LightweightSession())
+        {
+            await CheckPoolDepletedHandler.Handle(message, session, context);
+        }
+
+        // AllOutgoing records scheduled messages as Wolverine Envelopes — unwrap to the payload messages.
+        var scheduled = context.AllOutgoing
+            .Select(o => o is Envelope env ? env.Message : o)
+            .ToList();
+
+        // The Drill halted (deposit empty) → the buffer is now draining → a CheckInputStarved for THIS
+        // planet must have been scheduled so the refinery eventually halts InputStarved on its own.
+        Assert.Contains(scheduled.OfType<CheckInputStarved>(), m => m.PlanetId == planetId);
+        // Depletion is terminal — no further CheckPoolDepleted is armed for this planet.
+        Assert.DoesNotContain(scheduled.OfType<CheckPoolDepleted>(), m => m.PlanetId == planetId);
+    }
+
     private static async Task<Planet> FetchPlanet(IDocumentStore store, Guid planetId)
     {
         await using var session = store.LightweightSession();


### PR DESCRIPTION
## What

Fixes a latent cascade-scheduling gap: **ore depletion never armed the refinery's `CheckInputStarved`.**

`CheckPoolDepletedHandler` only self-rescheduled `CheckPoolDepleted` (terminal after depletion). So when a deposit emptied via the scheduled check, the Drill halted but the now-draining ore buffer's `CheckInputStarved` was never scheduled. On a planet with no *subsequent* building-composition change:

- the Refinery stayed `Operational` forever (never halted `InputStarved`), and
- `EvaluateOreBufferEmptied` never fired → `IronIngot.Rate` was never re-clamped → **ingots kept being produced from an empty buffer** (a conservation violation, bounded by the cap so Tier‑1 didn't catch it).

`StorageHaltScheduling.ScheduleAllChecksAsync`'s own comment says it exists "so the depletion → drill-halt → refinery-starvation → build-halt cascade fires in production" — but only the mutation sites (Place/Queue/Complete\*) called it, never the depletion check handler.

## Fix

On a **real** depletion halt (`events.Count > 0`), `CheckPoolDepletedHandler` now calls `ScheduleAllChecksAsync` from the fresh post-commit aggregate — arming the now-draining buffer's `CheckInputStarved`. Self-guarded and fan-out-free: after a real depletion `PredictDepletionDeadline` is null (terminal depletion isn't re-armed) and the storage/buffer predicts only schedule when genuinely filling/draining. The superseded/no-op branch keeps the linear `CheckPoolDepleted` self-reschedule.

Scope: **depletion path only.** The `OutputStorageFull` path is self-correcting (the Drill resumes as the Refinery frees ore-store headroom), so it has no terminal gap — `CheckStorageFullHandler` is untouched.

## Test

New `DepletionCascadeTests.DepletionSchedulesTheDownstreamRefineryStarvationCheck` asserts the handler **schedules** a `CheckInputStarved` for the planet (captured via `Wolverine.TestMessageContext`). The existing cascade test masked the gap by invoking `CheckInputStarvedHandler` by hand. **Verified the new assertion fails without the handler change** (empty outgoing collection) and passes with it.

## Verification

- `dotnet build src/Voidforge.slnx -warnaserror` 0/0.
- `dotnet test --filter "FullyQualifiedName~Halting|FullyQualifiedName~Cascade"` → 23/23 pass.
- `dotnet format --verify-no-changes` clean.

## Note (non-blocking)

The soak two-user 300s **Tier‑2 baseline may drift down** (`playerScoreMax`, possibly `shipsProduced`): pre-fix, A's refinery kept fabricating ingots after depletion; post-fix it correctly halts `InputStarved`. Tier 2 is advisory (never fails). Recommend re-blessing the 300s baseline after this and #101 merge if it WARNs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected depletion handling so genuinely depleted planets trigger all required downstream checks.
  * Prevented unnecessary repeat depletion checks when the depletion event has been superseded.

* **Tests**
  * Added coverage confirming that depletion schedules the appropriate input-starvation check without scheduling another depletion check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->