### PR TITLE
chore: re-bless two-user 300s soak Tier-2 baseline (post #102)

### DIFF
--- a/src/Voidforge.SoakTests/baselines/soak-baseline.json
+++ b/src/Voidforge.SoakTests/baselines/soak-baseline.json
@@ -24,10 +24,10 @@
     "oreEpsilon": 150
   },
   "expected": {
-    "oreMinedTotal": { "value": 7170, "kind": "exact-ish", "tol": "oreEpsilon" },
+    "oreMinedTotal": { "value": 7165, "kind": "exact-ish", "tol": "oreEpsilon" },
     "planetsColonized": { "value": 1, "kind": "count", "tol": "countAbs" },
     "shipsProduced": { "value": 4, "kind": "count", "tol": "countAbs" },
     "haltReasonsSeen": { "value": 2, "kind": "count-min", "tol": "countAbs" },
-    "playerScoreMax": { "value": 10052, "kind": "scalar", "tol": "scorePct" }
+    "playerScoreMax": { "value": 10065, "kind": "scalar", "tol": "scorePct" }
   }
 }


### PR DESCRIPTION
## What

Re-blesses the `two-user-economy-v1` 300s Tier-2 soak baseline from **N=5 fresh runs** after the depletion→`InputStarved` engine fix (#102), as the follow-up flagged in #102.

## Result

The fix barely moved the aggregates — in the active two-user economy, ongoing construction/completions incidentally armed the starvation check even pre-fix, so the phantom-ingot bug wasn't materially inflating these metrics. N=5 spreads:

| metric | 5-run range | old value | new value |
|--------|-------------|-----------|-----------|
| oreMinedTotal | 7143.9 – 7188.9 | 7170 | **7165** |
| playerScoreMax | 10054.0 – 10076.4 | 10052 | **10065** |
| planetsColonized | 1 (all) | 1 | 1 |
| shipsProduced | 4 (all) | 4 | 4 |
| haltReasonsSeen | 2 (all) | 2 | 2 |

Only `oreMinedTotal` and `playerScoreMax` recentered (to the observed means); counts and all tolerances (`oreEpsilon 150`, `countAbs 1`, `scorePct 10`) are unchanged — the observed spreads (ore ±23, score ±11) sit far inside them.

## Verification

A fresh 300s two-user run against the new baseline reports **Tier 2 BAND on all five metrics**, with **Tier 1 I1–I11** and **Tier 3 O1–O6** all passing (transport delivered, depletion fired, both halt reasons observed).

The soak project is out of `src/Voidforge.slnx`, so this baseline change doesn't affect CI's build/test lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated soak-test baseline expectations to reflect revised mining totals and maximum player scores.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->